### PR TITLE
let DofHandler take any AbstractGrid subtype

### DIFF
--- a/docs/src/literate/threaded_assembly.jl
+++ b/docs/src/literate/threaded_assembly.jl
@@ -85,7 +85,7 @@ function create_values(refshape, dim, order::Int)
 end;
 
 # Create a `ScratchValues` for each thread with the thread local data
-function create_scratchvalues(K, f, dh::DofHandler{Grid{dim,C,T},T}) where {dim, C, T}
+function create_scratchvalues(K, f, dh::DofHandler{dim, T, Grid{dim, C, T}}) where {dim, C, T}
     nthreads = Threads.nthreads()
     assemblers = [start_assemble(K, f) for i in 1:nthreads]
     cellvalues, facevalues = create_values(RefCube, dim, 2)

--- a/docs/src/literate/threaded_assembly.jl
+++ b/docs/src/literate/threaded_assembly.jl
@@ -85,7 +85,7 @@ function create_values(refshape, dim, order::Int)
 end;
 
 # Create a `ScratchValues` for each thread with the thread local data
-function create_scratchvalues(K, f, dh::DofHandler{dim}) where {dim}
+function create_scratchvalues(K, f, dh::DofHandler{Grid{dim,C,T},T}) where {dim, C, T}
     nthreads = Threads.nthreads()
     assemblers = [start_assemble(K, f) for i in 1:nthreads]
     cellvalues, facevalues = create_values(RefCube, dim, 2)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -259,7 +259,7 @@ end
 
 # for nodes
 function _update!(values::Vector{Float64}, f::Function, nodes::Set{Int}, field::Symbol, nodeidxs::Vector{Int}, globaldofs::Vector{Int},
-                  components::Vector{Int}, dh::DofHandler{dim,C,M}, facevalues::BCValues,
+                  components::Vector{Int}, dh::DofHandler{Grid{dim,C,M},M}, facevalues::BCValues,
                   dofmapping::Dict{Int,Int}, time::Float64) where {dim,C,M}
     counter = 1
     for (idx, nodenumber) in enumerate(nodeidxs)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -123,7 +123,9 @@ function close!(dh::DofHandler)
 end
 
 # close the DofHandler and distribute all the dofs
-function __close!(dh::DofHandler{Grid{dim, C, T}, T}) where {dim, C, T}
+function __close!(dh::DofHandler{G, T}) where {G<:AbstractGrid,T}
+    dim = getdim(dh.grid)
+    C = getcelltype(dh.grid)
     @assert !isclosed(dh)
 
     # `vertexdict` keeps track of the visited vertices. We store the global vertex

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -11,7 +11,7 @@ abstract type AbstractDofHandler end
 
 Construct a `DofHandler` based on the grid `grid`.
 """
-struct DofHandler{dim,C,T,G <: AbstractGrid} <: AbstractDofHandler
+struct DofHandler{G <: AbstractGrid,T} <: AbstractDofHandler
     field_names::Vector{Symbol}
     field_dims::Vector{Int}
     # TODO: field_interpolations can probably be better typed: We should at least require
@@ -26,7 +26,7 @@ struct DofHandler{dim,C,T,G <: AbstractGrid} <: AbstractDofHandler
 end
 
 function DofHandler(grid::Grid{dim,C,T}) where {dim,C,T}
-    DofHandler{dim,C,T,Grid}(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, JuAFEM.ScalarWrapper(-1))
+    DofHandler{Grid{dim,C,T}, T}(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, JuAFEM.ScalarWrapper(-1))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
@@ -123,7 +123,7 @@ function close!(dh::DofHandler)
 end
 
 # close the DofHandler and distribute all the dofs
-function __close!(dh::DofHandler{dim}) where {dim}
+function __close!(dh::DofHandler{Grid{dim, C, T}, T}) where {dim, C, T}
     @assert !isclosed(dh)
 
     # `vertexdict` keeps track of the visited vertices. We store the global vertex

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -298,10 +298,6 @@ function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid, i::I
     @assert dim == getdim(grid)
     C = getcelltype(grid)
     @assert length(global_coords) == nnodes(C)
-    # for j in 1:nnodes(C)
-    #    nodeid = getcells(grid, i).nodes[j]
-    #    global_coords[j] = getnodes(grid, nodeid).x
-    # end
     global_coords .= getcoordinates(grid, i)
     return global_coords
 end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -281,6 +281,18 @@ function cellnodes!(global_nodes::Vector{Int}, grid::Grid{dim,C}, i::Int) where 
     return global_nodes
 end
 
+function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid, i::Int) where {dim, T}
+    @assert dim == getdim(grid)
+    C = getcelltype(grid)
+    @assert length(global_coords) == nnodes(C)
+    #for j in 1:nnodes(C)
+    #    nodeid = getcells(grid, i).nodes[j]
+    #    global_coords[j] = getnodes(grid, nodeid).x
+    #end
+    global_coords = getcoordinates(grid, i)
+    return global_coords
+end
+
 function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::Grid{dim,C}, i::Int) where {dim,C,T}
     @assert length(global_coords) == nnodes(C)
     for j in 1:nnodes(C) # Currently assuming that DofHandler only has one celltype

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -11,7 +11,7 @@ abstract type AbstractDofHandler end
 
 Construct a `DofHandler` based on the grid `grid`.
 """
-struct DofHandler{dim,C,T} <: AbstractDofHandler
+struct DofHandler{dim,C,T,G <: AbstractGrid} <: AbstractDofHandler
     field_names::Vector{Symbol}
     field_dims::Vector{Int}
     # TODO: field_interpolations can probably be better typed: We should at least require
@@ -21,12 +21,12 @@ struct DofHandler{dim,C,T} <: AbstractDofHandler
     cell_dofs::Vector{Int}
     cell_dofs_offset::Vector{Int}
     closed::ScalarWrapper{Bool}
-    grid::Grid{dim,C,T}
+    grid::G
     ndofs::ScalarWrapper{Int}
 end
 
-function DofHandler(grid::Grid)
-    DofHandler(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, JuAFEM.ScalarWrapper(-1))
+function DofHandler(grid::Grid{dim,C,T}) where {dim,C,T}
+    DofHandler{dim,C,T,Grid}(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, JuAFEM.ScalarWrapper(-1))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -173,7 +173,7 @@ function WriteVTK.vtk_point_data(vtkfile, dh::MixedDofHandler{dim,T,G}, u::Vecto
             offset = field_offset(fh, name)
 
             for cellnum in cellnumbers
-                cell = getcells(dh.grid.cells, cellnum)
+                cell = getcells(dh.grid, cellnum)
                 n = ndofs_per_cell(dh, cellnum)
                 eldofs = zeros(Int, n)
                 _celldofs = celldofs!(eldofs, dh, cellnum)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -1,11 +1,11 @@
 
 abstract type AbstractProjector end
 
-struct L2Projector <: AbstractProjector
-    fe_values::CellValues
+struct L2Projector{CV<:CellValues} <: AbstractProjector
+    fe_values::CV
     M_cholesky #::SuiteSparse.CHOLMOD.Factor{Float64}
     dh::MixedDofHandler
-    set::Vector{Integer}
+    set::Vector{Int}
     node2dof_map::Dict{Int64, Array{Int64,N} where N}
 end
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -30,10 +30,10 @@ struct CellIterator{dim,C,T}
     nodes::Vector{Int}
     coords::Vector{Vec{dim,T}}
     cellset::Union{Vector{Int},Nothing}
-    dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}} #Future: remove DofHandler and rename MixedDofHandler->DofHandler
+    dh::Union{DofHandler{Grid{dim,C,T},T}, MixedDofHandler{dim,C,T}} #Future: remove DofHandler and rename MixedDofHandler->DofHandler
     celldofs::Vector{Int}
 
-    function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T}
+    function CellIterator{dim,C,T}(dh::Union{DofHandler{Grid{dim,C,T},T}, MixedDofHandler{dim,C,T}}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T}
         isconcretetype(C) || _check_same_celltype(dh.grid, cellset)
         N = nnodes_per_cell(dh.grid, cellset === nothing ? 1 : first(cellset))
         cell = ScalarWrapper(0)
@@ -56,7 +56,7 @@ end
 
 CellIterator(grid::Grid{dim,C,T}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
     CellIterator{dim,C,T}(grid, cellset, flags)
-CellIterator(dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
+CellIterator(dh::Union{DofHandler{Grid{dim,C,T},T}, MixedDofHandler{dim,C,T}}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
     CellIterator{dim,C,T}(dh, cellset, flags)
 
 # iterator interface

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -67,7 +67,7 @@ struct CellIterator{dim,C,T,G<:AbstractGrid}
     end
 end
 
-CellIterator(grid::Grid{dim,C,T}; cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
+CellIterator(grid::G; cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {G<:AbstractGrid} =
     CellIterator(grid, cellset, flags)
 CellIterator(dh::Union{DofHandler{Grid{dim,C,T},T}, MixedDofHandler{dim,C,T}}; cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
     CellIterator(dh, cellset, flags)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -57,6 +57,7 @@ struct CellIterator{dim,C,T,G<:AbstractGrid}
 
     function CellIterator(grid::G, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {G<:AbstractGrid}
         C = getcelltype(grid)
+        T = Float64 ## TODO extract from something else
         dim = getdim(grid)
         isconcretetype(C) || _check_same_celltype(grid, cellset)
         N = nnodes_per_cell(grid, cellset === nothing ? 1 : first(cellset))


### PR DESCRIPTION
This is essentially the same as https://github.com/KristofferC/JuAFEM.jl/pull/302 , but instead of `MixedDofHandler` done for `DofHandler`

The `DofHandler` should work for any properly subtyped `AbstractGrid`. Obviously, one could subtype `AbstractDofHandler` but this is in a lot of cases unnecessary because the `DofHandler` is pretty robust. In our case we want just to swap the `Grid` datastructure.

The new parametrisation is open for discussion, but we want to reuse the `DofHandler` for adaptivity and thus, need the proposed flexibility w.r.t. the grid type

As pointed out in https://github.com/KristofferC/JuAFEM.jl/pull/302 I'd like the most something like `DofHandler{Grid{dim, C, T}}` for the existing stuff, which would lead to `DofHandler{G<:AbstractGrid}`, but I'm unsure and need feedback on this. The first commit uses this option: `DofHandler{dim,C,T,G <: AbstractGrid}`

Edit: Second commit includes `DofHandler{G <: AbstractGrid, T}` option