### PR TITLE
correct function_gradient docstring

### DIFF
--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -98,9 +98,8 @@ for the degrees of freedom. For a scalar valued function, `u` contains scalars.
 For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
 or `u` can be a vector of `Vec`s (for use with ScalarValues).
 
-The value of a scalar valued function or a vector valued function with use of `VectorValues` is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
-or ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
-where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function with use of `ScalarValues`, the value is calculated as
+The value of a scalar valued function is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
+where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function the value is calculated as
 ``\\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) \\mathbf{u}_i`` where ``\\mathbf{u}_i`` are the
 nodal values of ``\\mathbf{u}``.
 """

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -146,7 +146,7 @@ The gradient of a scalar function is computed as
 ``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i``
 where ``u_i`` are the nodal values of the function.
 For a vector valued function the gradient is computed as
-``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) \\otimes \\mathbf{u}_i``
+``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{u}_i \\otimes \\mathbf{\\nabla} N_i (\\mathbf{x})``
 where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 """
 function function_gradient(fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T}

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -135,7 +135,7 @@ Base.@pure _valuetype(::VectorValues{dim}, ::AbstractVector{T}) where {dim,T} = 
 # Base.@pure _valuetype(::VectorValues{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
 
 """
-    function_scalar_gradient(fe_v::Values{dim}, q_point::Int, u::AbstractVector)
+    function_gradient(fe_v::Values{dim}, q_point::Int, u::AbstractVector)
 
 Compute the gradient of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -98,8 +98,9 @@ for the degrees of freedom. For a scalar valued function, `u` contains scalars.
 For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
 or `u` can be a vector of `Vec`s (for use with ScalarValues).
 
-The value of a scalar valued function is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
-where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function the value is calculated as
+The value of a scalar valued function or a vector valued function with use of `VectorValues` is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
+or ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
+where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function with use of `ScalarValues`, the value is calculated as
 ``\\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) \\mathbf{u}_i`` where ``\\mathbf{u}_i`` are the
 nodal values of ``\\mathbf{u}``.
 """

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -142,10 +142,11 @@ for the degrees of freedom. For a scalar valued function, `u` contains scalars.
 For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
 or `u` can be a vector of `Vec`s (for use with ScalarValues).
 
-The gradient of a scalar function is computed as
-``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i``
+The gradient of a scalar function or a vector valued function with use of `VectorValues` is computed as
+``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i`` or
+``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
 where ``u_i`` are the nodal values of the function.
-For a vector valued function the gradient is computed as
+For a vector valued function with use of `ScalarValues` the gradient is computed as
 ``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{u}_i \\otimes \\mathbf{\\nabla} N_i (\\mathbf{x})``
 where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 """


### PR DESCRIPTION
According to the old docstring, `function_gradient` for vector valued functions does ∇N ⊗ u, while it really does u ⊗ ∇N. This makes a difference in which vector determines the columns and which one determines the rows.