### PR TITLE
WIP: Traits for `ScalarValues` / `VectorValues`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Ferrite"
 uuid = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -142,10 +142,8 @@ end
 
 function reinit!(cv::CellValues{dim}, x::AbstractVector{Vec{dim,T}}) where {dim,T}
     n_geom_basefuncs = getngeobasefunctions(cv)
-    n_func_basefuncs = getn_scalarbasefunctions(cv)
+    n_func_basefuncs = getnbasefunctions(cv)
     @assert length(x) == n_geom_basefuncs
-    isa(cv, CellVectorValues) && (n_func_basefuncs *= dim)
-
 
     @inbounds for i in 1:length(cv.qr_weights)
         w = cv.qr_weights[i]

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -116,9 +116,8 @@ nodal values of ``\\mathbf{u}``.
 function_value(fe_v::T, q_point, u, dof_range) where T = function_value(FieldTrait(T), fe_v, q_point, u, dof_range)
 function_value(fe_v::T, q_point, u) where T = function_value(FieldTrait(T), fe_v, q_point, u)
 
-function function_value(ft::FieldTrait, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T}
-    n_base_funcs = getn_scalarbasefunctions(fe_v)
-    isa(ft, VectorValued) && (n_base_funcs *= dim)
+function function_value(::FieldTrait, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T}
+    n_base_funcs = getnbasefunctions(fe_v)
     @assert length(dof_range) == n_base_funcs
     @boundscheck checkbounds(u, dof_range)
     val = zero(_valuetype(fe_v, u))
@@ -167,9 +166,8 @@ where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 function_gradient(fe_v::T, q_point, u) where T = function_gradient(FieldTrait(T), fe_v, q_point, u)
 function_gradient(fe_v::T, q_point, u, dof_range) where T = function_gradient(FieldTrait(T), fe_v, q_point, u, dof_range)
 
-function function_gradient(ft::FieldTrait, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T}
-    n_base_funcs = getn_scalarbasefunctions(fe_v)
-    isa(ft, VectorValued) && (n_base_funcs *= dim)
+function function_gradient(::FieldTrait, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T}
+    n_base_funcs = getnbasefunctions(fe_v)
     @assert length(dof_range) == n_base_funcs
     @boundscheck checkbounds(u, dof_range)
     grad = zero(_gradienttype(fe_v, u))

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -251,7 +251,6 @@ function function_divergence(::IsScalarValued, fe_v::Values{dim}, q_point::Int, 
     return diverg
 end
 
-# See https://github.com/Ferrite-FEM/Ferrite.jl/issues/336
 function_divergence(::IsVectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T} =
     tr(function_gradient(fe_v, q_point, u, dof_range))
 
@@ -288,7 +287,6 @@ function Base.show(io::IO, ::MIME"text/plain", fe_v::Values)
 end
 
 # copy
-# TODO: needs to be adapted to new traits
 for ValueType in (CellScalarValues, CellVectorValues, FaceScalarValues, FaceVectorValues)
     args = [:(copy(cv.$fname)) for fname in fieldnames(ValueType)]
     @eval begin

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -166,9 +166,8 @@ end
 
 function reinit!(fv::FaceValues{dim}, x::AbstractVector{Vec{dim,T}}, face::Int) where {dim,T}
     n_geom_basefuncs = getngeobasefunctions(fv)
-    n_func_basefuncs = getn_scalarbasefunctions(fv)
+    n_func_basefuncs = getnbasefunctions(fv)
     @assert length(x) == n_geom_basefuncs
-    isa(fv, FaceVectorValues) && (n_func_basefuncs *= dim)
 
     fv.current_face[] = face
     cb = getcurrentface(fv)


### PR DESCRIPTION
A suggestion on using traits instead of Unions for defining `ScalarValues` and `VectorValues`.

I want to use it for subtyping `Values` without copying a bunch of code from Ferrite. Could also be useful for custom definition of (less common?) problems like the one mentioned in #398. 

I'm happy to hear some feedback, ~~if this is appreciated I'll add some docs as well.~~