### PR TITLE
Linear constraints

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -43,6 +43,47 @@ function Dirichlet(field_name::Symbol, faces::Set{T}, f::Function, components::A
     return Dirichlet(f, copy(faces), field_name, Vector(components), Int[], Int[])
 end
 
+struct LinearConstraint
+
+end
+
+struct Constraint
+
+end
+struct FollowerDofs
+    masterdof::Dof
+    slaveface::Vector{FaceIndex}
+
+    components::Vector{Int} # components of the field
+    local_face_dofs::Vector{Int}
+    local_face_dofs_offset::Vector{Int}
+end
+
+SimpleConstraint(masterdof, getfaceset(grid, "topface"), :u, [1,])
+
+add_penalty!(ch, followerconstrint, penatly = 10^9)
+add_lagrange!(ch, followerconstrint)
+
+function apply!(K, f, ch, d, Δd)
+
+    for c in ch.penatly_constraints
+        apply!(c, K, f, d, Δd)
+    end
+    
+end
+
+function apply!(ch, K, f, d, Δd, λ)
+
+        getG(G, ch, d)
+        getH(H, ch ,d)
+
+        f[m,m] += G
+        K[m,m] += H
+
+end
+
+
+
 """
     ConstraintHandler
 

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -315,7 +315,8 @@ with stored values in the correct places.
 
 See the [Sparsity Pattern](@ref) section of the manual.
 """
-@inline create_sparsity_pattern(dh::DofHandler) = _create_sparsity_pattern(dh, false)
+@inline create_sparsity_pattern(dh::DofHandler) = _create_sparsity_pattern(dh, nothing, false)
+@inline create_sparsity_pattern(dh::DofHandler, ch) = _create_sparsity_pattern(dh, ch, false)
 
 """
     create_symmetric_sparsity_pattern(dh::DofHandler)
@@ -326,9 +327,10 @@ triangle of the matrix. Return a `Symmetric{SparseMatrixCSC}`.
 
 See the [Sparsity Pattern](@ref) section of the manual.
 """
-@inline create_symmetric_sparsity_pattern(dh::DofHandler) = Symmetric(_create_sparsity_pattern(dh, true), :U)
+@inline create_symmetric_sparsity_pattern(dh::DofHandler) = Symmetric(_create_sparsity_pattern(dh, nothing, true), :U)
+@inline create_symmetric_sparsity_pattern(dh::DofHandler, ch) = Symmetric(_create_sparsity_pattern(dh, ch, true), :U)
 
-function _create_sparsity_pattern(dh::DofHandler, sym::Bool)
+function _create_sparsity_pattern(dh::DofHandler, ch=nothing, sym::Bool=false)
     ncells = getncells(dh.grid)
     n = ndofs_per_cell(dh)
     N = sym ? div(n*(n+1), 2) * ncells : n^2 * ncells
@@ -362,6 +364,11 @@ function _create_sparsity_pattern(dh::DofHandler, sym::Bool)
         I[cnt] = d
         J[cnt] = d
     end
+
+    if ch !== nothing
+        #TODO
+    end
+
     resize!(I, cnt)
     resize!(J, cnt)
     V = zeros(length(I))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -105,6 +105,7 @@ export
 # Constraints
     ConstraintHandler,
     Dirichlet,
+    LinearConstraint,
     update!,
     apply!,
     apply_rhs!,


### PR DESCRIPTION

This wip PR makes it possible to use linear constraints. I was able to use a lot of the old structure of the ConstraintHandler which is nice. I also got inspiration on how to condense the stiffness matrix from deal ii :) 

Currently this PR is not very fail safe, meaning that the user can add Dirichlet and/or linear constraints that does not "work" together, without warning the user. There is no logic that assures that constraints are linearly independent etc (this is something the user must make sure themselves). 

When adding constraints, the user must reference global dof ids directly. For this, we need better tools for querying dof ids on faces/edges/nodes etc. 

Example:
```
...
ch = ConstraintHandler(dh)
add!(ch, Dirichlet(:u, getfaceset(grid, "left"), (x,t)->0.0))
    add!(ch, LinearConstraint(4, [(7 => 2.0)], 1.5)) # u4 = 2.0*u7 - 1.5
close!(ch)
update!(ch, 0.0)
...
apply!(K, f, ch)
a = K\f
apply!(a,ch)

```