### PR TITLE
Fixed Helmholtz example - Neumann Boundary Condition

### DIFF
--- a/docs/src/literate/helmholtz.jl
+++ b/docs/src/literate/helmholtz.jl
@@ -26,7 +26,7 @@
 # \int \nabla δu \cdot \nabla u d\Omega
 # + \int δu \cdot u d\Omega
 # - \int δu \cdot f d\Omega
-# - \int δu \cdot g_2 d\Gamma_2 = 0 \forall δu
+# - \int δu g_2 d\Gamma_2 = 0 \forall δu
 # ```
 #
 # where $δu$ is a suitable test function that satisfies:
@@ -132,7 +132,7 @@ function doassemble(cellvalues::CellScalarValues{dim}, facevalues::FaceScalarVal
 
         # Now we manually add the von Neumann boundary terms
         # ```math
-        # \int δu \cdot g_2 d\Gamma_2
+        # \int δu g_2 d\Gamma_2
         # ```
         #+
         for face in 1:nfaces(cell)
@@ -143,11 +143,11 @@ function doassemble(cellvalues::CellScalarValues{dim}, facevalues::FaceScalarVal
                 for q_point in 1:getnquadpoints(facevalues)
                     coords_qp = spatial_coordinate(facevalues, q_point, coords)
                     n = getnormal(facevalues, q_point)
-                    g = gradient(u_ana, coords_qp) ⋅ n
+                    g_2 = gradient(u_ana, coords_qp) ⋅ n
                     dΓ = getdetJdV(facevalues, q_point)
                     for i in 1:n_basefuncs
                         δu = shape_value(facevalues, q_point, i)
-                        fe[i] += (δu * g) * dΓ
+                        fe[i] += (δu * g_2) * dΓ
                     end
                 end
             end

--- a/docs/src/literate/helmholtz.jl
+++ b/docs/src/literate/helmholtz.jl
@@ -26,7 +26,7 @@
 # \int \nabla δu \cdot \nabla u d\Omega
 # + \int δu \cdot u d\Omega
 # - \int δu \cdot f d\Omega
-# + \int δu \cdot (n \cdot \nabla u - g_2) d\Gamma_2
+# - \int δu \cdot g_2 d\Gamma_2 = 0 \forall δu
 # ```
 #
 # where $δu$ is a suitable test function that satisfies:
@@ -132,7 +132,7 @@ function doassemble(cellvalues::CellScalarValues{dim}, facevalues::FaceScalarVal
 
         # Now we manually add the von Neumann boundary terms
         # ```math
-        # \int δu \cdot (n \cdot \nabla u - g_2) d\Gamma_2
+        # \int δu \cdot g_2 d\Gamma_2
         # ```
         #+
         for face in 1:nfaces(cell)
@@ -147,11 +147,7 @@ function doassemble(cellvalues::CellScalarValues{dim}, facevalues::FaceScalarVal
                     dΓ = getdetJdV(facevalues, q_point)
                     for i in 1:n_basefuncs
                         δu = shape_value(facevalues, q_point, i)
-                        fe[i] += -(δu * g) * dΓ
-                        for j in 1:n_basefuncs
-                            ∇u = shape_gradient(cellvalues, q_point, j)
-                            Ke[i, j] += (δu * ∇u ⋅ n) * dΓ
-                        end
+                        fe[i] += (δu * g) * dΓ
                     end
                 end
             end
@@ -173,7 +169,7 @@ vtk_save(vtkfile)
 using Test #src
 #src this test catches unexpected changes in the result over time.
 #src the true maximum is slightly bigger then 1.0
-@test maximum(u) ≈ 0.995280389173959 #src
+@test maximum(u) ≈ 0.9952772469054607 #src
 @test u_ana(Vec{2}((-0.5, -0.5))) ≈ 1 #src
 @test u_ana(Vec{2}((0.5, -0.5)))  ≈ 1 #src
 @test u_ana(Vec{2}((-0.5, 0.5)))  ≈ 1 #src


### PR DESCRIPTION
The weak form formulation contained an error with the Neumann Boundary condition, which should vanish because of partial integration. Addtionally, the sign of g when added to the local force vector was incorrect. We fixed both these errors and also the documentation and the test at the end. 

Please note that the influence of this change is not directly visible in ParaView, as the used analytical function has three peaks in the middle of the region, thus the boundary condition has barely any influence. By changing the center to xs = (Vec{2}((-0.95,  0.95)),          Vec{2}((-0.95, -0.95)), Vec{2}(( 0.5,  -0.5))), the effect can be seen:
![PV_helmholtz](https://user-images.githubusercontent.com/66363480/148396663-3bcd70c0-b05f-4d2b-9232-93a53099e289.png)

Here, the top example is the old implementation, which shows oscillations in the bottom and a deformation in the top left corner, while the improved version looks much smoother and as one would expect the solution to look like.