### PR TITLE
Separate reference domain dimension and nodal coordinate dimension

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -221,11 +221,11 @@ function _update!(values::Vector{Float64}, f::Function, faces::Set{Tuple{Int,Int
                   components::Vector{Int}, dh::AbstractDofHandler, facevalues::BCValues,
                   dofmapping::Dict{Int,Int}, time::T) where {T}
 
-    dim = getdim(dh.grid)
+    xdim = getdim(dh.grid)
     _tmp_cellid = first(faces)[1]
 
     N = nnodes_per_cell(dh.grid, _tmp_cellid)
-    xh = zeros(Vec{dim, T}, N) # pre-allocate
+    xh = zeros(Vec{xdim, T}, N) # pre-allocate
     _celldofs = fill(0, ndofs_per_cell(dh, _tmp_cellid))
 
     for (cellidx, faceidx) in faces
@@ -259,8 +259,8 @@ end
 
 # for nodes
 function _update!(values::Vector{Float64}, f::Function, nodes::Set{Int}, field::Symbol, nodeidxs::Vector{Int}, globaldofs::Vector{Int},
-                  components::Vector{Int}, dh::DofHandler{dim,C,M}, facevalues::BCValues,
-                  dofmapping::Dict{Int,Int}, time::Float64) where {dim,C,M}
+                  components::Vector{Int}, dh::DofHandler{xdim,C,M}, facevalues::BCValues,
+                  dofmapping::Dict{Int,Int}, time::Float64) where {xdim,C,M}
     counter = 1
     for (idx, nodenumber) in enumerate(nodeidxs)
         x = dh.grid.nodes[nodenumber].x

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -11,6 +11,7 @@ abstract type AbstractDofHandler end
 
 Construct a `DofHandler` based on the grid `grid`.
 """
+# `dim` : node cooridnate dimension
 struct DofHandler{dim,C,T} <: AbstractDofHandler
     field_names::Vector{Symbol}
     field_dims::Vector{Int}

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -17,13 +17,13 @@ cell_to_vtkcell(::Type{QuadraticTetrahedron}) = VTKCellTypes.VTK_QUADRATIC_TETRA
 Create a unstructured VTK grid from a `Grid`. Return a `DatasetFile`
 which data can be appended to, see `vtk_point_data` and `vtk_cell_data`.
 """
-function WriteVTK.vtk_grid(filename::AbstractString, grid::Grid{dim,C,T}) where {dim,C,T}
+function WriteVTK.vtk_grid(filename::AbstractString, grid::Grid{xdim,C,T}) where {xdim,C,T}
     cls = MeshCell[]
     for cell in grid.cells
         celltype = JuAFEM.cell_to_vtkcell(typeof(cell))
         push!(cls, MeshCell(celltype, collect(cell.nodes)))
     end
-    coords = reshape(reinterpret(T, getnodes(grid)), (dim, getnnodes(grid)))
+    coords = reshape(reinterpret(T, getnodes(grid)), (xdim, getnnodes(grid)))
     return vtk_grid(filename, coords, cls)
 end
 
@@ -62,7 +62,7 @@ function WriteVTK.vtk_point_data(vtk::WriteVTK.DatasetFile, data::Vector{Vec{dim
     return vtk_point_data(vtk, out, name)
 end
 
-function vtk_nodeset(vtk::WriteVTK.DatasetFile, grid::Grid{dim}, nodeset::String) where {dim}
+function vtk_nodeset(vtk::WriteVTK.DatasetFile, grid::Grid{xdim}, nodeset::String) where {xdim}
     z = zeros(getnnodes(grid))
     z[collect(getnodeset(grid, nodeset))] .= 1.0
     vtk_point_data(vtk, z, nodeset)

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -33,16 +33,19 @@ utilizes scalar shape functions and `CellVectorValues` utilizes vectorial shape 
 """
 CellValues
 
-# CellScalarValues
-# `dim` : param domain dimension
-# `ndim` : node coordinate dimension
-struct CellScalarValues{dim,ndim,T<:Real,refshape<:AbstractRefShape} <: CellValues{dim,ndim,T,refshape}
+"""
+    CellScalarValues{ξdim,xdim,T<:Real,refshape<:AbstractRefShape} <: CellValues{ξdim,xdim,T,refshape}
+
+`ξdim` : reference domain dimension \\
+`xdim` : node coordinate dimension
+"""
+struct CellScalarValues{ξdim,xdim,T<:Real,refshape<:AbstractRefShape} <: CellValues{ξdim,xdim,T,refshape}
     N::Matrix{T}
-    dNdx::Matrix{Vec{ndim,T}}
-    dNdξ::Matrix{Vec{dim,T}}
+    dNdx::Matrix{Vec{xdim,T}}
+    dNdξ::Matrix{Vec{ξdim,T}}
     detJdV::Vector{T}
     M::Matrix{T}
-    dMdξ::Matrix{Vec{dim,T}}
+    dMdξ::Matrix{Vec{ξdim,T}}
     qr_weights::Vector{T}
 end
 
@@ -51,8 +54,12 @@ function CellScalarValues(quad_rule::QuadratureRule, func_interpol::Interpolatio
     CellScalarValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
-function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol; ndim=dim) where {dim,T,shape<:AbstractRefShape}
+function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{ξdim,shape}, func_interpol::Interpolation,
+        geom_interpol::Interpolation=func_interpol; xdim=ξdim) where {ξdim,T,shape<:AbstractRefShape}
+    # There is no way to infer xdim from ξdim
+    # In most solid mechanics cases, xdim = ξdim
+    # But in a truss element (line element with nodes in 2D or 3D), 
+    # xdim = 2 or 3, ξdim = 1. Users should pass in proper xdim value in the call site.
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape
@@ -60,14 +67,14 @@ function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_
 
     # Function interpolation
     n_func_basefuncs = getnbasefunctions(func_interpol)
-    N    = fill(zero(T)          * T(NaN), n_func_basefuncs, n_qpoints)
-    dNdx = fill(zero(Vec{ndim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
-    dNdξ = fill(zero(Vec{dim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
+    N    = fill(zero(T)           * T(NaN), n_func_basefuncs, n_qpoints)
+    dNdx = fill(zero(Vec{xdim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
+    dNdξ = fill(zero(Vec{ξdim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
 
     # Geometry interpolation
     n_geom_basefuncs = getnbasefunctions(geom_interpol)
-    M    = fill(zero(T)          * T(NaN), n_geom_basefuncs, n_qpoints)
-    dMdξ = fill(zero(Vec{dim,T}) * T(NaN), n_geom_basefuncs, n_qpoints)
+    M    = fill(zero(T)           * T(NaN), n_geom_basefuncs, n_qpoints)
+    dMdξ = fill(zero(Vec{ξdim,T}) * T(NaN), n_geom_basefuncs, n_qpoints)
 
     for (qp, ξ) in enumerate(quad_rule.points)
         for i in 1:n_func_basefuncs
@@ -80,17 +87,19 @@ function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_
 
     detJdV = fill(T(NaN), n_qpoints)
 
-    CellScalarValues{dim,ndim,T,shape}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
+    CellScalarValues{ξdim,xdim,T,shape}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
 end
 
 # CellVectorValues
-struct CellVectorValues{dim,ndim,T<:Real,refshape<:AbstractRefShape,M} <: CellValues{dim,ndim,T,refshape}
-    N::Matrix{Vec{dim,T}}
-    dNdx::Matrix{Tensor{2,ndim,T,M}}
-    dNdξ::Matrix{Tensor{2,dim,T,M}}
+# ? Vector dimension is assumed to be xdim ?
+# related: https://github.com/KristofferC/JuAFEM.jl/issues/193#issuecomment-502247133
+struct CellVectorValues{ξdim,xdim,T<:Real,refshape<:AbstractRefShape,M} <: CellValues{ξdim,xdim,T,refshape}
+    N::Matrix{Vec{xdim,T}}
+    dNdx::Matrix{Tensor{2,xdim,T,M}}
+    dNdξ::Matrix{Tensor{2,ξdim,T,M}}
     detJdV::Vector{T}
     M::Matrix{T}
-    dMdξ::Matrix{Vec{dim,T}}
+    dMdξ::Matrix{Vec{ξdim,T}}
     qr_weights::Vector{T}
 end
 
@@ -98,36 +107,41 @@ function CellVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolatio
     CellVectorValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
-function CellVectorValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol; ndim=dim) where {dim,T,shape<:AbstractRefShape}
+function CellVectorValues(::Type{T}, quad_rule::QuadratureRule{ξdim,shape}, func_interpol::Interpolation,
+        geom_interpol::Interpolation=func_interpol; xdim=ξdim) where {ξdim,T,shape<:AbstractRefShape}
+    # There is no way to infer xdim from ξdim
+    # In most solid mechanics cases, xdim = ξdim
+    # But in a truss element (line element with nodes in 2D or 3D), 
+    # xdim = 2 or 3, ξdim = 1. Users should pass in proper xdim value in the call site.
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape
     n_qpoints = length(getweights(quad_rule))
 
     # Function interpolation
-    n_func_basefuncs = getnbasefunctions(func_interpol) * dim
-    N    = fill(zero(Vec{dim,T})      * T(NaN), n_func_basefuncs, n_qpoints)
-    dNdx = fill(zero(Tensor{2,dim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
-    dNdξ = fill(zero(Tensor{2,dim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
+    n_func_basefuncs = getnbasefunctions(func_interpol) * xdim
+    N    = fill(zero(Vec{xdim,T})      * T(NaN), n_func_basefuncs, n_qpoints)
+    dNdx = fill(zero(Tensor{2,xdim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
+    # TODO: each entry should be a second order tensor with shape xdim x ξdim
+    dNdξ = fill(zero(Tensor{2,ξdim,T}) * T(NaN), n_func_basefuncs, n_qpoints)
 
     # Geometry interpolation
     n_geom_basefuncs = getnbasefunctions(geom_interpol)
     M    = fill(zero(T)          * T(NaN), n_geom_basefuncs, n_qpoints)
-    dMdξ = fill(zero(Vec{dim,T}) * T(NaN), n_geom_basefuncs, n_qpoints)
+    dMdξ = fill(zero(Vec{ξdim,T}) * T(NaN), n_geom_basefuncs, n_qpoints)
 
     for (qp, ξ) in enumerate(quad_rule.points)
         basefunc_count = 1
         for basefunc in 1:getnbasefunctions(func_interpol)
             dNdξ_temp, N_temp = gradient(ξ -> value(func_interpol, basefunc, ξ), ξ, :all)
-            for comp in 1:dim
-                N_comp = zeros(T, dim)
+            for comp in 1:xdim
+                N_comp = zeros(T, xdim)
                 N_comp[comp] = N_temp
-                N[basefunc_count, qp] = Vec{dim,T}((N_comp...,))
+                N[basefunc_count, qp] = Vec{xdim,T}((N_comp...,))
 
-                dN_comp = zeros(T, dim, dim)
+                dN_comp = zeros(T, ξdim, ξdim)
                 dN_comp[comp, :] = dNdξ_temp
-                dNdξ[basefunc_count, qp] = Tensor{2,dim,T}((dN_comp...,))
+                dNdξ[basefunc_count, qp] = Tensor{2,ξdim,T}((dN_comp...,))
                 basefunc_count += 1
             end
         end
@@ -139,18 +153,18 @@ function CellVectorValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_
     detJdV = fill(T(NaN), n_qpoints)
     MM = Tensors.n_components(Tensors.get_base(eltype(dNdx)))
 
-    CellVectorValues{dim,ndim,T,shape,MM}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
+    CellVectorValues{ξdim,xdim,T,shape,MM}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
 end
 
-function reinit!(cv::CellValues{dim,ndim}, x::AbstractVector{Vec{ndim,T}}) where {dim,ndim,T}
+function reinit!(cv::CellValues{ξdim,xdim}, x::AbstractVector{Vec{xdim,T}}) where {ξdim,xdim,T}
     n_geom_basefuncs = getngeobasefunctions(cv)
     n_func_basefuncs = getn_scalarbasefunctions(cv)
     @assert length(x) == n_geom_basefuncs
-    isa(cv, CellVectorValues) && (n_func_basefuncs *= dim)
+    isa(cv, CellVectorValues) && (n_func_basefuncs *= xdim)
 
     @inbounds for i in 1:length(cv.qr_weights)
         w = cv.qr_weights[i]
-        fecv_J = zero(Tensor{2,ndim})
+        fecv_J = zero(Tensor{2,xdim})
         for j in 1:n_geom_basefuncs
             fecv_J += x[j] ⊗ cv.dMdξ[j, i]
         end

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -34,7 +34,7 @@ point weight for the given quadrature point: ``\\det(J(\\mathbf{x})) w_q``
 This value is typically used when one integrates a function on a
 finite element cell or face as
 
-``\\int\\limits_\\Omega f(\\mathbf{x}) d \\Omega \\approx \\sum\\limits_{q = 1}^{n_q} f(\\mathbf{x}_q) \\det(J(\\mathbf{x})) w_q``
+``\\int\\limits_\\Omega f(\\mathbf{x}) d \\Omega \\approx \\sum\\limits_{q = 1}^{n_q} f(\\mathbf{x}_q) \\det(J(\\mathbf{x})) w_q``,
 ``\\int\\limits_\\Gamma f(\\mathbf{x}) d \\Gamma \\approx \\sum\\limits_{q = 1}^{n_q} f(\\mathbf{x}_q) \\det(J(\\mathbf{x})) w_q``
 
 """

--- a/src/FEValues/face_integrals.jl
+++ b/src/FEValues/face_integrals.jl
@@ -15,7 +15,7 @@ function create_face_quad_rule(quad_rule::QuadratureRule{0,shape,T}, ::Interpola
     return face_quad_rule
 end
 
-function weighted_normal(::Tensor{2,1,T}, ::FaceValues{1,T,RefCube}, face::Int) where {T}
+function weighted_normal(::Tensor{2,1,T}, ::FaceValues{1,1,T,RefCube}, face::Int) where {T}
     face == 1 && return Vec{1,T}((-one(T),))
     face == 2 && return Vec{1,T}(( one(T),))
     throw(ArgumentError("unknown face number: $face"))
@@ -46,7 +46,7 @@ function create_face_quad_rule(quad_rule::QuadratureRule{1,shape,T}, ::Interpola
     return face_quad_rule
 end
 
-function weighted_normal(J::Tensor{2,2}, ::FaceValues{2,T,RefCube}, face::Int) where {T}
+function weighted_normal(J::Tensor{2,2}, ::FaceValues{2,2,T,RefCube}, face::Int) where {T}
     @inbounds begin
         face == 1 && return Vec{2}(( J[2,1], -J[1,1]))
         face == 2 && return Vec{2}(( J[2,2], -J[1,2]))
@@ -78,7 +78,7 @@ function create_face_quad_rule(quad_rule::QuadratureRule{1,shape,T}, ::Interpola
     return face_quad_rule
 end
 
-function weighted_normal(J::Tensor{2,2}, ::FaceValues{2,T,RefTetrahedron}, face::Int) where {T}
+function weighted_normal(J::Tensor{2,2}, ::FaceValues{2,2,T,RefTetrahedron}, face::Int) where {T}
     @inbounds begin
         face == 1 && return Vec{2}((-(J[2,1] - J[2,2]), J[1,1] - J[1,2]))
         face == 2 && return Vec{2}((-J[2,2], J[1,2]))
@@ -118,7 +118,7 @@ function create_face_quad_rule(quad_rule::QuadratureRule{2,shape,T}, ::Interpola
     return face_quad_rule
 end
 
-function weighted_normal(J::Tensor{2,3}, ::FaceValues{3,T,RefCube}, face::Int) where {T}
+function weighted_normal(J::Tensor{2,3}, ::FaceValues{3,3,T,RefCube}, face::Int) where {T}
     @inbounds begin
         face == 1 && return J[:,2] × J[:,1]
         face == 2 && return J[:,1] × J[:,3]
@@ -155,7 +155,7 @@ function create_face_quad_rule(quad_rule::QuadratureRule{2,shape,T}, ::Interpola
     return face_quad_rule
 end
 
-function weighted_normal(J::Tensor{2,3}, ::FaceValues{3,T,RefTetrahedron}, face::Int) where {T}
+function weighted_normal(J::Tensor{2,3}, ::FaceValues{3,3,T,RefTetrahedron}, face::Int) where {T}
     @inbounds begin
         face == 1 && return J[:,2] × J[:,1]
         face == 2 && return J[:,1] × J[:,3]

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -11,7 +11,11 @@ Node(x::NTuple{dim,T}) where {dim,T} = Node(Vec{dim,T}(x))
 getcoordinates(n::Node) = n.x
 
 """
+    Cell{dim,N,M}
+
 A `Cell` is a sub-domain defined by a collection of `Node`s as it's vertices.
+`dim` is the node's cooridnate dimension. `N` is the number of nodes in a cell.
+`M` is the number of faces in a cell.
 """
 abstract type AbstractCell{dim,N,M} end
 struct Cell{dim,N,M} <: AbstractCell{dim,N,M}

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -23,9 +23,9 @@ struct RefCube <: AbstractRefShape end
 """
 Abstract type which has `CellValues` and `FaceValues` as subtypes
 """
-abstract type Values{dim,T,refshape} end
-abstract type CellValues{dim,T,refshape} <: Values{dim,T,refshape} end
-abstract type FaceValues{dim,T,refshape} <: Values{dim,T,refshape} end
+abstract type Values{dim,ndim,T,refshape} end
+abstract type CellValues{dim,ndim,T,refshape} <: Values{dim,ndim,T,refshape} end
+abstract type FaceValues{dim,ndim,T,refshape} <: Values{dim,ndim,T,refshape} end
 
 include("utils.jl")
 

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -22,10 +22,14 @@ struct RefCube <: AbstractRefShape end
 
 """
 Abstract type which has `CellValues` and `FaceValues` as subtypes
+
+`ξdim` : reference domain dimension \\
+`xdim` : node coordinate dimension \\
+`refshape` : reference shape, see also [`AbstractRefShape`](@ref).
 """
-abstract type Values{dim,ndim,T,refshape} end
-abstract type CellValues{dim,ndim,T,refshape} <: Values{dim,ndim,T,refshape} end
-abstract type FaceValues{dim,ndim,T,refshape} <: Values{dim,ndim,T,refshape} end
+abstract type Values{ξdim,xdim,T,refshape} end
+abstract type CellValues{ξdim,xdim,T,refshape} <: Values{ξdim,xdim,T,refshape} end
+abstract type FaceValues{ξdim,xdim,T,refshape} <: Values{ξdim,xdim,T,refshape} end
 
 include("utils.jl")
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1,7 +1,7 @@
 """
-    Interpolation{dim, ref_shape, order}()
+    Interpolation{ξdim, ref_shape, order}()
 
-Return an `Interpolation` of given dimension `dim`, reference shape
+Return an `Interpolation` of given dimension `ξdim`, reference shape
 (see see [`AbstractRefShape`](@ref)) `ref_shape` and order `order`.
 `order` corresponds to the highest order term in the polynomial.
 The interpolation is used to define shape functions to interpolate
@@ -29,34 +29,34 @@ julia> getnbasefunctions(ip)
 6
 ```
 """
-abstract type Interpolation{dim,shape,order} end
+abstract type Interpolation{ξdim,shape,order} end
 
 """
 Return the dimension of an `Interpolation`
 """
-@inline getdim(ip::Interpolation{dim}) where {dim} = dim
+@inline getdim(ip::Interpolation{ξdim}) where {ξdim} = ξdim
 
 """
 Return the reference shape of an `Interpolation`
 """
-@inline getrefshape(ip::Interpolation{dim,shape}) where {dim,shape} = shape
+@inline getrefshape(ip::Interpolation{ξdim,shape}) where {ξdim,shape} = shape
 
 """
 Return the polynomial order of the `Interpolation`
 """
-@inline getorder(ip::Interpolation{dim,shape,order}) where {dim,shape,order} = order
+@inline getorder(ip::Interpolation{ξdim,shape,order}) where {ξdim,shape,order} = order
 
 """
 Compute the value of the shape functions at a point ξ for a given interpolation
 """
-function value(ip::Interpolation{dim}, ξ::Vec{dim,T}) where {dim,T}
+function value(ip::Interpolation{ξdim}, ξ::Vec{ξdim,T}) where {ξdim,T}
     [value(ip, i, ξ) for i in 1:getnbasefunctions(ip)]
 end
 
 """
 Compute the gradients of the shape functions at a point ξ for a given interpolation
 """
-function derivative(ip::Interpolation{dim}, ξ::Vec{dim,T}) where {dim,T}
+function derivative(ip::Interpolation{ξdim}, ξ::Vec{ξdim,T}) where {ξdim,T}
     [gradient(ξ -> value(ip, i, ξ), ξ) for i in 1:getnbasefunctions(ip)]
 end
 
@@ -84,7 +84,7 @@ end
 
 # The following functions are used to distribute the dofs. Definitions:
 #   vertexdof: dof on a "corner" of the reference shape
-#   facedof: dof in the dim-1 dimension (line in 2D, surface in 3D)
+#   facedof: dof in the ξdim-1 dimension (line in 2D, surface in 3D)
 #   edgedof: dof on a line between 2 vertices (i.e. "corners") (3D only)
 #   celldof: dof that is local to the element
 
@@ -97,13 +97,13 @@ ncelldofs(::Interpolation)   = 0
 ############
 # Lagrange #
 ############
-struct Lagrange{dim,shape,order} <: Interpolation{dim,shape,order} end
+struct Lagrange{ξdim,shape,order} <: Interpolation{ξdim,shape,order} end
 
-getlowerdim(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{dim-1,shape,order}()
-getlowerorder(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{dim,shape,order-1}()
+getlowerdim(::Lagrange{ξdim,shape,order}) where {ξdim,shape,order} = Lagrange{ξdim-1,shape,order}()
+getlowerorder(::Lagrange{ξdim,shape,order}) where {ξdim,shape,order} = Lagrange{ξdim,shape,order-1}()
 
 ##################################
-# Lagrange dim 1 RefCube order 1 #
+# Lagrange ξdim 1 RefCube order 1 #
 ##################################
 getnbasefunctions(::Lagrange{1,RefCube,1}) = 2
 nvertexdofs(::Lagrange{1,RefCube,1}) = 1
@@ -123,7 +123,7 @@ function value(ip::Lagrange{1,RefCube,1}, i::Int, ξ::Vec{1})
 end
 
 ##################################
-# Lagrange dim 1 RefCube order 2 #
+# Lagrange ξdim 1 RefCube order 2 #
 ##################################
 getnbasefunctions(::Lagrange{1,RefCube,2}) = 3
 nvertexdofs(::Lagrange{1,RefCube,2}) = 1
@@ -146,7 +146,7 @@ function value(ip::Lagrange{1,RefCube,2}, i::Int, ξ::Vec{1})
 end
 
 ##################################
-# Lagrange dim 2 RefCube order 1 #
+# Lagrange ξdim 2 RefCube order 1 #
 ##################################
 getnbasefunctions(::Lagrange{2,RefCube,1}) = 4
 nvertexdofs(::Lagrange{2,RefCube,1}) = 1
@@ -171,7 +171,7 @@ function value(ip::Lagrange{2,RefCube,1}, i::Int, ξ::Vec{2})
 end
 
 ##################################
-# Lagrange dim 2 RefCube order 2 #
+# Lagrange ξdim 2 RefCube order 2 #
 ##################################
 getnbasefunctions(::Lagrange{2,RefCube,2}) = 9
 nvertexdofs(::Lagrange{2,RefCube,2}) = 1
@@ -208,7 +208,7 @@ function value(ip::Lagrange{2,RefCube,2}, i::Int, ξ::Vec{2})
 end
 
 #########################################
-# Lagrange dim 2 RefTetrahedron order 1 #
+# Lagrange ξdim 2 RefTetrahedron order 1 #
 #########################################
 getnbasefunctions(::Lagrange{2,RefTetrahedron,1}) = 3
 getlowerdim(::Lagrange{2, RefTetrahedron, order}) where {order} = Lagrange{1, RefCube, order}()
@@ -233,7 +233,7 @@ function value(ip::Lagrange{2,RefTetrahedron,1}, i::Int, ξ::Vec{2})
 end
 
 #########################################
-# Lagrange dim 2 RefTetrahedron order 2 #
+# Lagrange ξdim 2 RefTetrahedron order 2 #
 #########################################
 getnbasefunctions(::Lagrange{2,RefTetrahedron,2}) = 6
 nvertexdofs(::Lagrange{2,RefTetrahedron,2}) = 1
@@ -265,7 +265,7 @@ function value(ip::Lagrange{2,RefTetrahedron,2}, i::Int, ξ::Vec{2})
 end
 
 #########################################
-# Lagrange dim 3 RefTetrahedron order 1 #
+# Lagrange ξdim 3 RefTetrahedron order 1 #
 #########################################
 getnbasefunctions(::Lagrange{3,RefTetrahedron,1}) = 4
 nvertexdofs(::Lagrange{3,RefTetrahedron,1}) = 1
@@ -291,7 +291,7 @@ function value(ip::Lagrange{3,RefTetrahedron,1}, i::Int, ξ::Vec{3})
 end
 
 #########################################
-# Lagrange dim 3 RefTetrahedron order 2 #
+# Lagrange ξdim 3 RefTetrahedron order 2 #
 #########################################
 getnbasefunctions(::Lagrange{3,RefTetrahedron,2}) = 10
 nvertexdofs(::Lagrange{3,RefTetrahedron,2}) = 1
@@ -332,7 +332,7 @@ function value(ip::Lagrange{3,RefTetrahedron,2}, i::Int, ξ::Vec{3})
 end
 
 ##################################
-# Lagrange dim 3 RefCube order 1 #
+# Lagrange ξdim 3 RefCube order 1 #
 ##################################
 getnbasefunctions(::Lagrange{3,RefCube,1}) = 8
 nvertexdofs(::Lagrange{3,RefCube,1}) = 1
@@ -368,7 +368,7 @@ end
 ###############
 # Serendipity #
 ###############
-struct Serendipity{dim,shape,order} <: Interpolation{dim,shape,order} end
+struct Serendipity{ξdim,shape,order} <: Interpolation{ξdim,shape,order} end
 
 #####################################
 # Serendipity dim 2 RefCube order 2 #

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -23,42 +23,41 @@ for cell in CellIterator(grid)
 end
 ```
 """
-# `dim`: node coordinate dimension
-struct CellIterator{dim,C,T}
+struct CellIterator{xdim,C,T}
     flags::UpdateFlags
-    grid::Grid{dim,C,T}
+    grid::Grid{xdim,C,T}
     current_cellid::ScalarWrapper{Int}
     nodes::Vector{Int}
-    coords::Vector{Vec{dim,T}}
+    coords::Vector{Vec{xdim,T}}
     cellset::Vector{Int}
-    dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}} #Future: remove DofHandler and rename MixedDofHandler->DofHandler
+    dh::Union{DofHandler{xdim,C,T}, MixedDofHandler{xdim,C,T}} #Future: remove DofHandler and rename MixedDofHandler->DofHandler
     celldofs::Vector{Int}
 
-    function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}}, cellset::AbstractVector{Int}, flags::UpdateFlags) where {dim,C,T}
+    function CellIterator{xdim,C,T}(dh::Union{DofHandler{xdim,C,T}, MixedDofHandler{xdim,C,T}}, cellset::AbstractVector{Int}, flags::UpdateFlags) where {xdim,C,T}
         isconcretetype(C) || _check_same_celltype(dh.grid, cellset)
         N = nnodes_per_cell(dh.grid, first(cellset))
         cell = ScalarWrapper(0)
         nodes = zeros(Int, N)
-        coords = zeros(Vec{dim,T}, N)
+        coords = zeros(Vec{xdim,T}, N)
         n = ndofs_per_cell(dh, first(cellset))
         celldofs = zeros(Int, n)
-        return new{dim,C,T}(flags, dh.grid, cell, nodes, coords, cellset, dh, celldofs)
+        return new{xdim,C,T}(flags, dh.grid, cell, nodes, coords, cellset, dh, celldofs)
     end
 
-    function CellIterator{dim,C,T}(grid::Grid{dim,C,T}, cellset::AbstractVector{Int}, flags::UpdateFlags) where {dim,C,T}
+    function CellIterator{xdim,C,T}(grid::Grid{xdim,C,T}, cellset::AbstractVector{Int}, flags::UpdateFlags) where {xdim,C,T}
         isconcretetype(C) || _check_same_celltype(grid, cellset)
         N = nnodes_per_cell(grid, first(cellset))
         cell = ScalarWrapper(0)
         nodes = zeros(Int, N)
-        coords = zeros(Vec{dim,T}, N)
-        return new{dim,C,T}(flags, grid, cell, nodes, coords)
+        coords = zeros(Vec{xdim,T}, N)
+        return new{xdim,C,T}(flags, grid, cell, nodes, coords)
     end
 end
 
-CellIterator(grid::Grid{dim,C,T}, cellset::AbstractVector{Int}=1:getncells(grid), flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
-    CellIterator{dim,C,T}(grid, cellset, flags)
-CellIterator(dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}}, cellset::AbstractVector{Int}=1:getncells(dh.grid), flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
-    CellIterator{dim,C,T}(dh, cellset, flags)
+CellIterator(grid::Grid{xdim,C,T}, cellset::AbstractVector{Int}=1:getncells(grid), flags::UpdateFlags=UpdateFlags()) where {xdim,C,T} =
+    CellIterator{xdim,C,T}(grid, cellset, flags)
+CellIterator(dh::Union{DofHandler{xdim,C,T}, MixedDofHandler{xdim,C,T}}, cellset::AbstractVector{Int}=1:getncells(dh.grid), flags::UpdateFlags=UpdateFlags()) where {xdim,C,T} =
+    CellIterator{xdim,C,T}(dh, cellset, flags)
 
 # iterator interface
 function Base.iterate(ci::CellIterator, state = 1)
@@ -83,7 +82,7 @@ Base.eltype(::Type{T})         where {T<:CellIterator} = T
 @inline celldofs!(v::Vector, ci::CellIterator) = celldofs!(v, ci.dh, ci.current_cellid[])
 @inline celldofs(ci::CellIterator) = ci.celldofs
 
-function reinit!(ci::CellIterator{dim,C}, i::Int) where {dim,C}
+function reinit!(ci::CellIterator{xdim,C}, i::Int) where {xdim,C}
     ci.current_cellid[] = ci.cellset[i]
 
     ci.flags.nodes  && cellnodes!(ci.nodes, ci.dh, ci.current_cellid[])
@@ -104,12 +103,12 @@ function check_compatible_geointerpolation(cv::Union{CellValues, FaceValues}, ci
     end
 end
 
-@inline function reinit!(cv::CellValues{dim,ndim,T}, ci::CellIterator{ndim,N,T}) where {dim,ndim,N,T}
+@inline function reinit!(cv::CellValues{ξdim,xdim,T}, ci::CellIterator{xdim,N,T}) where {ξdim,xdim,N,T}
     check_compatible_geointerpolation(cv, ci)
     reinit!(cv, ci.coords)
 end
 
-@inline function reinit!(fv::FaceValues{dim,ndim,T}, ci::CellIterator{ndim,N,T}, face::Int) where {dim,ndim,N,T}
+@inline function reinit!(fv::FaceValues{ξdim,xdim,T}, ci::CellIterator{xdim,N,T}, face::Int) where {ξdim,xdim,N,T}
     check_compatible_geointerpolation(fv, ci)
     reinit!(fv, ci.coords, face)
 end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -23,6 +23,7 @@ for cell in CellIterator(grid)
 end
 ```
 """
+# `dim`: node coordinate dimension
 struct CellIterator{dim,C,T}
     flags::UpdateFlags
     grid::Grid{dim,C,T}
@@ -103,12 +104,12 @@ function check_compatible_geointerpolation(cv::Union{CellValues, FaceValues}, ci
     end
 end
 
-@inline function reinit!(cv::CellValues{dim,T}, ci::CellIterator{dim,N,T}) where {dim,N,T}
+@inline function reinit!(cv::CellValues{dim,ndim,T}, ci::CellIterator{ndim,N,T}) where {dim,ndim,N,T}
     check_compatible_geointerpolation(cv, ci)
     reinit!(cv, ci.coords)
 end
 
-@inline function reinit!(fv::FaceValues{dim,T}, ci::CellIterator{dim,N,T}, face::Int) where {dim,N,T}
+@inline function reinit!(fv::FaceValues{dim,ndim,T}, ci::CellIterator{ndim,N,T}, face::Int) where {dim,ndim,N,T}
     check_compatible_geointerpolation(fv, ci)
     reinit!(fv, ci.coords, face)
 end


### PR DESCRIPTION
### Summary

This PR tries to split the `dim` type parameter to `ξdim` and `xdim`. Before, the dimension of the reference domain (`\xi`) is coupled with the dimension of the nodal coordinate domain.

This PR starts with changing `Values{dim,T,refshape}` to `Values{ξdim,xdim,T,refshape}`, and other changes are made to make things compatible and non-breaking. The `dim` in function argument are renamed to `ξdim` or `xdim` to clarify the context.
This PR is particularly useful for modeling non-standard cell in JuAFEM, e.g. truss elements (1D `Line` cell with nodes in 2D or 3D).

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I ran all tests on my computer and it's all green (i.e. `] test`).
   - All local tests (julia 1.5.0 on Windows) passed except the ones involve file sha comparison. I'm not sure if the CI tests would pass or not 
```julia
Test Summary:         | Fail  Total
Grid, DofHandler, vtk |   16     16
```
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)