### PR TITLE
Improvements to L2 projection

### DIFF
--- a/docs/src/literate/l2_projection.jl
+++ b/docs/src/literate/l2_projection.jl
@@ -41,10 +41,10 @@ end
 q = compute_heat_fluxes(cellvalues, dh, u);
 
 # Next, create an L2-projector using the same interpolation as was used to approximate the temperature field. On instantiation, the projector assembles the coefficient matrix `M` and computes the Cholesky factorization of it. By doing so, the projector can be reused without having to invert `M` every time.
-projector = L2Projector(cellvalues, ip, grid);
+projector = L2Projector(ip, grid);
 
 # Project the integration point values to the nodal values
-q_nodes = project(q, projector);
+q_nodes = project(projector, q, qr);
 
 
 # ## Exporting to VTK

--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -7,3 +7,8 @@ DocTestSetup = :(using Ferrite)
 ```@docs
 vtk_grid
 ```
+
+```@docs
+L2Projector
+project
+```

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -95,8 +95,11 @@ function L2Projector(
 end
 
 # Quadrature sufficient for integrating a mass matrix
-function _mass_qr(::Interpolation{dim, shape, order}) where {dim, shape, order}
+function _mass_qr(::Lagrange{dim, shape, order}) where {dim, shape, order}
     return QuadratureRule{dim,shape}(order + 1)
+end
+function _mass_qr(::Lagrange{dim, RefTetrahedron, 2}) where {dim}
+    return QuadratureRule{dim,RefTetrahedron}(4)
 end
 
 function _assemble_L2_matrix(fe_values, set, dh)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -56,9 +56,9 @@ Keyword arguments:
 
 
 The `L2Projector` acts as the integrated left hand side of the projection equation:
-Find projection ``u`` such that
+Find projection ``u \\in L_2(\\Omega)`` such that
 ```math
-\\int v u \\ \\mathrm{d}\\Omega = \\int \\delta u f \\ \\mathrm{d}\\Omega \\quad \\forall v \\in L_2(\\Omega),
+\\int v u \\ \\mathrm{d}\\Omega = \\int v f \\ \\mathrm{d}\\Omega \\quad \\forall v \\in L_2(\\Omega),
 ```
 where ``f`` is the data to project.
 
@@ -156,9 +156,9 @@ Makes a L2 projection of data `vals` to the nodes of the grid using the projecto
 (see [`L2Projector`](@ref)).
 
 `project` integrates the right hand side, and solves the projection ``u`` from the following projection equation:
-Find projection ``u`` such that
+Find projection ``u \\in L_2(\\Omega)`` such that
 ```math
-\\int v u \\ \\mathrm{d}\\Omega = \\int \\delta u f \\ \\mathrm{d}\\Omega \\quad \\forall v \\in L_2(\\Omega),
+\\int v u \\ \\mathrm{d}\\Omega = \\int v f \\ \\mathrm{d}\\Omega \\quad \\forall v \\in L_2(\\Omega),
 ```
 where ``f`` is the data to project, i.e. `vals`.
 

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -124,7 +124,7 @@ function _assemble_L2_matrix(fe_values, set, dh)
 end
 
 function project(vars::Vector{Vector{T}}, proj::L2Projector;
-                 project_to_nodes=true) where T <: AbstractTensor
+                 project_to_nodes=true) where T <: Union{Number, AbstractTensor}
     Base.depwarn("project(vars, proj::L2Projector) is deprecated, " *
                  "use project(proj, vars, qr) instead.", :project)
     return project(proj, vars; project_to_nodes=project_to_nodes)

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -1,13 +1,13 @@
 
-
+# Tests a L2-projection of integration point values (to nodal values),
+# determined from the function y = 1 + x[1]^2 + (2x[2])^2
 function test_projection(order)
     if order == 1
-        grid = Ferrite.generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
+        grid = generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
     elseif order == 2
-        # grid = Ferrite.generate_grid(QuadraticQuadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
-        grid = Ferrite.generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
+        # grid = generate_grid(QuadraticQuadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
+        grid = generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
     end
-
 
     dim = 2
     ip = Lagrange{dim, RefCube, order}()
@@ -21,18 +21,32 @@ function test_projection(order)
     # analytical values
     qp_values = [[f(spatial_coordinate(cv, qp, xe)) for qp in 1:getnquadpoints(cv)]]
 
-    # Now recover the nodal values using a L2 projection. Since f is quadratic and the interpolation as well, we should recover the exact nodal values
-    projector = L2Projector(cv, ip, grid)
+    # Now recover the nodal values using a L2 projection.
+    proj = L2Projector(ip, grid; geom_ip=ip_geom)
+    point_vars = project(proj, qp_values, qr)
+    ## Old API with fe values as first arg
+    proj = @test_deprecated L2Projector(cv, ip, grid)
+    point_vars_2 = @test_deprecated project(qp_values, proj)
+    ## Old API with qr as first arg
+    proj = @test_deprecated L2Projector(qr, ip, grid)
+    point_vars_3 = @test_deprecated project(qp_values, proj)
 
-    point_vars = Ferrite.project(qp_values, projector)
+    @test point_vars ≈ point_vars_2 ≈ point_vars_3
 
-    ae = compute_vertex_values(grid, f)
-    # The projection gives the values in node order -> reorder ae
-    # @test point_vars[1:4] ≈ [ae[1], ae[2], ae[4], ae[3]]
-    # return point_vars[1:4], [ae[1], ae[2], ae[4], ae[3]]
-    return point_vars[1:4], [ae[1], ae[2], ae[3], ae[4]]
+    if order == 1
+        # A linear approximation can not recover a quadratic solution,
+        # so projected values will be different from the analytical ones
+        ae = [Vec{1}((0.1666666666666664,)), Vec{1}((1.166666666666667,)),
+              Vec{1}((4.166666666666666,)),  Vec{1}((5.166666666666667,))]
+        @test point_vars[1:4] ≈ ae
+    elseif order == 2
+        # For a quadratic approximation the analytical solution is recovered
+        ae = compute_vertex_values(grid, f)
+        @test point_vars[1:4] ≈ ae
+    end
 end
 
+# Test a mixed grid, where only a subset of the cells contains a field
 function test_projection_mixedgrid()
     # generate a mesh with 1 quadrilateral and 2 triangular elements
     dim = 2
@@ -69,67 +83,32 @@ function test_projection_mixedgrid()
     # Assume f would only exist on the first cell, we project it to the nodes of the
     # 1st cell while ignoring the rest of the domain. NaNs should be stored in all
     # nodes that do not belong to the 1st cell
-    projector = L2Projector(cv, ip, mesh, 1:1)
-    point_vars = Ferrite.project(qp_values, projector)
+    proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=1:1)
+    point_vars = project(proj, qp_values, qr)
+    ## Old API with fe values as first arg
+    proj = @test_deprecated L2Projector(cv, ip, mesh, 1:1)
+    point_vars_2 = @test_deprecated project(qp_values, proj)
+    ## Old API with qr as first arg
+    proj = @test_deprecated L2Projector(qr, ip, mesh, 1:1)
+    point_vars_3 = @test_deprecated project(qp_values, proj)
 
     # In the nodes of the 1st cell we should recover the field
     for node in mesh.cells[1].nodes
-        @test ae[node] ≈ point_vars[node]
+        @test ae[node] ≈ point_vars[node] ≈ point_vars_2[node] ≈ point_vars_3[node]
     end
 
     # in all other nodes we should have NaNs
     for node in setdiff(1:getnnodes(mesh), mesh.cells[1].nodes)
         for d1 = 1:dim, d2 = 1:dim
              @test isnan(point_vars[node][d1, d2])
+             @test isnan(point_vars_2[node][d1, d2])
+             @test isnan(point_vars_3[node][d1, d2])
          end
     end
 end
 
-function test_projection_newprojector(order)
-    if order == 1
-        grid = Ferrite.generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
-    elseif order == 2
-        # grid = Ferrite.generate_grid(QuadraticQuadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
-        grid = Ferrite.generate_grid(Quadrilateral, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
-    end
-
-
-    dim = 2
-    ip = Lagrange{dim, RefCube, order}()
-    ip_geom = Lagrange{dim, RefCube, 1}()
-    qr = QuadratureRule{dim, RefCube}(order+1)
-    cv = CellScalarValues(qr, ip, ip_geom)
-
-    # Create node values for the cell
-    f(x) = Tensor{1,1,Float64}((1 + x[1]^2 + (2x[2])^2, ))
-    xe = getcoordinates(grid, 1)
-    # analytical values
-    qp_values = [[f(spatial_coordinate(cv, qp, xe)) for qp in 1:getnquadpoints(cv)]]
-
-    # Now recover the nodal values using a L2 projection. Since f is quadratic and the interpolation as well, we should recover the exact nodal values
-    projector = L2Projector(qr, ip, grid)
-
-    point_vars = Ferrite.project(qp_values, projector)
-
-    ae = compute_vertex_values(grid, f)
-    # The projection gives the values in node order -> reorder ae
-    # @test point_vars[1:4] ≈ [ae[1], ae[2], ae[4], ae[3]]
-    # return point_vars[1:4], [ae[1], ae[2], ae[4], ae[3]]
-    return point_vars[1:4], [ae[1], ae[2], ae[3], ae[4]]
-end
-
 @testset "Test L2-Projection" begin
-    # Tests a L2-projection of integration point values (to nodal values), determined from the function y = 1 + x[1]^2 + (2x[2])^2
-
-    # A linear approximation can not recover a quadratic solution, so projected values will be different from the analytical ones
-    projected_vars, analytical_vars = test_projection(1)
-    @test projected_vars ≉  analytical_vars
-
-    # For a quadratic approximation the analytical solution is recovered
-    projected_vars, analytical_vars = test_projection(2)
-    @test projected_vars ≈ analytical_vars
-
-    # Test a mixed grid, where only a subset of the cells contains a field
+    test_projection(1)
+    test_projection(2)
     test_projection_mixedgrid()
-
 end


### PR DESCRIPTION
Slight change of API.
Old:
```julia
proj = L2Projector(qr, ip, mesh)
point_vars = project(qp_values, proj)
```
New:
```julia
proj = L2Projector(ip, mesh)
point_vars = project(proj, qp_values, qr)
```

The main advantages, IMO, are that (i) the new API uses kwargs for "special stuff" (like using it for a specific cell set), (ii) better default quad rule for the lhs, and (iii) that the qr is bundled with the values in the call to project.

Also adds support for scalar fields.

Should add some more docs.