### PR TITLE
Extract dofs on face

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -23,11 +23,12 @@ struct DofHandler{dim,C,T} <: AbstractDofHandler
     closed::ScalarWrapper{Bool}
     grid::Grid{dim,C,T}
     ndofs::ScalarWrapper{Int}
+    local_facedofs::CellVector{Int}
 end
 
 function DofHandler(grid::Grid)
     isconcretetype(getcelltype(grid)) || error("Grid includes different celltypes. Use MixedDofHandler instead of DofHandler")
-    DofHandler(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, Ferrite.ScalarWrapper(-1))
+    DofHandler(Symbol[], Int[], Interpolation[], BCValues{Float64}[], Int[], Int[], ScalarWrapper(false), grid, Ferrite.ScalarWrapper(-1), CellVector(Int[],Int[],Int[]))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
@@ -261,6 +262,23 @@ function __close!(dh::DofHandler{dim}) where {dim}
     dh.ndofs[] = maximum(dh.cell_dofs)
     dh.closed[] = true
 
+    #Extract local facedofs
+    for iface in 1:nfaces(getcelltype(dh.grid))
+        local_face_dofs = []
+        for i in 1:nfields(dh)
+            ip = dh.field_interpolations[i]
+            field_dim = dh.field_dims[i]
+            field_faces = faces(ip)
+            offset = (i-1) * getnbasefunctions(ip)*field_dim
+            for fdof in field_faces[iface], d in 1:field_dim
+                push!(local_face_dofs, (fdof-1)*field_dim + d + offset)
+            end
+        end
+        push!(dh.local_facedofs.offset, length(dh.local_facedofs.values)+1)
+        push!(dh.local_facedofs.length, length(local_face_dofs))
+        append!(dh.local_facedofs.values, local_face_dofs)
+    end
+
     return dh, vertexdicts, edgedicts, facedicts
 
 end
@@ -270,6 +288,15 @@ function celldofs!(global_dofs::Vector{Int}, dh::DofHandler, i::Int)
     @assert length(global_dofs) == ndofs_per_cell(dh, i)
     unsafe_copyto!(global_dofs, 1, dh.cell_dofs, dh.cell_dofs_offset[i], length(global_dofs))
     return global_dofs
+end
+
+function facedofs!(global_face_dofs::Vector{Int}, dh::DofHandler, faceid::FaceIndex, global_cell_dofs::Vector{Int} = zeros(Int,ndofs_per_cell(dh, faceid[1])))
+    cellid, faceidx = faceid
+    celldofs!(global_cell_dofs, dh, cellid)
+    for (i,fdof) in enumerate(dh.local_facedofs[faceidx])
+        global_face_dofs[i] = global_cell_dofs[fdof]
+    end
+    return global_face_dofs
 end
 
 function cellnodes!(global_nodes::Vector{Int}, grid::Grid{dim,C}, i::Int) where {dim,C}

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -12,17 +12,6 @@ function FieldHandler(fields::Vector{Field}, cellset)
     return FieldHandler(fields, cellset)
 end
 
-struct CellVector{T}
-    values::Vector{T}
-    offset::Vector{Int}
-    length::Vector{Int}
-end
-
-function Base.getindex(elvec::CellVector, el::Int)
-    offset = elvec.offset[el]
-    return elvec.values[offset:offset + elvec.length[el]-1]
- end
-
 struct MixedDofHandler{dim,T,G<:AbstractGrid{dim}} <: Ferrite.AbstractDofHandler
     fieldhandlers::Vector{FieldHandler}
     cell_dofs::CellVector{Int}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,3 +23,14 @@ end
 Base.copy(s::ScalarWrapper{T}) where {T} = ScalarWrapper{T}(copy(s.x))
 
 copy!!(x, y) = copyto!(resize!(x, length(y)), y) # Future.copy!
+
+struct CellVector{T}
+    values::Vector{T}
+    offset::Vector{Int}
+    length::Vector{Int}
+end
+
+function Base.getindex(elvec::CellVector, el::Int)
+    offset = elvec.offset[el]
+    return elvec.values[offset:offset + elvec.length[el]-1]
+ end


### PR DESCRIPTION
I think it is pretty common to want to extract the dofs on some face in order to calculate for example the reaction forces on a boundary. This PR adds a function similar to` celldofs!(dofs, dh, cellid)`, called `facedofs!(dofs, dh, FaceIndex(cellid, faceid))`.

```
grid = generate_grid(Hexahedron, (3,3,3))
dh = DofHandler(grid)
push!(dh, :u, 2)
close!(dh)

faceset = collect(getfaceset(grid, "left"))

fdofs = zeros(Int, 8) #number of dofs on a face
Ferrite.facedofs!(fdofs, dh, faceset[1])
```

This PR could also make it possible integrate for example external forces on boundaries using the face-interpolation directly, instead of using the cell-interpolation + `FaceVectorValues`  which we are currently using.

This was just a concept I wanted to try out, let me know if this is something that could be usefull, and then I can work some more on it :) 