### PR TITLE
Add VertexIndex, EdgeIndex and FaceIndex and update ConstraintHandler

### DIFF
--- a/src/Grid/grid_generators.jl
+++ b/src/Grid/grid_generators.jl
@@ -1,10 +1,11 @@
 function boundaries_to_sparse(boundary)
+
     n = length(boundary)
     I = Vector{Int}(undef, n)
     J = Vector{Int}(undef, n)
     V = Vector{Bool}(undef, n)
     for (idx, el) in enumerate(boundary)
-        cell, face = el
+        cell, face = el.cellidx, el.idx
         I[idx] = face
         J[idx] = cell
         V[idx] = true
@@ -42,14 +43,14 @@ function generate_grid(::Type{Line}, nel::NTuple{1,Int}, left::Vec{1,T}=Vec{1}((
 
 
     # Cell faces
-    boundary = Vector([(1, 1),
-                       (nel_x, 2)])
+    boundary = Vector([FaceIndex(1, 1),
+                       FaceIndex(nel_x, 2)])
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
-    facesets = Dict("left"  => Set{Tuple{Int,Int}}([boundary[1]]),
-                    "right" => Set{Tuple{Int,Int}}([boundary[2]]))
+    facesets = Dict("left"  => Set{FaceIndex}([boundary[1]]),
+                    "right" => Set{FaceIndex}([boundary[2]]))
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
 
@@ -72,14 +73,14 @@ function generate_grid(::Type{QuadraticLine}, nel::NTuple{1,Int}, left::Vec{1,T}
     end
 
     # Cell faces
-    boundary = Tuple{Int,Int}[(1, 1),
-                         (nel_x, 2)]
+    boundary = [FaceIndex(1, 1),
+                FaceIndex(nel_x, 2)]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
-    facesets = Dict("left"  => Set{Tuple{Int,Int}}([boundary[1]]),
-                    "right" => Set{Tuple{Int,Int}}([boundary[2]]))
+    facesets = Dict("left"  => Set{FaceIndex}([boundary[1]]),
+                    "right" => Set{FaceIndex}([boundary[2]]))
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
 
@@ -135,20 +136,20 @@ function generate_grid(C::Type{Quadrilateral}, nel::NTuple{2,Int}, LL::Vec{2,T},
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(nel_x, nel_y))
-    boundary = Tuple{Int,Int}[[(cl, 1) for cl in cell_array[:,1]];
-                              [(cl, 2) for cl in cell_array[end,:]];
-                              [(cl, 3) for cl in cell_array[:,end]];
-                              [(cl, 4) for cl in cell_array[1,:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[:,1]];
+                          [FaceIndex(cl, 2) for cl in cell_array[end,:]];
+                          [FaceIndex(cl, 3) for cl in cell_array[:,end]];
+                          [FaceIndex(cl, 4) for cl in cell_array[1,:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
     offset = 0
-    facesets = Dict{String, Set{Tuple{Int,Int}}}()
-    facesets["bottom"] = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,1]))   .+ offset]); offset += length(cell_array[:,1])
-    facesets["right"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[end,:])) .+ offset]); offset += length(cell_array[end,:])
-    facesets["top"]    = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,end])) .+ offset]); offset += length(cell_array[:,end])
-    facesets["left"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,:]))   .+ offset]); offset += length(cell_array[1,:])
+    facesets = Dict{String, Set{FaceIndex}}()
+    facesets["bottom"] = Set{FaceIndex}(boundary[(1:length(cell_array[:,1]))   .+ offset]); offset += length(cell_array[:,1])
+    facesets["right"]  = Set{FaceIndex}(boundary[(1:length(cell_array[end,:])) .+ offset]); offset += length(cell_array[end,:])
+    facesets["top"]    = Set{FaceIndex}(boundary[(1:length(cell_array[:,end])) .+ offset]); offset += length(cell_array[:,end])
+    facesets["left"]   = Set{FaceIndex}(boundary[(1:length(cell_array[1,:]))   .+ offset]); offset += length(cell_array[1,:])
 
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
@@ -174,20 +175,20 @@ function generate_grid(::Type{QuadraticQuadrilateral}, nel::NTuple{2,Int}, LL::V
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(nel_x, nel_y))
-    boundary = Tuple{Int,Int}[[(cl, 1) for cl in cell_array[:,1]];
-                              [(cl, 2) for cl in cell_array[end,:]];
-                              [(cl, 3) for cl in cell_array[:,end]];
-                              [(cl, 4) for cl in cell_array[1,:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[:,1]];
+                              [FaceIndex(cl, 2) for cl in cell_array[end,:]];
+                              [FaceIndex(cl, 3) for cl in cell_array[:,end]];
+                              [FaceIndex(cl, 4) for cl in cell_array[1,:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
     offset = 0
-    facesets = Dict{String, Set{Tuple{Int,Int}}}()
-    facesets["bottom"] = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,1]))   .+ offset]); offset += length(cell_array[:,1])
-    facesets["right"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[end,:])) .+ offset]); offset += length(cell_array[end,:])
-    facesets["top"]    = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,end])) .+ offset]); offset += length(cell_array[:,end])
-    facesets["left"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,:]))   .+ offset]); offset += length(cell_array[1,:])
+    facesets = Dict{String, Set{FaceIndex}}()
+    facesets["bottom"] = Set{FaceIndex}(boundary[(1:length(cell_array[:,1]))   .+ offset]); offset += length(cell_array[:,1])
+    facesets["right"]  = Set{FaceIndex}(boundary[(1:length(cell_array[end,:])) .+ offset]); offset += length(cell_array[end,:])
+    facesets["top"]    = Set{FaceIndex}(boundary[(1:length(cell_array[:,end])) .+ offset]); offset += length(cell_array[:,end])
+    facesets["left"]   = Set{FaceIndex}(boundary[(1:length(cell_array[1,:]))   .+ offset]); offset += length(cell_array[1,:])
 
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
@@ -217,24 +218,24 @@ function generate_grid(::Type{Hexahedron}, nel::NTuple{3,Int}, left::Vec{3,T}=Ve
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(nel_x, nel_y, nel_z))
-    boundary = Tuple{Int,Int}[[(cl, 1) for cl in cell_array[:,:,1][:]];
-                              [(cl, 2) for cl in cell_array[:,1,:][:]];
-                              [(cl, 3) for cl in cell_array[end,:,:][:]];
-                              [(cl, 4) for cl in cell_array[:,end,:][:]];
-                              [(cl, 5) for cl in cell_array[1,:,:][:]];
-                              [(cl, 6) for cl in cell_array[:,:,end][:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[:,:,1][:]];
+                              [FaceIndex(cl, 2) for cl in cell_array[:,1,:][:]];
+                              [FaceIndex(cl, 3) for cl in cell_array[end,:,:][:]];
+                              [FaceIndex(cl, 4) for cl in cell_array[:,end,:][:]];
+                              [FaceIndex(cl, 5) for cl in cell_array[1,:,:][:]];
+                              [FaceIndex(cl, 6) for cl in cell_array[:,:,end][:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
     offset = 0
-    facesets = Dict{String,Set{Tuple{Int,Int}}}()
-    facesets["bottom"] = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,:,1][:]))   .+ offset]); offset += length(cell_array[:,:,1][:])
-    facesets["front"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,1,:][:]))   .+ offset]); offset += length(cell_array[:,1,:][:])
-    facesets["right"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[end,:,:][:])) .+ offset]); offset += length(cell_array[end,:,:][:])
-    facesets["back"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,end,:][:])) .+ offset]); offset += length(cell_array[:,end,:][:])
-    facesets["left"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,:,:][:]))   .+ offset]); offset += length(cell_array[1,:,:][:])
-    facesets["top"]    = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[:,:,end][:])) .+ offset]); offset += length(cell_array[:,:,end][:])
+    facesets = Dict{String,Set{FaceIndex}}()
+    facesets["bottom"] = Set{FaceIndex}(boundary[(1:length(cell_array[:,:,1][:]))   .+ offset]); offset += length(cell_array[:,:,1][:])
+    facesets["front"]  = Set{FaceIndex}(boundary[(1:length(cell_array[:,1,:][:]))   .+ offset]); offset += length(cell_array[:,1,:][:])
+    facesets["right"]  = Set{FaceIndex}(boundary[(1:length(cell_array[end,:,:][:])) .+ offset]); offset += length(cell_array[end,:,:][:])
+    facesets["back"]   = Set{FaceIndex}(boundary[(1:length(cell_array[:,end,:][:])) .+ offset]); offset += length(cell_array[:,end,:][:])
+    facesets["left"]   = Set{FaceIndex}(boundary[(1:length(cell_array[1,:,:][:]))   .+ offset]); offset += length(cell_array[1,:,:][:])
+    facesets["top"]    = Set{FaceIndex}(boundary[(1:length(cell_array[:,:,end][:])) .+ offset]); offset += length(cell_array[:,:,end][:])
 
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
@@ -259,20 +260,20 @@ function generate_grid(::Type{Triangle}, nel::NTuple{2,Int}, LL::Vec{2,T}, LR::V
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(2, nel_x, nel_y))
-    boundary = Tuple{Int,Int}[[(cl, 1) for cl in cell_array[1,:,1]];
-                               [(cl, 1) for cl in cell_array[2,end,:]];
-                               [(cl, 2) for cl in cell_array[2,:,end]];
-                               [(cl, 3) for cl in cell_array[1,1,:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[1,:,1]];
+                               [FaceIndex(cl, 1) for cl in cell_array[2,end,:]];
+                               [FaceIndex(cl, 2) for cl in cell_array[2,:,end]];
+                               [FaceIndex(cl, 3) for cl in cell_array[1,1,:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
     offset = 0
-    facesets = Dict{String,Set{Tuple{Int,Int}}}()
-    facesets["bottom"] = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,:,1]))   .+ offset]); offset += length(cell_array[1,:,1])
-    facesets["right"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[2,end,:])) .+ offset]); offset += length(cell_array[2,end,:])
-    facesets["top"]    = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[2,:,end])) .+ offset]); offset += length(cell_array[2,:,end])
-    facesets["left"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,1,:]))   .+ offset]); offset += length(cell_array[1,1,:])
+    facesets = Dict{String,Set{FaceIndex}}()
+    facesets["bottom"] = Set{FaceIndex}(boundary[(1:length(cell_array[1,:,1]))   .+ offset]); offset += length(cell_array[1,:,1])
+    facesets["right"]  = Set{FaceIndex}(boundary[(1:length(cell_array[2,end,:])) .+ offset]); offset += length(cell_array[2,end,:])
+    facesets["top"]    = Set{FaceIndex}(boundary[(1:length(cell_array[2,:,end])) .+ offset]); offset += length(cell_array[2,:,end])
+    facesets["left"]   = Set{FaceIndex}(boundary[(1:length(cell_array[1,1,:]))   .+ offset]); offset += length(cell_array[1,1,:])
 
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end
@@ -299,20 +300,20 @@ function generate_grid(::Type{QuadraticTriangle}, nel::NTuple{2,Int}, LL::Vec{2,
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(2, nel_x, nel_y))
-    boundary = Tuple{Int,Int}[[(cl, 1) for cl in cell_array[1,:,1]];
-                              [(cl, 1) for cl in cell_array[2,end,:]];
-                              [(cl, 2) for cl in cell_array[2,:,end]];
-                              [(cl, 3) for cl in cell_array[1,1,:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[1,:,1]];
+                              [FaceIndex(cl, 1) for cl in cell_array[2,end,:]];
+                              [FaceIndex(cl, 2) for cl in cell_array[2,:,end]];
+                              [FaceIndex(cl, 3) for cl in cell_array[1,1,:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 
     # Cell face sets
     offset = 0
-    facesets = Dict{String,Set{Tuple{Int,Int}}}()
-    facesets["bottom"] = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,:,1]))   .+ offset]); offset += length(cell_array[1,:,1])
-    facesets["right"]  = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[2,end,:])) .+ offset]); offset += length(cell_array[2,end,:])
-    facesets["top"]    = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[2,:,end])) .+ offset]); offset += length(cell_array[2,:,end])
-    facesets["left"]   = Set{Tuple{Int,Int}}(boundary[(1:length(cell_array[1,1,:]))   .+ offset]); offset += length(cell_array[1,1,:])
+    facesets = Dict{String,Set{FaceIndex}}()
+    facesets["bottom"] = Set{FaceIndex}(boundary[(1:length(cell_array[1,:,1]))   .+ offset]); offset += length(cell_array[1,:,1])
+    facesets["right"]  = Set{FaceIndex}(boundary[(1:length(cell_array[2,end,:])) .+ offset]); offset += length(cell_array[2,end,:])
+    facesets["top"]    = Set{FaceIndex}(boundary[(1:length(cell_array[2,:,end])) .+ offset]); offset += length(cell_array[2,:,end])
+    facesets["left"]   = Set{FaceIndex}(boundary[(1:length(cell_array[1,1,:]))   .+ offset]); offset += length(cell_array[1,1,:])
 
     return Grid(cells, nodes, facesets=facesets, boundary_matrix=boundary_matrix)
 end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -271,6 +271,8 @@ getnbasefunctions(::Lagrange{3,RefTetrahedron,1}) = 4
 nvertexdofs(::Lagrange{3,RefTetrahedron,1}) = 1
 
 faces(::Lagrange{3,RefTetrahedron,1}) = ((1,2,3), (1,2,4), (2,3,4), (1,4,3))
+edges(::Lagrange{3,RefTetrahedron,1}) = ((1,2), (2,3), (3,1), (1,4), (2,4), (3,4))
+vertices(::Lagrange{3,RefTetrahedron,1}) = (1, 2, 3, 4)
 
 function reference_coordinates(::Lagrange{3,RefTetrahedron,1})
     return [Vec{3, Float64}((0.0, 0.0, 0.0)),
@@ -298,6 +300,8 @@ nvertexdofs(::Lagrange{3,RefTetrahedron,2}) = 1
 nedgedofs(::Lagrange{3,RefTetrahedron,2}) = 1
 
 faces(::Lagrange{3,RefTetrahedron,2}) = ((1,2,3,5,6,7), (1,2,4,5,9,8), (2,3,4,6,10,9), (1,4,3,8,10,7))
+edges(::Lagrange{3,RefTetrahedron,2}) = ((1,5,2), (2,6,3), (3,7,1), (1,8,4), (2,9,4), (3,10,4))
+vertices(::Lagrange{3,RefTetrahedron,2}) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 function reference_coordinates(::Lagrange{3,RefTetrahedron,2})
     return [Vec{3, Float64}((0.0, 0.0, 0.0)),
@@ -337,7 +341,10 @@ end
 getnbasefunctions(::Lagrange{3,RefCube,1}) = 8
 nvertexdofs(::Lagrange{3,RefCube,1}) = 1
 
+
 faces(::Lagrange{3,RefCube,1}) = ((1,4,3,2), (1,2,6,5), (2,3,7,6), (3,4,8,7), (1,5,8,4), (5,6,7,8))
+edges(::Lagrange{3,RefCube,1}) = ((1,2), (2,3), (3,4), (4,1), (1,5), (2,6), (3,7), (4,8), (5,6), (6,7), (7,8), (8,5))
+vertices(::Lagrange{3,RefCube,1}) = (1,2,3,4,5,6,7,8)
 
 function reference_coordinates(::Lagrange{3,RefCube,1})
     return [Vec{3, Float64}((-1.0, -1.0, -1.0)),


### PR DESCRIPTION
Currently it is only possible to add constraints on faces and node-ids. This PR makes it possible add constraints on edges and vertices. It was possible to only need one `add(::ConstraintHandler, d::Dirichlet)` -function regardless if one adds constraints on vertices ,edges or faces by utilizing the  `vertices`, `edges` and `faces` functions.

I also removed the possibility to add constraints on nodes since one can now put them on vertices. One could add a `node2vertex()` function 

This is not a completely working PR. One more change in `_update(::ConstraintHandler)` function is needed regarding `BCValues`