### PR TITLE
Remove unused type arguments that cause allocations in Ferrite.cellnodes!()

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -63,7 +63,7 @@ function cellcoords!(global_coords::Vector{Vec{dim,T}}, dh::MixedDofHandler, i::
     return global_coords
 end
 
-function cellnodes!(global_nodes::Vector{Int}, dh::MixedDofHandler, i::Int) where {dim,T}
+function cellnodes!(global_nodes::Vector{Int}, dh::MixedDofHandler, i::Int)
     @assert isclosed(dh)
     @assert length(global_nodes) == nnodes_per_cell(dh, i)
     unsafe_copyto!(global_nodes, 1, dh.cell_nodes.values, dh.cell_nodes.offset[i], length(global_nodes))


### PR DESCRIPTION
This seems like a bug in julia? Feels weird, hopefully i am not benchmarking it wrong in some way :sweat_smile: 

`@btime Ferrite.cellnodes!($nodes, $dh, $1)`

Before:
`25.734 ns (1 allocation: 112 bytes)`

Now:
`5.311 ns (0 allocations: 0 bytes)`