### PR TITLE
Some common elements

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -124,6 +124,17 @@ function sortface(face::Tuple{Int,Int,Int})
     return (a, b, c)
 end
 
+function sortface(face::Tuple{Int,Int,Int,Int})
+    a, b, c, d = face
+    c, d = minmax(c, d)
+    b, d = minmax(b, d)
+    a, d = minmax(a, d)
+    b, c = minmax(b, c)
+    a, c = minmax(a, c)
+    a, b = minmax(a, b)
+    return (a, b, c)
+end
+
 function close!(dh::DofHandler)
     dh, _, _, _ = __close!(dh)
     return dh

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -211,7 +211,7 @@ getnormal(fv::FaceValues, qp::Int) = fv.normals[qp]
 """
     BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Union{Type{<:BoundaryIndex}})
 
-`BCValues` stores the shape values at all faces/edges/vertices (depending on `boundary_type`) for the geomatric interpolation (`geom_interpol`), 
+`BCValues` stores the shape values at all faces/edges/vertices (depending on `boundary_type`) for the geomatric interpolation (`geom_interpol`),
 for each dof-position determined by the `func_interpol`. Used mainly by the `ConstrainHandler`.
 """
 struct BCValues{T}
@@ -238,8 +238,8 @@ function BCValues(::Type{T}, func_interpol::Interpolation{dim,refshape}, geom_in
         push!(qrs, qrf)
     end
 
-    n_qpoints = length(getweights(qrs[1])) # assume same in all
     n_faces = length(qrs)
+    n_qpoints = n_faces == 0 ? 0 : length(getweights(qrs[1])) # assume same in all
     n_geom_basefuncs = getnbasefunctions(geom_interpol)
     M =    fill(zero(T)           * T(NaN), n_geom_basefuncs, n_qpoints, n_faces)
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -3,6 +3,7 @@ export
     Interpolation,
     RefCube,
     RefTetrahedron,
+    BubbleEnrichedLagrange,
     CrouzeixRaviart,
     Lagrange,
     DiscontinuousLagrange,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -4,6 +4,7 @@ export
     RefCube,
     RefTetrahedron,
     Lagrange,
+    DiscontinuousLagrange,
     Serendipity,
     getnbasefunctions,
 
@@ -53,7 +54,7 @@ export
     Tetrahedron,
     QuadraticTetrahedron,
     Hexahedron,
-    QuadraticHexahedron,
+    #QuadraticHexahedron,
     CellIndex,
     FaceIndex,
     EdgeIndex,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -3,6 +3,7 @@ export
     Interpolation,
     RefCube,
     RefTetrahedron,
+    CrouzeixRaviart,
     Lagrange,
     DiscontinuousLagrange,
     Serendipity,

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -134,27 +134,27 @@ getlowerorder(::DiscontinuousLagrange{dim,shape,order}) where {dim,shape,order} 
 # ncelldofs(::DiscontinuousLagrange{dim,RefCube,order}) where {dim,order} = (order+1)^dim
 # ncelldofs(::DiscontinuousLagrange{2,RefTetrahedron,order}) where {order} = (order+1)*(order+2)/2
 # ncelldofs(::DiscontinuousLagrange{3,RefTetrahedron,order}) where {order} = (order+1)*(order+2)/2
-getnbasefunctions(::DiscontinuousLagrange{dim,ref_geo,order}) where {dim,ref_geo,order} = getnbasefunctions(Lagrange{dim,ref_geo,order}())
-ncelldofs(::DiscontinuousLagrange{dim,ref_geo,order}) where {dim,ref_geo,order} = getnbasefunctions(DiscontinuousLagrange{dim,ref_geo,order}())
+getnbasefunctions(::DiscontinuousLagrange{dim,shape,order}) where {dim,shape,order} = getnbasefunctions(Lagrange{dim,shape,order}())
+ncelldofs(::DiscontinuousLagrange{dim,shape,order}) where {dim,shape,order} = getnbasefunctions(DiscontinuousLagrange{dim,shape,order}())
 
-getnbasefunctions(::DiscontinuousLagrange{dim,ref_geo,0}) where {dim,ref_geo} = 1
-ncelldofs(::DiscontinuousLagrange{dim,ref_geo,0}) where {dim,ref_geo} = 1
+getnbasefunctions(::DiscontinuousLagrange{dim,shape,0}) where {dim,shape} = 1
+ncelldofs(::DiscontinuousLagrange{dim,shape,0}) where {dim,shape} = 1
 
-faces(::DiscontinuousLagrange{dim,ref_geo,order}) where {dim,ref_geo,order} = ()
+faces(::DiscontinuousLagrange{dim,shape,order}) where {dim,shape,order} = ()
 
 # Mirror the Lagrange element for now.
-function reference_coordinates(ip::DiscontinuousLagrange{dim, ref_type, order}) where {dim, ref_type, order}
-    return reference_coordinates(Lagrange{dim, ref_type, order}())
+function reference_coordinates(ip::DiscontinuousLagrange{dim,shape,order}) where {dim,shape,order}
+    return reference_coordinates(Lagrange{dim,shape,order}())
 end
-function value(ip::DiscontinuousLagrange{dim,ref_type,order}, i::Int, ξ::Vec{dim}) where {dim, ref_type, order}
+function value(ip::DiscontinuousLagrange{dim,shape,order}, i::Int, ξ::Vec{dim}) where {dim,shape,order}
     return value(Lagrange{dim, ref_type, order}())
 end
 
 # Excepting the L0 element.
-function reference_coordinates(ip::DiscontinuousLagrange{dim, ref_type, 0}) where {dim, ref_type}
-    return repeat([Vec{dim, Float64}(ntuple(x->0.0, dim))])*getnbasefunctions(ip)
+function reference_coordinates(ip::DiscontinuousLagrange{dim,shape,0}) where {dim,shape}
+    return [Vec{dim, Float64}(ntuple(x->0.0, dim))]
 end
-function value(ip::DiscontinuousLagrange{dim,ref_type,0}, i::Int, ξ::Vec{dim}) where {dim,ref_type}
+function value(ip::DiscontinuousLagrange{dim,shape,0}, i::Int, ξ::Vec{dim}) where {dim,shape}
     return 1.0
 end
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -142,11 +142,19 @@ ncelldofs(::DiscontinuousLagrange{dim,ref_geo,0}) where {dim,ref_geo} = 1
 
 faces(::DiscontinuousLagrange{dim,ref_geo,order}) where {dim,ref_geo,order} = ()
 
-function reference_coordinates(ip::DiscontinuousLagrange{dim, RefCube, 0}) where {dim}
-    return repeat([Vec{2, Float64}(ntuple(x->0.0, dim))])*getnbasefunctions(ip)
+# Mirror the Lagrange element for now.
+function reference_coordinates(ip::DiscontinuousLagrange{dim, ref_type, order}) where {dim, ref_type, order}
+    return reference_coordinates(Lagrange{dim, ref_type, order}())
+end
+function value(ip::DiscontinuousLagrange{dim,ref_type,order}, i::Int, ξ::Vec{dim}) where {dim, ref_type, order}
+    return value(Lagrange{dim, ref_type, order}())
 end
 
-function value(ip::Union{DiscontinuousLagrange{dim,ref_type,0}}, i::Int, ξ::Vec{dim}) where {ref_type, dim}
+# Excepting the L0 element.
+function reference_coordinates(ip::DiscontinuousLagrange{dim, ref_type, 0}) where {dim, ref_type}
+    return repeat([Vec{dim, Float64}(ntuple(x->0.0, dim))])*getnbasefunctions(ip)
+end
+function value(ip::DiscontinuousLagrange{dim,ref_type,0}, i::Int, ξ::Vec{dim}) where {dim,ref_type}
     return 1.0
 end
 
@@ -210,14 +218,14 @@ nvertexdofs(::Lagrange{2,RefCube,1}) = 1
 
 faces(::Lagrange{2,RefCube,1}) = ((1,2), (2,3), (3,4), (4,1))
 
-function reference_coordinates(::Union{Lagrange{2,RefCube,1}, DiscontinuousLagrange{2,RefCube,1}})
+function reference_coordinates(::Lagrange{2,RefCube,1})
     return [Vec{2, Float64}((-1.0, -1.0)),
             Vec{2, Float64}(( 1.0, -1.0)),
             Vec{2, Float64}(( 1.0,  1.0,)),
             Vec{2, Float64}((-1.0,  1.0,))]
 end
 
-function value(ip::Union{Lagrange{2,RefCube,1}, DiscontinuousLagrange{2,RefCube,1}}, i::Int, ξ::Vec{2})
+function value(ip::Lagrange{2,RefCube,1}, i::Int, ξ::Vec{2})
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return (1 - ξ_x) * (1 - ξ_y) * 0.25

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -565,9 +565,9 @@ function value(ip::Serendipity{2,RefCube,2}, i::Int, ξ::Vec{2})
     throw(ArgumentError("no shape function $i for interpolation $ip"))
 end
 
-##################################
+#####################################
 # Serendipity dim 3 RefCube order 2 #
-##################################
+#####################################
 getnbasefunctions(::Serendipity{3,RefCube,2}) = 20
 getlowerdim(::Serendipity{3,RefCube,2}) = Serendipity{2,RefCube,2}()
 getlowerorder(::Serendipity{3,RefCube,2}) = Lagrange{3,RefCube,1}()
@@ -623,5 +623,40 @@ function value(ip::Serendipity{3,RefCube,2}, i::Int, ξ::Vec{3})
     i == 18 && return 0.25(1 + ξ_x) * (1 - ξ_y) * (1 - ξ_z^2)
     i == 19 && return 0.25(1 + ξ_x) * (1 + ξ_y) * (1 - ξ_z^2)
     i == 20 && return 0.25(1 - ξ_x) * (1 + ξ_y) * (1 - ξ_z^2)
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+
+#############################
+# Crouzeix–Raviart Elements #
+#############################
+"""
+Classical non-conforming Crouzeix–Raviart element.
+
+For details we refer ot the original paper:
+M. Crouzeix and P. Raviart. "Conforming and nonconforming finite element 
+methods for solving the stationary Stokes equations I." ESAIM: Mathematical Modelling 
+and Numerical Analysis-Modélisation Mathématique et Analyse Numérique 7.R3 (1973): 33-75.
+"""
+struct CrouzeixRaviart{dim,order} <: Interpolation{dim,RefTetrahedron,order} end
+
+getnbasefunctions(::CrouzeixRaviart{2,1}) = 3
+nfacedofs(::CrouzeixRaviart{2,1}) = 1
+
+vertices(::CrouzeixRaviart{2,1}) = ()
+faces(::CrouzeixRaviart{2,1}) = ((1,), (2,), (3,))
+
+function reference_coordinates(::CrouzeixRaviart{2,1})
+    return [Vec{2, Float64}((0.5, 0.5)),
+            Vec{2, Float64}((0.0, 0.5)),
+            Vec{2, Float64}((0.5, 0.0))]
+end
+
+function value(ip::CrouzeixRaviart{2,1}, i::Int, ξ::Vec{2})
+    ξ_x = ξ[1]
+    ξ_y = ξ[2]
+    i == 1 && return 2*ξ_x + 2*ξ_y - 1.0
+    i == 2 && return 1.0 - 2*ξ_x
+    i == 3 && return 1.0 - 2*ξ_y
     throw(ArgumentError("no shape function $i for interpolation $ip"))
 end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -482,14 +482,12 @@ function reference_coordinates(::Lagrange{3,RefCube,2})
             ]
 end
 
-function value(ip::Lagrange{3,RefCube,2}, i::Int, ξ::Vec{3})
+function value(ip::Lagrange{3,RefCube,2}, i::Int, ξ::Vec{3, T}) where {T}
     # Some local helpers.
-    @inline φ₁(x) = -0.5*x*(1-x)
-    @inline φ₂(x) = (1+x)*(1-x)
-    @inline φ₃(x) = 0.5*x*(1+x)
-    ξ_x = ξ[1]
-    ξ_y = ξ[2]
-    ξ_z = ξ[3]
+    @inline φ₁(x::T) = -0.5*x*(1-x)
+    @inline φ₂(x::T) = (1+x)*(1-x)
+    @inline φ₃(x::T) = 0.5*x*(1+x)
+    (ξ_x, ξ_y, ξ_z) = ξ
     # vertices
     i == 1 && return φ₁(ξ_x) * φ₁(ξ_y) * φ₁(ξ_z)
     i == 2 && return φ₃(ξ_x) * φ₁(ξ_y) * φ₁(ξ_z)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -437,7 +437,7 @@ end
 ##################################
 # Lagrange dim 3 RefCube order 2 #
 ##################################
-# Based on vtkTriQuadraticHexahedron
+# Based on vtkTriQuadraticHexahedron (see https://kitware.github.io/vtk-examples/site/Cxx/GeometricObjects/IsoparametricCellsDemo/)
 getnbasefunctions(::Lagrange{3,RefCube,2}) = 27
 nvertexdofs(::Lagrange{3,RefCube,2}) = 1
 nedgedofs(::Lagrange{3,RefCube,2}) = 1
@@ -445,7 +445,7 @@ nfacedofs(::Lagrange{3,RefCube,2}) = 1
 ncelldofs(::Lagrange{3,RefCube,2}) = 1
 
 faces(::Lagrange{3,RefCube,2}) = ((1,2,6,5, 9,18,13,17, 23), (2,3,7,6, 10,19,14,18, 22), (3,4,8,7, 11,20,15,19, 24), (1,5,8,4, 12,17,16,20, 21), (1,4,3,2, 9,10,11,12, 25), (5,6,7,8, 13,14,15,16, 26))
-edges(::Lagrange{3,RefCube,2}) = ((1,2), (2,3), (3,4), (4,1), (1,5), (2,6), (3,7), (4,8), (5,6), (6,7), (7,8), (8,5))
+edges(::Lagrange{3,RefCube,2}) = ((1,2, 9), (2,3, 10), (3,4, 11), (4,1, 12), (1,5, 16), (2,6, 19), (3,7, 18), (4,8, 19), (5,6, 13), (6,7, 14), (7,8, 15), (8,5, 16))
 
 function reference_coordinates(::Lagrange{3,RefCube,2})
            # vertex

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -7,10 +7,17 @@ for interpolation in (Lagrange{1, RefCube, 1}(),
                       Lagrange{2, RefTetrahedron, 1}(),
                       Lagrange{2, RefTetrahedron, 2}(),
                       Lagrange{3, RefCube, 1}(),
+                      Lagrange{3, RefCube, 2}(),
                       Serendipity{2, RefCube, 2}(),
                       Serendipity{3, RefCube, 2}(),
                       Lagrange{3, RefTetrahedron, 1}(),
-                      Lagrange{3, RefTetrahedron, 2}(),)
+                      Lagrange{3, RefTetrahedron, 2}(),
+                      #
+                      DiscontinuousLagrange{1, RefCube, 0}(),
+                      DiscontinuousLagrange{2, RefCube, 0}(),
+                      DiscontinuousLagrange{3, RefCube, 0}(),
+                      DiscontinuousLagrange{2, RefTetrahedron, 0}(),
+                      DiscontinuousLagrange{3, RefTetrahedron, 0}(),)
 
     # Test of utility functions
     ndim = Ferrite.getdim(interpolation)

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -17,15 +17,19 @@ for interpolation in (Lagrange{1, RefCube, 1}(),
                       DiscontinuousLagrange{2, RefCube, 0}(),
                       DiscontinuousLagrange{3, RefCube, 0}(),
                       DiscontinuousLagrange{2, RefTetrahedron, 0}(),
-                      DiscontinuousLagrange{3, RefTetrahedron, 0}(),)
+                      DiscontinuousLagrange{3, RefTetrahedron, 0}(),
+                      #
+                      CrouzeixRaviart{2,1}(),)
 
     # Test of utility functions
     ndim = Ferrite.getdim(interpolation)
     r_shape = Ferrite.getrefshape(interpolation)
     func_order = Ferrite.getorder(interpolation)
     @test typeof(interpolation) <: Interpolation{ndim,r_shape,func_order}
-    @test typeof(Ferrite.getlowerdim(interpolation)) <: Interpolation{ndim-1}
-    @test typeof(Ferrite.getlowerorder(interpolation)) <: Interpolation{ndim,r_shape,func_order-1}
+
+    # Note that not every element formulation exists for every order and dimension.
+    applicable(Ferrite.getlowerdim, interpolation) && @test typeof(Ferrite.getlowerdim(interpolation)) <: Interpolation{ndim-1}
+    applicable(Ferrite.getlowerorder, interpolation) && @test typeof(Ferrite.getlowerorder(interpolation)) <: Interpolation{ndim,r_shape,func_order-1}
 
     n_basefuncs = getnbasefunctions(interpolation)
     x = rand(Tensor{1, ndim})

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -19,6 +19,8 @@ for interpolation in (Lagrange{1, RefCube, 1}(),
                       DiscontinuousLagrange{2, RefTetrahedron, 0}(),
                       DiscontinuousLagrange{3, RefTetrahedron, 0}(),
                       #
+                      BubbleEnrichedLagrange{2,RefTetrahedron,1}(),
+                      #
                       CrouzeixRaviart{2,1}(),)
 
     # Test of utility functions


### PR DESCRIPTION
## Showcase

L2P0 elements for heat fluxes
![Screenshot from 2021-10-13 05-10-22](https://user-images.githubusercontent.com/9196588/137209213-a785e561-66c6-4115-88bb-07b1f9b9d0d9.png)


## Scope

The following elements are included
* [x] ~~Arbitrary~~ Zero, first and second order discontinuous Lagrange (L2 elements) - fixes fixes #352 
* [x] First order nonconforming Crouzeix-Raviart from original paper @bhaveshshrimali
* [x] Bubble element (2D P1b)
* [x] Quadratic hex (3D Q2 / 27-node brick)

Further flux spaces for scalar-valued problems are introduced and presented in the postprocessing example.

##  Nongoals

* Fixing close! for arbitrary order (Lagrange) bases 
* Non-nodal elements
* Flux spaces for vector-valued problems (which requires matrix-valued dofs)
* Tutorial for new elements
