### PR TITLE
Add Contributing and Questions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You can install Ferrite from the Pkg REPL:
 pkg> add Ferrite
 ```
 
+## Contributing and Questions
+If you have specific questions about Ferrite.jl, you're welcome to reach out to us on the Julia Slack under #ferrite-fem or on Zulip under #Ferrite.jl ([here](https://julialang.org/community/) you can find links to Slack and Zulip). If you encounter a problem, please open an [issue](https://github.com/Ferrite-FEM/Ferrite.jl/issues). Feel free to ask us in case you are not sure if a problem is on the side of Ferrite.jl! 
+Contributions are very welcome, as are feature requests and suggestions. Please keep in mind that we are part of the Julia community and adhere to the [Julia Community Standards](https://julialang.org/community/standards/).
+
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: http://ferrite-fem.github.io/Ferrite.jl/dev/

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ pkg> add Ferrite
 ```
 
 ## Contributing and Questions
-If you have specific questions about Ferrite.jl, you're welcome to reach out to us on the Julia Slack under #ferrite-fem or on Zulip under #Ferrite.jl ([here](https://julialang.org/community/) you can find links to Slack and Zulip). If you encounter a problem, please open an [issue](https://github.com/Ferrite-FEM/Ferrite.jl/issues). Feel free to ask us in case you are not sure if a problem is on the side of Ferrite.jl! 
-Contributions are very welcome, as are feature requests and suggestions. Please keep in mind that we are part of the Julia community and adhere to the [Julia Community Standards](https://julialang.org/community/standards/).
+If you have specific questions about Ferrite.jl, you're welcome to reach out to us on the Julia Slack under #ferrite-fem or on Zulip under #Ferrite.jl ([here](https://julialang.org/community/) you can find links to Slack and Zulip). If you encounter a problem, please open an [issue](https://github.com/Ferrite-FEM/Ferrite.jl/issues). Feel free to ask us in case you are not sure if a problem is on the side of Ferrite.jl! \
+Contributions are very welcome, as are feature requests and suggestions. \
+Please keep in mind that we are part of the Julia community and adhere to the [Julia Community Standards](https://julialang.org/community/standards/).
 
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ pkg> add Ferrite
 ```
 
 ## Contributing and Questions
-If you have specific questions about Ferrite.jl, you're welcome to reach out to us on the Julia Slack under #ferrite-fem or on Zulip under #Ferrite.jl ([here](https://julialang.org/community/) you can find links to Slack and Zulip). If you encounter a problem, please open an [issue](https://github.com/Ferrite-FEM/Ferrite.jl/issues). Feel free to ask us in case you are not sure if a problem is on the side of Ferrite.jl! \
-Contributions are very welcome, as are feature requests and suggestions. \
+If you have specific questions about Ferrite.jl, you're welcome to reach out to us on the Julia Slack under #ferrite-fem or on Zulip under #Ferrite.jl ([here](https://julialang.org/community/) you can find links to Slack and Zulip). If you encounter a problem, please open an [issue](https://github.com/Ferrite-FEM/Ferrite.jl/issues). Feel free to ask us in case you are not sure if a problem is on the side of Ferrite.jl!  
+Contributions are very welcome, as are feature requests and suggestions.  
 Please keep in mind that we are part of the Julia community and adhere to the [Julia Community Standards](https://julialang.org/community/standards/).
 
 


### PR DESCRIPTION
During the Gender Diversity BoF the point was raised that explicit information about how to reach out to package maintainers in e.g. the readme makes it a lot easier to actually reach out with questions / report issues etc., especially for newcomers. Not only valid for people from underrepresented genders of course, this should put the bar a bit lower for everyone. 
Here is a suggestion, what we could write. I took some inspiration from the Tensors.jl readme. @koehlerson suggested that some people might like Zulip better than Slack, so he opened a Zulip channel today. 

I think it would be great to incorporate such a section, please feel free to suggest changes to it if you'd like anything to be changed!