### PR TITLE
RFC: specialize on interpolations in the different Values structs

### DIFF
--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -34,7 +34,7 @@ utilizes scalar shape functions and `CellVectorValues` utilizes vectorial shape 
 CellValues
 
 # CellScalarValues
-struct CellScalarValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_interp} <: CellValues{dim,T,refshape,func_interp,geo_interp}
+struct CellScalarValues{dim,T<:Real,refshape<:AbstractRefShape,FI,GI} <: CellValues{dim,T,refshape,FI,GI}
     N::Matrix{T}
     dNdx::Matrix{Vec{dim,T}}
     dNdξ::Matrix{Vec{dim,T}}
@@ -42,6 +42,8 @@ struct CellScalarValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_i
     M::Matrix{T}
     dMdξ::Matrix{Vec{dim,T}}
     qr_weights::Vector{T}
+    func_interp::FI
+    geo_interp::GI
 end
 
 function CellScalarValues(quad_rule::QuadratureRule, func_interpol::Interpolation,
@@ -78,11 +80,11 @@ function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{dim,shape,}, func
 
     detJdV = fill(T(NaN), n_qpoints)
 
-    CellScalarValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol)}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
+    CellScalarValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol)}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights, func_interpol, geom_interpol)
 end
 
 # CellVectorValues
-struct CellVectorValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_interp,M} <: CellValues{dim,T,refshape,func_interp,geo_interp}
+struct CellVectorValues{dim,T<:Real,refshape<:AbstractRefShape,FI,GI,M} <: CellValues{dim,T,refshape,FI,GI}
     N::Matrix{Vec{dim,T}}
     dNdx::Matrix{Tensor{2,dim,T,M}}
     dNdξ::Matrix{Tensor{2,dim,T,M}}
@@ -90,6 +92,8 @@ struct CellVectorValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_i
     M::Matrix{T}
     dMdξ::Matrix{Vec{dim,T}}
     qr_weights::Vector{T}
+    func_interp::FI
+    geo_interp::GI
 end
 
 function CellVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=func_interpol)
@@ -137,7 +141,7 @@ function CellVectorValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_
     detJdV = fill(T(NaN), n_qpoints)
     MM = Tensors.n_components(Tensors.get_base(eltype(dNdx)))
 
-    CellVectorValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol),MM}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights)
+    CellVectorValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol),MM}(N, dNdx, dNdξ, detJdV, M, dMdξ, quad_rule.weights, func_interpol, geom_interpol)
 end
 
 function reinit!(cv::CellValues{dim}, x::AbstractVector{Vec{dim,T}}) where {dim,T}

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -7,10 +7,8 @@ using Base: @propagate_inbounds
 const ScalarValues{dim,T,shape,func_interp,geo_interp} = Union{CellScalarValues{dim,T,shape},FaceScalarValues{dim,T,shape,func_interp,geo_interp}}
 const VectorValues{dim,T,shape,func_interp,geo_interp} = Union{CellVectorValues{dim,T,shape},FaceVectorValues{dim,T,shape,func_interp,geo_interp}}
 
-getnbasefunctions(fe::Values{dim, T, shape, func_interp}) where {dim, T, shape, func_interp} =
-    getnbasefunctions(func_interp) * (fe isa VectorValues ? dim : 1)
-getngeobasefunctions(::Values{dim, T, shape, func_interp, geo_interp}) where {dim, T, shape, func_interp, geo_interp} =
-    getnbasefunctions(geo_interp)
+getnbasefunctions(fe::Values{dim}) where {dim} = getnbasefunctions(fe.func_interp) * (fe isa VectorValues ? dim : 1)
+getngeobasefunctions(fe::Values) = getnbasefunctions(fe.geo_interp)
 
 getn_scalarbasefunctions(cv::ScalarValues) = getnbasefunctions(cv)
 getn_scalarbasefunctions(cv::VectorValues{dim}) where {dim} = getnbasefunctions(cv) ÷ dim

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -40,7 +40,7 @@ For a scalar field, the `FaceScalarValues` type should be used. For vector field
 FaceValues
 
 # FaceScalarValues
-struct FaceScalarValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_interp} <: FaceValues{dim,T,refshape,func_interp,geo_interp}
+struct FaceScalarValues{dim,T<:Real,refshape<:AbstractRefShape,FI,GI} <: FaceValues{dim,T,refshape,FI,GI}
     N::Array{T,3}
     dNdx::Array{Vec{dim,T},3}
     dNdξ::Array{Vec{dim,T},3}
@@ -50,6 +50,8 @@ struct FaceScalarValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_i
     dMdξ::Array{Vec{dim,T},3}
     qr_weights::Vector{T}
     current_face::ScalarWrapper{Int}
+    func_interp::FI
+    geo_interp::GI
 end
 
 function FaceScalarValues(quad_rule::QuadratureRule, func_interpol::Interpolation,
@@ -93,11 +95,11 @@ function FaceScalarValues(::Type{T}, quad_rule::QuadratureRule{dim_qr,shape}, fu
 
     detJdV = fill(T(NaN), n_qpoints, n_faces)
 
-    FaceScalarValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol)}(N, dNdx, dNdξ, detJdV, normals, M, dMdξ, quad_rule.weights, ScalarWrapper(0))
+    FaceScalarValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol)}(N, dNdx, dNdξ, detJdV, normals, M, dMdξ, quad_rule.weights, ScalarWrapper(0), func_interpol, geom_interpol)
 end
 
 # FaceVectorValues
-struct FaceVectorValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_interp,M} <: FaceValues{dim,T,refshape,func_interp,geo_interp}
+struct FaceVectorValues{dim,T<:Real,refshape<:AbstractRefShape,FI,GI,M} <: FaceValues{dim,T,refshape,FI,GI}
     N::Array{Vec{dim,T},3}
     dNdx::Array{Tensor{2,dim,T,M},3}
     dNdξ::Array{Tensor{2,dim,T,M},3}
@@ -107,6 +109,8 @@ struct FaceVectorValues{dim,T<:Real,refshape<:AbstractRefShape,func_interp,geo_i
     dMdξ::Array{Vec{dim,T},3}
     qr_weights::Vector{T}
     current_face::ScalarWrapper{Int}
+    func_interp::FI
+    geo_interp::GI
 end
 
 function FaceVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=func_interpol)
@@ -161,7 +165,7 @@ function FaceVectorValues(::Type{T}, quad_rule::QuadratureRule{dim_qr,shape}, fu
     detJdV = fill(T(NaN), n_qpoints, n_faces)
     MM = Tensors.n_components(Tensors.get_base(eltype(dNdx)))
 
-    FaceVectorValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol),MM}(N, dNdx, dNdξ, detJdV, normals, M, dMdξ, quad_rule.weights, ScalarWrapper(0))
+    FaceVectorValues{dim,T,shape,typeof(func_interpol),typeof(geom_interpol),MM}(N, dNdx, dNdξ, detJdV, normals, M, dMdξ, quad_rule.weights, ScalarWrapper(0), func_interpol, geom_interpol)
 end
 
 function reinit!(fv::FaceValues{dim}, x::AbstractVector{Vec{dim,T}}, face::Int) where {dim,T}

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -23,9 +23,9 @@ struct RefCube <: AbstractRefShape end
 """
 Abstract type which has `CellValues` and `FaceValues` as subtypes
 """
-abstract type Values{dim,T,refshape} end
-abstract type CellValues{dim,T,refshape} <: Values{dim,T,refshape} end
-abstract type FaceValues{dim,T,refshape} <: Values{dim,T,refshape} end
+abstract type Values{dim,T,refshape,func_interp,geo_interp} end
+abstract type CellValues{dim,T,refshape,func_interp,geo_interp} <: Values{dim,T,refshape,func_interp,geo_interp} end
+abstract type FaceValues{dim,T,refshape,func_interp,geo_interp} <: Values{dim,T,refshape,func_interp,geo_interp} end
 
 include("utils.jl")
 

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -23,9 +23,9 @@ struct RefCube <: AbstractRefShape end
 """
 Abstract type which has `CellValues` and `FaceValues` as subtypes
 """
-abstract type Values{dim,T,refshape,func_interp,geo_interp} end
-abstract type CellValues{dim,T,refshape,func_interp,geo_interp} <: Values{dim,T,refshape,func_interp,geo_interp} end
-abstract type FaceValues{dim,T,refshape,func_interp,geo_interp} <: Values{dim,T,refshape,func_interp,geo_interp} end
+abstract type Values{dim,T,refshape,FI,GI} end
+abstract type CellValues{dim,T,refshape,FI,GI} <: Values{dim,T,refshape,FI,GI} end
+abstract type FaceValues{dim,T,refshape,FI,GI} <: Values{dim,T,refshape,FI,GI} end
 
 include("utils.jl")
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -34,17 +34,17 @@ abstract type Interpolation{dim,shape,order} end
 """
 Return the dimension of an `Interpolation`
 """
-@inline getdim(ip::Interpolation{dim}) where {dim} = dim
+@inline getdim(::Interpolation{dim}) where {dim} = dim
 
 """
 Return the reference shape of an `Interpolation`
 """
-@inline getrefshape(ip::Interpolation{dim,shape}) where {dim,shape} = shape
+@inline getrefshape(::Interpolation{dim,shape}) where {dim,shape} = shape
 
 """
 Return the polynomial order of the `Interpolation`
 """
-@inline getorder(ip::Interpolation{dim,shape,order}) where {dim,shape,order} = order
+@inline getorder(::Interpolation{dim,shape,order}) where {dim,shape,order} = order
 
 """
 Compute the value of the shape functions at a point ξ for a given interpolation
@@ -67,7 +67,7 @@ end
 """
 Return the number of base functions for an [`Interpolation`](@ref) or `Values` object.
 """
-getnbasefunctions
+getnbasefunctions(x::Interpolation) = getnbasefunctions(typeof(x))
 
 # struct that gathers all the information needed to distribute
 # dofs for a given interpolation.
@@ -116,7 +116,7 @@ getlowerorder(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{di
 ##################################
 # Lagrange dim 1 RefCube order 1 #
 ##################################
-getnbasefunctions(::Lagrange{1,RefCube,1}) = 2
+getnbasefunctions(::Type{Lagrange{1,RefCube,1}}) = 2
 nvertexdofs(::Lagrange{1,RefCube,1}) = 1
 
 faces(::Lagrange{1,RefCube,1}) = ((1,), (2,))
@@ -136,7 +136,7 @@ end
 ##################################
 # Lagrange dim 1 RefCube order 2 #
 ##################################
-getnbasefunctions(::Lagrange{1,RefCube,2}) = 3
+getnbasefunctions(::Type{Lagrange{1,RefCube,2}}) = 3
 nvertexdofs(::Lagrange{1,RefCube,2}) = 1
 ncelldofs(::Lagrange{1,RefCube,2}) = 1
 
@@ -159,7 +159,7 @@ end
 ##################################
 # Lagrange dim 2 RefCube order 1 #
 ##################################
-getnbasefunctions(::Lagrange{2,RefCube,1}) = 4
+getnbasefunctions(::Type{Lagrange{2,RefCube,1}}) = 4
 nvertexdofs(::Lagrange{2,RefCube,1}) = 1
 
 faces(::Lagrange{2,RefCube,1}) = ((1,2), (2,3), (3,4), (4,1))
@@ -184,7 +184,7 @@ end
 ##################################
 # Lagrange dim 2 RefCube order 2 #
 ##################################
-getnbasefunctions(::Lagrange{2,RefCube,2}) = 9
+getnbasefunctions(::Type{Lagrange{2,RefCube,2}}) = 9
 nvertexdofs(::Lagrange{2,RefCube,2}) = 1
 nfacedofs(::Lagrange{2,RefCube,2}) = 1
 ncelldofs(::Lagrange{2,RefCube,2}) = 1
@@ -221,7 +221,7 @@ end
 #########################################
 # Lagrange dim 2 RefTetrahedron order 1 #
 #########################################
-getnbasefunctions(::Lagrange{2,RefTetrahedron,1}) = 3
+getnbasefunctions(::Type{Lagrange{2,RefTetrahedron,1}}) = 3
 getlowerdim(::Lagrange{2, RefTetrahedron, order}) where {order} = Lagrange{1, RefCube, order}()
 nvertexdofs(::Lagrange{2,RefTetrahedron,1}) = 1
 
@@ -246,7 +246,7 @@ end
 #########################################
 # Lagrange dim 2 RefTetrahedron order 2 #
 #########################################
-getnbasefunctions(::Lagrange{2,RefTetrahedron,2}) = 6
+getnbasefunctions(::Type{Lagrange{2,RefTetrahedron,2}}) = 6
 nvertexdofs(::Lagrange{2,RefTetrahedron,2}) = 1
 nfacedofs(::Lagrange{2,RefTetrahedron,2}) = 1
 
@@ -278,7 +278,7 @@ end
 #########################################
 # Lagrange dim 3 RefTetrahedron order 1 #
 #########################################
-getnbasefunctions(::Lagrange{3,RefTetrahedron,1}) = 4
+getnbasefunctions(::Type{Lagrange{3,RefTetrahedron,1}}) = 4
 nvertexdofs(::Lagrange{3,RefTetrahedron,1}) = 1
 
 faces(::Lagrange{3,RefTetrahedron,1}) = ((1,2,3), (1,2,4), (2,3,4), (1,4,3))
@@ -304,7 +304,7 @@ end
 #########################################
 # Lagrange dim 3 RefTetrahedron order 2 #
 #########################################
-getnbasefunctions(::Lagrange{3,RefTetrahedron,2}) = 10
+getnbasefunctions(::Type{Lagrange{3,RefTetrahedron,2}}) = 10
 nvertexdofs(::Lagrange{3,RefTetrahedron,2}) = 1
 nedgedofs(::Lagrange{3,RefTetrahedron,2}) = 1
 
@@ -345,7 +345,7 @@ end
 ##################################
 # Lagrange dim 3 RefCube order 1 #
 ##################################
-getnbasefunctions(::Lagrange{3,RefCube,1}) = 8
+getnbasefunctions(::Type{Lagrange{3,RefCube,1}}) = 8
 nvertexdofs(::Lagrange{3,RefCube,1}) = 1
 
 faces(::Lagrange{3,RefCube,1}) = ((1,4,3,2), (1,2,6,5), (2,3,7,6), (3,4,8,7), (1,5,8,4), (5,6,7,8))
@@ -384,7 +384,7 @@ struct Serendipity{dim,shape,order} <: Interpolation{dim,shape,order} end
 #####################################
 # Serendipity dim 2 RefCube order 2 #
 #####################################
-getnbasefunctions(::Serendipity{2,RefCube,2}) = 8
+getnbasefunctions(::Type{Serendipity{2,RefCube,2}}) = 8
 getlowerdim(::Serendipity{2,RefCube,2}) = Lagrange{1,RefCube,2}()
 getlowerorder(::Serendipity{2,RefCube,2}) = Lagrange{2,RefCube,1}()
 nvertexdofs(::Serendipity{2,RefCube,2}) = 1

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -60,6 +60,8 @@ function derivative(ip::Interpolation{dim}, ξ::Vec{dim,T}) where {dim,T}
     [gradient(ξ -> value(ip, i, ξ), ξ) for i in 1:getnbasefunctions(ip)]
 end
 
+Base.copy(ip::Interpolation) = ip
+
 #####################
 # Utility functions #
 #####################
@@ -67,7 +69,7 @@ end
 """
 Return the number of base functions for an [`Interpolation`](@ref) or `Values` object.
 """
-getnbasefunctions(x::Interpolation) = getnbasefunctions(typeof(x))
+getnbasefunctions
 
 # struct that gathers all the information needed to distribute
 # dofs for a given interpolation.
@@ -116,7 +118,7 @@ getlowerorder(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{di
 ##################################
 # Lagrange dim 1 RefCube order 1 #
 ##################################
-getnbasefunctions(::Type{Lagrange{1,RefCube,1}}) = 2
+getnbasefunctions(::Lagrange{1,RefCube,1}) = 2
 nvertexdofs(::Lagrange{1,RefCube,1}) = 1
 
 faces(::Lagrange{1,RefCube,1}) = ((1,), (2,))
@@ -136,7 +138,7 @@ end
 ##################################
 # Lagrange dim 1 RefCube order 2 #
 ##################################
-getnbasefunctions(::Type{Lagrange{1,RefCube,2}}) = 3
+getnbasefunctions(::Lagrange{1,RefCube,2}) = 3
 nvertexdofs(::Lagrange{1,RefCube,2}) = 1
 ncelldofs(::Lagrange{1,RefCube,2}) = 1
 
@@ -159,7 +161,7 @@ end
 ##################################
 # Lagrange dim 2 RefCube order 1 #
 ##################################
-getnbasefunctions(::Type{Lagrange{2,RefCube,1}}) = 4
+getnbasefunctions(::Lagrange{2,RefCube,1}) = 4
 nvertexdofs(::Lagrange{2,RefCube,1}) = 1
 
 faces(::Lagrange{2,RefCube,1}) = ((1,2), (2,3), (3,4), (4,1))
@@ -184,7 +186,7 @@ end
 ##################################
 # Lagrange dim 2 RefCube order 2 #
 ##################################
-getnbasefunctions(::Type{Lagrange{2,RefCube,2}}) = 9
+getnbasefunctions(::Lagrange{2,RefCube,2}) = 9
 nvertexdofs(::Lagrange{2,RefCube,2}) = 1
 nfacedofs(::Lagrange{2,RefCube,2}) = 1
 ncelldofs(::Lagrange{2,RefCube,2}) = 1
@@ -221,7 +223,7 @@ end
 #########################################
 # Lagrange dim 2 RefTetrahedron order 1 #
 #########################################
-getnbasefunctions(::Type{Lagrange{2,RefTetrahedron,1}}) = 3
+getnbasefunctions(::Lagrange{2,RefTetrahedron,1}) = 3
 getlowerdim(::Lagrange{2, RefTetrahedron, order}) where {order} = Lagrange{1, RefCube, order}()
 nvertexdofs(::Lagrange{2,RefTetrahedron,1}) = 1
 
@@ -246,7 +248,7 @@ end
 #########################################
 # Lagrange dim 2 RefTetrahedron order 2 #
 #########################################
-getnbasefunctions(::Type{Lagrange{2,RefTetrahedron,2}}) = 6
+getnbasefunctions(::Lagrange{2,RefTetrahedron,2}) = 6
 nvertexdofs(::Lagrange{2,RefTetrahedron,2}) = 1
 nfacedofs(::Lagrange{2,RefTetrahedron,2}) = 1
 
@@ -278,7 +280,7 @@ end
 #########################################
 # Lagrange dim 3 RefTetrahedron order 1 #
 #########################################
-getnbasefunctions(::Type{Lagrange{3,RefTetrahedron,1}}) = 4
+getnbasefunctions(::Lagrange{3,RefTetrahedron,1}) = 4
 nvertexdofs(::Lagrange{3,RefTetrahedron,1}) = 1
 
 faces(::Lagrange{3,RefTetrahedron,1}) = ((1,2,3), (1,2,4), (2,3,4), (1,4,3))
@@ -304,7 +306,7 @@ end
 #########################################
 # Lagrange dim 3 RefTetrahedron order 2 #
 #########################################
-getnbasefunctions(::Type{Lagrange{3,RefTetrahedron,2}}) = 10
+getnbasefunctions(::Lagrange{3,RefTetrahedron,2}) = 10
 nvertexdofs(::Lagrange{3,RefTetrahedron,2}) = 1
 nedgedofs(::Lagrange{3,RefTetrahedron,2}) = 1
 
@@ -345,7 +347,7 @@ end
 ##################################
 # Lagrange dim 3 RefCube order 1 #
 ##################################
-getnbasefunctions(::Type{Lagrange{3,RefCube,1}}) = 8
+getnbasefunctions(::Lagrange{3,RefCube,1}) = 8
 nvertexdofs(::Lagrange{3,RefCube,1}) = 1
 
 faces(::Lagrange{3,RefCube,1}) = ((1,4,3,2), (1,2,6,5), (2,3,7,6), (3,4,8,7), (1,5,8,4), (5,6,7,8))
@@ -384,7 +386,7 @@ struct Serendipity{dim,shape,order} <: Interpolation{dim,shape,order} end
 #####################################
 # Serendipity dim 2 RefCube order 2 #
 #####################################
-getnbasefunctions(::Type{Serendipity{2,RefCube,2}}) = 8
+getnbasefunctions(::Serendipity{2,RefCube,2}) = 8
 getlowerdim(::Serendipity{2,RefCube,2}) = Lagrange{1,RefCube,2}()
 getlowerorder(::Serendipity{2,RefCube,2}) = Lagrange{2,RefCube,1}()
 nvertexdofs(::Serendipity{2,RefCube,2}) = 1

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -78,8 +78,12 @@ for (func_interpol, quad_rule) in  (
         cvc = copy(cv)
         for fname in fieldnames(typeof(cv))
             @test typeof(cv) == typeof(cvc)
-            @test pointer(getfield(cv, fname)) != pointer(getfield(cvc, fname))
-            @test getfield(cv, fname) == getfield(cvc, fname)
+            v = getfield(cv, fname)
+            vc = getfield(cvc, fname)
+            if hasmethod(pointer, Tuple{typeof(v)})
+                @test pointer(v) != pointer(vc)
+            end
+            @test v == vc
         end
     end
 end

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -1,5 +1,5 @@
 @testset "CellValues" begin
-for (func_interpol, quad_rule) in  (
+for (func_interp, quad_rule) in  (
                                     (Lagrange{1, RefCube, 1}(), QuadratureRule{1, RefCube}(2)),
                                     (Lagrange{1, RefCube, 2}(), QuadratureRule{1, RefCube}(2)),
                                     (Lagrange{2, RefCube, 1}(), QuadratureRule{2, RefCube}(2)),
@@ -13,14 +13,14 @@ for (func_interpol, quad_rule) in  (
                                    )
 
     for fe_valtype in (CellScalarValues, CellVectorValues)
-        cv = fe_valtype(quad_rule, func_interpol)
-        ndim = Ferrite.getdim(func_interpol)
-        n_basefuncs = getnbasefunctions(func_interpol)
+        cv = fe_valtype(quad_rule, func_interp)
+        ndim = Ferrite.getdim(func_interp)
+        n_basefuncs = getnbasefunctions(func_interp)
 
         fe_valtype == CellScalarValues && @test getnbasefunctions(cv) == n_basefuncs
-        fe_valtype == CellVectorValues && @test getnbasefunctions(cv) == n_basefuncs * Ferrite.getdim(func_interpol)
+        fe_valtype == CellVectorValues && @test getnbasefunctions(cv) == n_basefuncs * Ferrite.getdim(func_interp)
 
-        x, n = valid_coordinates_and_normals(func_interpol)
+        x, n = valid_coordinates_and_normals(func_interp)
         reinit!(cv, x)
 
         # We test this by applying a given deformation gradient on all the nodes.
@@ -58,16 +58,16 @@ for (func_interpol, quad_rule) in  (
         for i in 1:getnquadpoints(cv)
             vol += getdetJdV(cv,i)
         end
-        @test vol ≈ calculate_volume(func_interpol, x)
+        @test vol ≈ calculate_volume(func_interp, x)
 
         # Test quadrature rule after reinit! with ref. coords
-        x = Ferrite.reference_coordinates(func_interpol)
+        x = Ferrite.reference_coordinates(func_interp)
         reinit!(cv, x)
         vol = 0.0
         for i in 1:getnquadpoints(cv)
             vol += getdetJdV(cv,i)
         end
-        @test vol ≈ reference_volume(func_interpol)
+        @test vol ≈ reference_volume(func_interp)
 
         # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
         for (i, qp_x) in enumerate(getpoints(quad_rule))

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -84,11 +84,13 @@ for (func_interpol, quad_rule) in  (
         # test copy
         fvc = copy(fv)
         for fname in fieldnames(typeof(fv))
-            @test typeof(fv) == typeof(fvc)
-            if !isa(getfield(fv, fname), Ferrite.ScalarWrapper)
-                @test pointer(getfield(fv, fname)) != pointer(getfield(fvc, fname))
-                @test getfield(fv, fname) == getfield(fvc, fname)
+            isa(getfield(fv, fname), Ferrite.ScalarWrapper) && continue
+            v = getfield(fv, fname)
+            vc = getfield(fvc, fname)
+            if hasmethod(pointer, Tuple{typeof(v)})
+                @test pointer(v) != pointer(vc)
             end
+            @test v == vc
         end
     end
 end

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -1,5 +1,5 @@
 @testset "FaceValues" begin
-for (func_interpol, quad_rule) in  (
+for (func_interp, quad_rule) in  (
                                     (Lagrange{1, RefCube, 1}(), QuadratureRule{0, RefCube}(2)),
                                     (Lagrange{1, RefCube, 2}(), QuadratureRule{0, RefCube}(2)),
                                     (Lagrange{2, RefCube, 1}(), QuadratureRule{1, RefCube}(2)),
@@ -13,15 +13,15 @@ for (func_interpol, quad_rule) in  (
                                    )
 
     for fe_valtype in (FaceScalarValues, FaceVectorValues)
-        fv = fe_valtype(quad_rule, func_interpol)
-        ndim = Ferrite.getdim(func_interpol)
-        n_basefuncs = getnbasefunctions(func_interpol)
+        fv = fe_valtype(quad_rule, func_interp)
+        ndim = Ferrite.getdim(func_interp)
+        n_basefuncs = getnbasefunctions(func_interp)
 
         fe_valtype == FaceScalarValues && @test getnbasefunctions(fv) == n_basefuncs
-        fe_valtype == FaceVectorValues && @test getnbasefunctions(fv) == n_basefuncs * Ferrite.getdim(func_interpol)
+        fe_valtype == FaceVectorValues && @test getnbasefunctions(fv) == n_basefuncs * Ferrite.getdim(func_interp)
 
-        xs, n = valid_coordinates_and_normals(func_interpol)
-        for face in 1:getnfaces(func_interpol)
+        xs, n = valid_coordinates_and_normals(func_interp)
+        for face in 1:getnfaces(func_interp)
             reinit!(fv, xs, face)
             @test Ferrite.getcurrentface(fv) == face
 
@@ -61,17 +61,17 @@ for (func_interpol, quad_rule) in  (
             for i in 1:getnquadpoints(fv)
                 vol += getdetJdV(fv,i)
             end
-            x_face = xs[[Ferrite.faces(func_interpol)[face]...]]
-            @test vol ≈ calculate_volume(Ferrite.getlowerdim(func_interpol), x_face)
+            x_face = xs[[Ferrite.faces(func_interp)[face]...]]
+            @test vol ≈ calculate_volume(Ferrite.getlowerdim(func_interp), x_face)
 
             # Test quadrature rule after reinit! with ref. coords
-            x = Ferrite.reference_coordinates(func_interpol)
+            x = Ferrite.reference_coordinates(func_interp)
             reinit!(fv, x, face)
             vol = 0.0
             for i in 1:getnquadpoints(fv)
                 vol += getdetJdV(fv, i)
             end
-            @test vol ≈ reference_volume(func_interpol, face)
+            @test vol ≈ reference_volume(func_interp, face)
 
             # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
             # TODO: Renable somehow after quad rule is no longer stored in FaceValues


### PR DESCRIPTION
Allows the compiler to know how many base functions there are when doing e.g. `reinit!`.

Example benchmark:

```jl
using Ferrite, BenchmarkTools

for dim in (2, 3)
    for shape in (RefTetrahedron, RefCube)
        for order in (1, 2)
            if dim == 3 && shape == RefCube
                continue
            end
            qr = QuadratureRule{dim,shape}(1)
            linear = Lagrange{dim,shape,1}()

            quadratic = Lagrange{dim,shape,2}()
            cv_vector = CellVectorValues(qr, quadratic, linear)
            cv_scalar = CellScalarValues(qr, quadratic, linear)

            x = (dim == 2 && shape == RefTetrahedron) ? Triangle :
                (dim == 2 && shape == RefCube) ? Quadrilateral :
                (dim == 3 && shape == RefTetrahedron) ? Tetrahedron :
                (dim == 3 && shape == RefTCube) ? Hexahedron : error()

            grid = generate_grid(x, dim == 2 ? (1,1) : (1,1,1))
            xe = getcoordinates(grid, 1)

            @btime reinit!($cv_scalar, $xe)
            @btime reinit!($cv_vector, $xe)
        end
    end
end
```

Results (PR in left, master in right):

```
10.409 ns vs 17.469 ns
19.393 ns vs 26.296 ns
10.000 ns vs 17.474 ns
20.199 ns vs 24.866 ns
13.961 ns vs 20.624 ns
25.148 ns vs 30.444 ns
14.174 ns vs 20.608 ns
25.492 ns vs 30.443 ns
31.065 ns vs 42.441 ns
84.960 ns vs 93.313 ns
30.860 ns vs 42.312 ns
83.530 ns vs 85.384 ns
```