### PR TITLE
added apply_multiple_rhs! for applying boundary condition to a collec…

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -99,6 +99,7 @@ export
     update!,
     apply!,
     apply_zero!,
+    apply_multiple_rhs!,
     add!,
     free_dofs,
 


### PR DESCRIPTION
Added apply_multiple_rhs! for simultaneously applying boundary condition to a collection of rhs-vectors at once.

Since the matrix ``K`` is modified by ``apply!``, if you want to setup to solve ``Ku = f`` for various choices of ``f`` with the same boundary condition, it seems you would need to have a copy of ``K`` every time you want to apply the boundary condition to a new rhs. So I made an apply method which doesn't requiring any copying of ``K``.

Example:
```
# Single rhs situation
apply!(K, f, ch)
u = K \ f

# Multiple rhs situation
apply_multiple_rhs!(K, [f,g,h], ch)
u = K \ f
v = K \ g
w = K \ h
```

If this is completely superfluous and there already is a good way of dealing with this kind of situation, I haven't been able to find it at least.
