### PR TITLE
bugfixes for findfirst in MixedDofHandler+ tests

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -98,7 +98,7 @@ function getfielddim(dh::MixedDofHandler, name::Symbol)
 
     for fh in dh.fieldhandlers
         field_pos = findfirst(i->i == name, getfieldnames(fh))
-        if field_pos > 0
+        if field_pos != nothing
             return fh.fields[field_pos].dim
         end
     end

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -98,7 +98,7 @@ function getfielddim(dh::MixedDofHandler, name::Symbol)
 
     for fh in dh.fieldhandlers
         field_pos = findfirst(i->i == name, getfieldnames(fh))
-        if field_pos != nothing
+        if field_pos !== nothing
             return fh.fields[field_pos].dim
         end
     end

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -388,7 +388,7 @@ end
 
 function find_field(fh::FieldHandler, field_name::Symbol)
     j = findfirst(i->i == field_name, getfieldnames(fh))
-    j == 0 && error("did not find field $field_name")
+    j == nothing && error("did not find field $field_name")
     return j
 end
 

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -388,7 +388,7 @@ end
 
 function find_field(fh::FieldHandler, field_name::Symbol)
     j = findfirst(i->i == field_name, getfieldnames(fh))
-    j == nothing && error("did not find field $field_name")
+    j === nothing && error("did not find field $field_name")
     return j
 end
 

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -110,7 +110,7 @@ function WriteVTK.vtk_point_data(vtkfile, dh::MixedDofHandler, u::Vector, suffix
         for fh in dh.fieldhandlers
             # check if this fh contains this field, otherwise continue to the next
             field_pos = findfirst(i->i == name, getfieldnames(fh))
-            if field_pos == 0 && continue end
+            if field_pos == nothing && continue end
 
             cellnumbers = sort(collect(fh.cellset))  # TODO necessary to have them ordered?
             offset = field_offset(fh, name)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -110,7 +110,7 @@ function WriteVTK.vtk_point_data(vtkfile, dh::MixedDofHandler, u::Vector, suffix
         for fh in dh.fieldhandlers
             # check if this fh contains this field, otherwise continue to the next
             field_pos = findfirst(i->i == name, getfieldnames(fh))
-            if field_pos === nothing && continue end
+            field_pos === nothing && continue
 
             cellnumbers = sort(collect(fh.cellset))  # TODO necessary to have them ordered?
             offset = field_offset(fh, name)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -110,7 +110,7 @@ function WriteVTK.vtk_point_data(vtkfile, dh::MixedDofHandler, u::Vector, suffix
         for fh in dh.fieldhandlers
             # check if this fh contains this field, otherwise continue to the next
             field_pos = findfirst(i->i == name, getfieldnames(fh))
-            if field_pos == nothing && continue end
+            if field_pos === nothing && continue end
 
             cellnumbers = sort(collect(fh.cellset))  # TODO necessary to have them ordered?
             offset = field_offset(fh, name)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -406,6 +406,29 @@ function test_element_order()
 
 end
 
+function test_getfielddim()
+    grid = get_2d_grid() # cell 1: quad, cell2: triangle
+    dh = MixedDofHandler(grid)
+
+    # assume two fields: a scalar field :s and a vector field :v
+    # :v lives on both cells, :s lives only on the triangle
+    ip_tri = Lagrange{2,RefTetrahedron,1}()
+    ip_quad = Lagrange{2,RefCube,1}()
+    v_tri = Field(:v, ip_tri, 2)
+    v_quad = Field(:v, ip_quad, 2)
+    s = Field(:s, ip_tri, 1)
+
+    push!(dh, FieldHandler([v_quad], Set((1,))))
+    push!(dh, FieldHandler([v_tri, s], Set((2,))))
+
+    close!(dh)
+
+    # retrieve field dimensions
+    @test Ferrite.getfielddim(dh, :v) == 2
+    @test Ferrite.getfielddim(dh, :s) ==1
+end
+
+
 function test_mixed_grid_show()
     grid = get_2d_grid()
     str = sprint(show, MIME("text/plain"), grid)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -406,7 +406,7 @@ function test_element_order()
 
 end
 
-function test_getfielddim()
+function test_field_on_subdomain()
     grid = get_2d_grid() # cell 1: quad, cell2: triangle
     dh = MixedDofHandler(grid)
 
@@ -426,6 +426,12 @@ function test_getfielddim()
     # retrieve field dimensions
     @test Ferrite.getfielddim(dh, :v) == 2
     @test Ferrite.getfielddim(dh, :s) ==1
+
+    # find field in FieldHandler
+    @test Ferrite.find_field(dh.fieldhandlers[1], :v) == 1
+    @test Ferrite.find_field(dh.fieldhandlers[2], :v) == 1
+    @test Ferrite.find_field(dh.fieldhandlers[2], :s) == 2
+    @test_throws ErrorException Ferrite.find_field(dh.fieldhandlers[1], :s)
 end
 
 
@@ -452,6 +458,6 @@ end
     test_3d_mixed_field_mixed_celltypes();
     test_2_element_heat_eq();
     test_element_order();
-    test_getfielddim();
+    test_field_on_subdomain();
     test_mixed_grid_show()
 end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -452,5 +452,6 @@ end
     test_3d_mixed_field_mixed_celltypes();
     test_2_element_heat_eq();
     test_element_order();
+    test_getfielddim();
     test_mixed_grid_show()
 end


### PR DESCRIPTION
`findfirst` returns `nothing` when it doesn't find a match, not 0