### PR TITLE
Allow coloring subsets of cells

### DIFF
--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -27,4 +27,5 @@ vtk_grid(filename::AbstractString, grid::Grid{dim,C,T}; compress::Bool) where {d
 vtk_point_data(vtk::WriteVTK.DatasetFile, data::Union{Vector{SymmetricTensor{2,dim,T,M}}},name::AbstractString) where {dim,T,M}
 vtk_point_data(vtk::WriteVTK.DatasetFile, data::Union{ Vector{Tensor{order,dim,T,M}}, Vector{SymmetricTensor{order,dim,T,M}}}, name::AbstractString) where {order,dim,T,M}
 vtk_cellset
+vtk_cell_data_colors
 ```

--- a/docs/src/reference/grid.md
+++ b/docs/src/reference/grid.md
@@ -3,3 +3,7 @@ DocTestSetup = :(using Ferrite)
 ```
 
 # Grid
+## Multithreaded Assembly
+```@docs
+create_coloring
+```

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -176,7 +176,7 @@ The resulting colors can be visualized using [`vtk_cell_data_colors`](@ref).
     )
     ```
 """
-function create_coloring(g::Grid; alg::ColoringAlgorithm=WORKSTREAM, cellset::Set{Int}=Set{Int}(1:getncells(g)))
+function create_coloring(g::Grid, cellset::Set{Int}=Set{Int}(1:getncells(g)); alg::ColoringAlgorithm=WORKSTREAM)
     incidence_matrix = create_incidence_matrix(g, cellset)
     if alg === WORKSTREAM
         return workstream_coloring(incidence_matrix, cellset)

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -142,10 +142,10 @@ end
 @enum ColoringAlgorithm GREEDY WORKSTREAM
 
 """
-    create_coloring(g::Grid; alg::ColoringAlgorithm)
+    create_coloring(g::Grid, cellset::Set{Int}=Set(1:getncells(g)); alg::ColoringAlgorithm)
 
 Create a coloring of the cells in grid `g` such that no neighboring cells
-have the same color.
+have the same color. If only a subset of cells should be colored, the cells to color can be specified by `cellset`.
 
 Returns a vector of vectors with cell indexes, e.g.:
 
@@ -159,9 +159,10 @@ ret = [
 Two different algorithms are available, specified with the `alg` keyword argument:
  - `alg = Ferrite.WORKSTREAM` (default): Three step algorithm from
    [*WorkStream*](https://www.math.colostate.edu/%7Ebangerth/publications/2013-pattern.pdf)
-   , albeit with a greedy coloring in the second step.
- - `alg = Ferrite.GREEDY`: greedy algorithm that works well for structured grid such as
-   e.g. grids from `generate_grid`.
+   , albeit with a greedy coloring in the second step. Generally results in more colors than `Ferrite.GREEDY`,
+   however the cells are more equally distributed among the colors.
+ - `alg = Ferrite.GREEDY`: greedy algorithm that works well for structured quadrilateral grids such as
+   e.g. quadrilateral grids from `generate_grid`.
 
 The resulting colors can be visualized using [`vtk_cell_data_colors`](@ref).
 

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -218,7 +218,7 @@ end
 @testset "grid coloring" begin
     function test_coloring(grid, cellset=Set(1:getncells(grid)))
         for alg in (Ferrite.GREEDY, Ferrite.WORKSTREAM)
-            color_vectors = create_coloring(grid; alg=alg, cellset=cellset)
+            color_vectors = create_coloring(grid, cellset; alg=alg)
             @test sum(length, color_vectors) == length(cellset)
             @test union(Set.(color_vectors)...) == cellset
             conn = Ferrite.create_incidence_matrix(grid, cellset)

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -216,12 +216,12 @@ end
 end
 
 @testset "grid coloring" begin
-    function test_coloring(grid)
+    function test_coloring(grid, cellset=Set(1:getncells(grid)))
         for alg in (Ferrite.GREEDY, Ferrite.WORKSTREAM)
-            color_vectors = create_coloring(grid; alg=alg)
-            @test sum(length, color_vectors) == getncells(grid)
-            @test union(Set.(color_vectors)...) == Set(1:getncells(grid))
-            conn = Ferrite.create_incidence_matrix(grid)
+            color_vectors = create_coloring(grid; alg=alg, cellset=cellset)
+            @test sum(length, color_vectors) == length(cellset)
+            @test union(Set.(color_vectors)...) == cellset
+            conn = Ferrite.create_incidence_matrix(grid, cellset)
             for color in color_vectors, c1 in color, c2 in color
                 @test !conn[c1, c2]
             end
@@ -237,4 +237,11 @@ end
     # test_coloring(generate_grid(QuadraticTetrahedron, (5, 5, 5)))
     test_coloring(generate_grid(Hexahedron, (5, 5, 5)))
     # test_coloring(generate_grid(QuadraticHexahedron, (5, 5, 5)))
+
+    # color only a subset
+    test_coloring(generate_grid(Line, (5,)), Set{Int}(1:3))
+    test_coloring(generate_grid(Triangle, (5, 5)), Set{Int}(1:3^2))
+    test_coloring(generate_grid(Quadrilateral, (5, 5)), Set{Int}(1:3^2))
+    test_coloring(generate_grid(Tetrahedron, (5, 5, 5)), Set{Int}(1:3^3))
+    test_coloring(generate_grid(Hexahedron, (5, 5, 5)), Set{Int}(1:3^3))
 end

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -244,4 +244,6 @@ end
     test_coloring(generate_grid(Quadrilateral, (5, 5)), Set{Int}(1:3^2))
     test_coloring(generate_grid(Tetrahedron, (5, 5, 5)), Set{Int}(1:3^3))
     test_coloring(generate_grid(Hexahedron, (5, 5, 5)), Set{Int}(1:3^3))
+    # unconnected subset
+    test_coloring(generate_grid(Triangle, (10, 10)), union(Set(1:10), Set(70:80)))
 end


### PR DESCRIPTION
Allows to specify a subset of the cells to color. This can make sense especially with mixed grids.
Also adds the docstrings for coloring to the docs.