### PR TITLE
Reduce the ouput in quasi-incompressible hyperelasticity example

### DIFF
--- a/docs/src/literate/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate/quasi_incompressible_hyperelasticity.jl
@@ -23,16 +23,16 @@
 # ```math
 #     \Psi(u) = \frac{\mu}{2}\left(I_1 - 3 \right) - \mu \log(J) + \frac{\lambda}{2}\left( J - 1\right){}^2,
 # ```
-# where I₁=F:F≡FᵢⱼFᵢⱼ and J = det(F) denote the standard invariants of the deformation gradient tensor F = 𝛪 + ∇u.
+# where $I_1 = F:F = F_{ij}F_{ij}$ and J = det(F) denote the standard invariants of the deformation gradient tensor $F = \mathbb{I}+\nabla u$.
 # The above problem is ill-posed in the limit of incompressibility (or near-incompressibility), namely when
 # ```math
 #     \lambda/\mu \rightarrow +\infty.
 # ```
 # In order to alleviate the problem, we consider the partial legendre transform of the strain energy density Ψ with respect to J = det(F), namely
 # ```math
-#   \widehat{\Psi}(p) = \sup_{J} \left[ p(J - 1) - \frac{\mu}{2}\left(I_1 - 3 \right) + \mu \log(J) - \frac{\lambda}{2}\left( J - 1\right){}^2 \right].
+#   \widehat{\Psi}(u, p) = \sup_{J} \left[ p(J - 1) - \frac{\mu}{2}\left(I_1 - 3 \right) + \mu \log(J) - \frac{\lambda}{2}\left( J - 1\right){}^2 \right].
 # ```
-# The supremum, say J*, can be calculated in closed form by simply using the first order optimailty condition, i.e. ∂Ψ/∂J = 0. This gives 
+# The supremum, say $J^\star$, can be calculated in closed form by the first order optimailty condition $\partial\widehat{\Psi}/\partial J = 0$. This gives 
 # ```math
 #   J^\star(p) = \frac{\lambda + p + \sqrt{(\lambda + p){}^2 + 4 \lambda \mu }}{(2 \lambda)}.
 # ```
@@ -44,22 +44,22 @@
 # ```math
 #   \inf_{u\in\mathcal{K}}\sup_{p} \int_\Omega\Psi^{\star} (u, p) \ \mathrm{d}\Omega.
 # ```
-# The total (modified) energy Π* can then be written as
+# The total (modified) energy $\Pi^\star$ can then be written as
 # ```math
 #   \Pi^\star(u, p) = \int_\Omega p (J - J^\star) \ \mathrm{d}\Omega + \int_\Omega \frac{\mu}{2} \left( I_1 - 3\right) \ \mathrm{d}\Omega - \int_\Omega \mu\log(J^\star)\ \mathrm{d}\Omega + \int_\Omega \frac{\lambda}{2}\left( J^\star - 1 \right){}^2\ \mathrm{d}\Omega
 # ```
-# Calculating the euler-lagrange equations from the above energy give us our governing equations in the weak form, namely
+# The euler-lagrange equations corresponding to the above energy give us our governing PDEs in the weak form, namely
 # ```math
 #   \int_\Omega \frac{\partial\Psi^\star}{\partial F}:\delta F \ \mathrm{d}\Omega = 0 
 # ```
 # and
 # ```math
-#   \int_\Omega \frac{\partial \Psi^\star}{\partial p}\delta p \ \mathrm{d}\Omega,
+#   \int_\Omega \frac{\partial \Psi^\star}{\partial p}\delta p \ \mathrm{d}\Omega = 0,
 # ```
-# where δF = δ∇u = ∇(δu) and δu and δp denote arbitrary variations with respect to displacement and pressure. See the references
-# below for a more detailed exmplanation of the above mathematical trick. Now, in order to apply Newton's method to the 
-# above problem, we further need to calculate the respective hessians (tangent), namely, ∂²Ψ*/∂F², ∂²Ψ*/∂p² and ∂²Ψ*/∂F∂p
-# which, using `Tensors.jl`, can be determined conveniently using automatic differentiation. Hence we only need to define the above potential.
+# where δF = δ∇u = ∇(δu) and δu and δp denote arbitrary variations with respect to displacement and pressure (or the test functions). See the references
+# below for a more detailed explanation of the above mathematical trick. Now, in order to apply Newton's method to the 
+# above problem, we further need to linearize the above equations and calculate the respective hessians (or tangents), namely, $\partial^2\Psi^\star/\partial F^2$, $\partial^2\Psi^\star/\partial p^2$ and $\partial^2\Psi^\star/\partial F\partial p$
+# which, using `Tensors.jl`, can be determined conveniently using automatic differentiation (see the code below). Hence we only need to define the above potential.
 # The remaineder of the example follows similarly. 
 # ## References
 # 1. [A paradigm for higher-order polygonal elements in finite elasticity using a gradient correction scheme, CMAME 2016, 306, 216–251](http://pamies.cee.illinois.edu/Publications_files/CMAME_2016.pdf)
@@ -67,7 +67,7 @@
 #
 # We now get to the actual code. First, we import the respective packages
 
-using Ferrite, Tensors, TimerOutputs, ProgressMeter
+using Ferrite, Tensors, ProgressMeter
 using BlockArrays, SparseArrays, LinearAlgebra
 
 # and the corresponding `struct` to store our material properties.
@@ -255,14 +255,14 @@ function assemble_global!(K::SparseMatrixCSC, f, cellvalues_u::CellVectorValues{
 
     assembler = start_assemble(K, f)
     ## Loop over all cells in the grid
-    @timeit "assemble" for cell in CellIterator(dh)
+    for cell in CellIterator(dh)
         global_dofs = celldofs(cell)
         global_dofsu = global_dofs[1:nu]; # first nu dofs are displacement
         global_dofsp = global_dofs[nu + 1:end]; # last np dofs are pressure
         @assert size(global_dofs, 1) == nu + np # sanity check
         ue = w[global_dofsu] # displacement dofs for the current cell
         pe = w[global_dofsp] # pressure dofs for the current cell
-        @timeit "element assemble" assemble_element!(ke, fe, cell, cellvalues_u, cellvalues_p, mp, ue, pe)
+        assemble_element!(ke, fe, cell, cellvalues_u, cellvalues_p, mp, ue, pe)
         assemble!(assembler, global_dofs, fe, ke)
     end
 end;
@@ -271,7 +271,6 @@ end;
 # solution in terms of a pseudo time like parameter, which in this case is used to gradually apply the boundary
 # displacement on the right face. Also for definitenessm we consider λ/μ = 10⁴
 function solve(interpolation_u, interpolation_p)
-    reset_timer!()
 
     ## import the mesh
     grid = importTestGrid()
@@ -307,18 +306,19 @@ function solve(interpolation_u, interpolation_p)
     pvd = paraview_collection("hyperelasticity_incomp_mixed.pvd");
     for t ∈ 0.0:Δt:Tf
         ## Perform Newton iterations
-        print("Time is $t")
         Ferrite.update!(dbc, t)
         apply!(w, dbc)
         newton_itr = -1
-        prog = ProgressMeter.ProgressThresh(NEWTON_TOL, "Solving:")
+        prog = ProgressMeter.ProgressThresh(NEWTON_TOL, "Solving @ time $t of $Tf;")
         fill!(ΔΔw, 0.0);
         while true; newton_itr += 1
             assemble_global!(K, f, cellvalues_u, cellvalues_p, dh, mp, w)
             norm_res = norm(f[Ferrite.free_dofs(dbc)])
             apply_zero!(K, f, dbc)
-            ProgressMeter.update!(prog, norm_res; showvalues = [(:iter, newton_itr)])
-
+            ## Only display output at specific load steps
+            if t%(5*Δt) == 0
+                ProgressMeter.update!(prog, norm_res; showvalues = [(:iter, newton_itr)])
+            end
             if norm_res < NEWTON_TOL
                 break
             elseif newton_itr > 30
@@ -332,15 +332,13 @@ function solve(interpolation_u, interpolation_p)
         end;
 
         ## Save the solution fields
-        @timeit "export" begin
+        begin
             vtk_grid("hyperelasticity_incomp_mixed_$t.vtu", dh, compress=false) do vtkfile
                 vtk_point_data(vtkfile, dh, w)
                 vtk_save(vtkfile)
                 pvd[t] = vtkfile
             end
         end
-
-        print_timer(title = "Analysis with $(getncells(grid)) elements", linechars = :ascii)
     end;
     vtk_save(pvd);
     vol_def = calculate_volume_deformed_mesh(w, dh, cellvalues_u);

--- a/docs/src/literate/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate/quasi_incompressible_hyperelasticity.jl
@@ -332,12 +332,10 @@ function solve(interpolation_u, interpolation_p)
         end;
 
         ## Save the solution fields
-        begin
-            vtk_grid("hyperelasticity_incomp_mixed_$t.vtu", dh, compress=false) do vtkfile
-                vtk_point_data(vtkfile, dh, w)
-                vtk_save(vtkfile)
-                pvd[t] = vtkfile
-            end
+        vtk_grid("hyperelasticity_incomp_mixed_$t.vtu", dh, compress=false) do vtkfile
+            vtk_point_data(vtkfile, dh, w)
+            vtk_save(vtkfile)
+            pvd[t] = vtkfile
         end
     end;
     vtk_save(pvd);


### PR DESCRIPTION
Sorry for the hurried implementation in #370. While there are no major changes to the code anywhere,
as [discussed](https://github.com/Ferrite-FEM/Ferrite.jl/pull/370#issuecomment-916266027) in #370, the current output to screen is humongous. Since all of it is not necessary, it suffices to output just the overall progress at specific time steps. The current code outputs [this](https://github.com/Ferrite-FEM/Ferrite.jl/pull/370#issuecomment-916519967) which is both terse and informative
