### PR TITLE
support adding Dirichlet BCs to nodesets

### DIFF
--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -16,4 +16,32 @@
 
     @test ch.prescribed_dofs == collect(1:9)
     @test ch.values == [-1, -1, 1, -1, -1, 1, 0, 0, 0]
+
+    ## test node bc with mixed dof handler
+   dim = 2
+   mesh = generate_grid(QuadraticQuadrilateral, (2,1))
+   addcellset!(mesh, "set1", Set(1))
+   addcellset!(mesh, "set2", Set(2))
+   addnodeset!(mesh, "bottom", Set(1:5))
+
+   dh  = MixedDofHandler(mesh)
+
+   ip_quadratic = Lagrange{dim, RefCube, 2}()
+   ip_linear = Lagrange{dim, RefCube, 1}()
+   field_u = Field(:u, ip_quadratic, dim)
+   field_c = Field(:c, ip_linear, 1)
+   push!(dh, FieldHandler([field_u, field_c], getcellset(mesh, "set1")))
+   push!(dh, FieldHandler([field_u], getcellset(mesh, "set2")))
+
+   close!(dh)
+
+   ch = ConstraintHandler(dh)
+   add!(ch, dh.fieldhandlers[1], Dirichlet(:u, getnodeset(mesh, "bottom"), (x,t)->1.0, 1))
+   add!(ch, dh.fieldhandlers[2], Dirichlet(:u, getnodeset(mesh, "bottom"), (x,t)->1.0, 1))
+   add!(ch, dh.fieldhandlers[1], Dirichlet(:c, getnodeset(mesh, "bottom"), (x,t)->2.0, 1))
+   close!(ch)
+   update!(ch)
+
+   @test ch.prescribed_dofs == [1,3,9,19,20,23,27]
+   @test ch.values == [1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
 end


### PR DESCRIPTION
Allow to add Dirichlet BCs to nodesets for the `MixedDofHandler`.

Also allows to add boundary conditions to a `FieldHandler` even if not all nodes/faces are part of the corresponding cellset. In that case a warning will be given and the node/face will simply be skipped. Considering that most mesh generators give nodesets in the format of "left nodes" and not seperated according to quad/tri/etc. elements, I think this is a lot more convenient.

@lijas : Now I did mess with functions that you are touching in #343, but it is small changes.

This replaces #294.