### PR TITLE
fix ch when adding bcs to faces with MixedDofHandler

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -35,12 +35,12 @@ struct Dirichlet # <: Constraint
     local_face_dofs_offset::Vector{Int}
 end
 function Dirichlet(field_name::Symbol, faces::Union{Set{Int},Set{Tuple{Int,Int}}}, f::Function, component::Int=1)
-    Dirichlet(field_name, faces, f, [component])
+    Dirichlet(field_name, copy(faces), f, [component])
 end
 function Dirichlet(field_name::Symbol, faces::Union{Set{Int},Set{Tuple{Int,Int}}}, f::Function, components::AbstractVector{Int})
     unique(components) == components || error("components not unique: $components")
     # issorted(components) || error("components not sorted: $components")
-    return Dirichlet(f, faces, field_name, Vector(components), Int[], Int[])
+    return Dirichlet(f, copy(faces), field_name, Vector(components), Int[], Int[])
 end
 
 """
@@ -204,9 +204,9 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Tuple{Int,Int
         @debug println("adding dofs $(_celldofs[local_face_dofs[r]]) to dbc")
     end
 
-    _dbc = Dirichlet(dbc.f, setdiff(dbc.faces, redundant_faces), dbc.field_name, dbc.components, dbc.local_face_dofs, dbc.local_face_dofs_offset)
+    setdiff!(dbc.faces, redundant_faces)
     # save it to the ConstraintHandler
-    push!(ch.dbcs, _dbc)
+    push!(ch.dbcs, dbc)
     push!(ch.bcvalues, bcvalue)
     append!(ch.prescribed_dofs, constrained_dofs)
 end

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -90,7 +90,7 @@ function apply_rhs!(data::RHSData, f::AbstractVector, ch::ConstraintHandler, app
     @assert length(f) == 0 || length(f) == size(K, 1)
     @boundscheck length(f) == 0 || checkbounds(f, ch.prescribed_dofs)
 
-	m = data.m
+    m = data.m
     @inbounds for i in 1:length(ch.values)
         d = ch.prescribed_dofs[i]
         v = ch.values[i]
@@ -191,12 +191,12 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Tuple{Int,Int
 
     # loop over all the faces in the set and add the global dofs to `constrained_dofs`
     constrained_dofs = Int[]
-	redundant_faces = NTuple{2, Int}[]
+    redundant_faces = NTuple{2, Int}[]
     for (cellidx, faceidx) in bcfaces
-		if cellidx ∉ cellset
-			push!(redundant_faces, (cellidx, faceidx)) # will be removed from dbc
-			continue # skip faces that are not part of the cellset
-		end
+        if cellidx ∉ cellset
+            push!(redundant_faces, (cellidx, faceidx)) # will be removed from dbc
+            continue # skip faces that are not part of the cellset
+        end
         _celldofs = fill(0, ndofs_per_cell(ch.dh, cellidx))
         celldofs!(_celldofs, ch.dh, cellidx) # extract the dofs for this cell
         r = local_face_dofs_offset[faceidx]:(local_face_dofs_offset[faceidx+1]-1)
@@ -204,7 +204,7 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Tuple{Int,Int
         @debug println("adding dofs $(_celldofs[local_face_dofs[r]]) to dbc")
     end
 
-	_dbc = Dirichlet(dbc.f, setdiff(dbc.faces, redundant_faces), dbc.field_name, dbc.components, dbc.local_face_dofs, dbc.local_face_dofs_offset)
+    _dbc = Dirichlet(dbc.f, setdiff(dbc.faces, redundant_faces), dbc.field_name, dbc.components, dbc.local_face_dofs, dbc.local_face_dofs_offset)
     # save it to the ConstraintHandler
     push!(ch.dbcs, _dbc)
     push!(ch.bcvalues, bcvalue)
@@ -222,7 +222,7 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpo
     _celldofs = fill(0, ndofs_per_cell(ch.dh, first(cellset)))
     node_dofs = zeros(Int, ncomps, nnodes)
     visited = falses(nnodes)
-	for cell in CellIterator(ch.dh, collect(cellset)) # only go over cells that belong to current FieldHandler
+    for cell in CellIterator(ch.dh, collect(cellset)) # only go over cells that belong to current FieldHandler
         celldofs!(_celldofs, cell) # update the dofs for this cell
         for idx in 1:min(interpol_points, length(cell.nodes))
             node = cell.nodes[idx]
@@ -242,7 +242,7 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpo
     sizehint!(dbc.local_face_dofs, length(bcnodes))
     for node in bcnodes
         if !visited[node]
-			# either the node belongs to another field handler or it does not have dofs in the constrained field
+    # either the node belongs to another field handler or it does not have dofs in the constrained field
             continue
         end
         for i in 1:ncomps
@@ -468,16 +468,16 @@ function _check_cellset_dirichlet(::AbstractGrid, cellset::Set{Int}, faceset::Se
 end
 
 function _check_cellset_dirichlet(grid::AbstractGrid, cellset::Set{Int}, nodeset::Set{Int})
-	nodes = Set{Int}()
-	for cellid in cellset
-		for nodeid in grid.cells[cellid].nodes
-			nodeid ∈ nodes || push!(nodes, nodeid)
-		end
-	end
+    nodes = Set{Int}()
+    for cellid in cellset
+        for nodeid in grid.cells[cellid].nodes
+            nodeid ∈ nodes || push!(nodes, nodeid)
+        end
+    end
 
-	for nodeid in nodeset
-		if !(nodeid ∈ nodes)
-			@warn("You are trying to add a constraint to a node that is not in the cellset of the fieldhandler. The node will be skipped.")
-		end
-	end
+    for nodeid in nodeset
+        if !(nodeid ∈ nodes)
+            @warn("You are trying to add a constraint to a node that is not in the cellset of the fieldhandler. The node will be skipped.")
+        end
+    end
 end


### PR DESCRIPTION
In #346  I made it possible to have faces/nodes in the `faces` of `Dirichlet` that do not belong to the cellset of the `FieldHandler` the boundary condition is added to. The reason was to be consistent with adding boundary conditions to nodesets. (And that I think it doesn't make sense to ask the user to filter facesets/nodesets according to e.g. element types.)

However, that broke the `update!` function for mixed meshes when the same boundary condition is applied to faces of different celltypes. Here, the `faces` are filtered in the `add!` function and a new `Dirichlet` with a suitable faceset is created. I am not sure if it is the best way to solve the problem. Happy to hear if somebody has a better suggestion!