### PR TITLE
Update FEM Introduction Page

### DIFF
--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -26,7 +26,7 @@
 #
 # The resulting weak form is given by
 # ```math
-# \int_{\Omega} \nabla v \cdot \nabla u \ d\Omega = \int_{\Omega} v \ d\Omega \quad \forall v \in \mathbb{T},
+# \int_{\Omega} \nabla \delta u \cdot \nabla u \ d\Omega = \int_{\Omega} \delta u \ d\Omega \quad \forall \delta u \in \mathbb{T},
 # ```
 # where $\mathbb{T}$ is a suitable test function space.
 #-
@@ -153,21 +153,21 @@ function doassemble(cellvalues::CellScalarValues{dim}, K::SparseMatrixCSC, dh::D
         for q_point in 1:getnquadpoints(cellvalues)
             dΩ = getdetJdV(cellvalues, q_point)
             # For each quadrature point we loop over all the (local) shape functions.
-            # We need the value and gradient of the testfunction `v` and also the gradient
-            # of the trial function `u`. We get all of these from `cellvalues`.
-            # Please note that the variables named $\nabla v$ and $\nabla u$ are actually
-            # $\nabla \phi_i(\textbf{x}_q)$ and $\nabla \phi_j(\textbf{x}_q)$, and
-            # $v$ is actually $\phi_i(\textbf{x}_q)$. However, to underline the strong
-            # relation between the weak form and the implementation, we the code is written
-            # with the symbols in the weak form instead.
+            # We need the value and gradient of the test function `δu` and also the
+            # gradient of the trial function `u`. We get all of these from `cellvalues`.
+            # Please note that the variables `δu`, `∇δu` and `∇u` are actually
+            # $\phi_i(\textbf{x}_q)$, $\nabla \phi_i(\textbf{x}_q)$ and $\nabla
+            # \phi_j(\textbf{x}_q)$, i.e. the evaluation of the trial and test functions.
+            # However, to underline the strong parallel between the weak form and the
+            # implementation, this example uses the symbols appearing in the weak form.
             #+
             for i in 1:n_basefuncs
-                v  = shape_value(cellvalues, q_point, i)
-                ∇v = shape_gradient(cellvalues, q_point, i)
-                fe[i] += v * dΩ
+                δu  = shape_value(cellvalues, q_point, i)
+                ∇δu = shape_gradient(cellvalues, q_point, i)
+                fe[i] += δu * dΩ
                 for j in 1:n_basefuncs
                     ∇u = shape_gradient(cellvalues, q_point, j)
-                    Ke[i, j] += (∇v ⋅ ∇u) * dΩ
+                    Ke[i, j] += (∇δu ⋅ ∇u) * dΩ
                 end
             end
         end

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -13,22 +13,22 @@
 # The strong form of the (linear) heat equation is given by
 #
 # ```math
-#  -\nabla \cdot (k \nabla u) = f  \quad x \in \Omega,
+#  -\nabla \cdot (k \nabla u) = f  \quad \textbf{x} \in \Omega,
 # ```
 #
 # where $u$ is the unknown temperature field, $k$ the heat conductivity,
 # $f$ the heat source and $\Omega$ the domain. For simplicity we set $f = 1$
 # and $k = 1$. We will consider homogeneous Dirichlet boundary conditions such that
 # ```math
-# u(x) = 0 \quad x \in \partial \Omega,
+# u(\textbf{x}) = 0 \quad \textbf{x} \in \partial \Omega,
 # ```
 # where $\partial \Omega$ denotes the boundary of $\Omega$.
 #
 # The resulting weak form is given by
 # ```math
-# \int_{\Omega} \nabla v \cdot \nabla u \ d\Omega = \int_{\Omega} v \ d\Omega,
+# \int_{\Omega} \nabla v \cdot \nabla u \ d\Omega = \int_{\Omega} v \ d\Omega \quad \forall v \in \mathbb{T},
 # ```
-# where $v$ is a suitable test function.
+# where $\mathbb{T}$ is a suitable test function space.
 #-
 # ## Commented Program
 #
@@ -91,9 +91,9 @@ ch = ConstraintHandler(dh);
 
 # Now we are set up to define our constraint. We specify which field
 # the condition is for, and our combined face set `∂Ω`. The last
-# argument is a function which takes the spatial coordinate $x$ and
+# argument is a function which takes the spatial coordinate $\textbf{x}$ and
 # the current time $t$ and returns the prescribed value. In this case
-# it is trivial -- no matter what $x$ and $t$ we return $0$. When we have
+# it is trivial -- no matter what $\textbf{x}$ and $t$ we return $0$. When we have
 # specified our constraint we `add!` it to `ch`.
 dbc = Dirichlet(:u, ∂Ω, (x, t) -> 0)
 add!(ch, dbc);
@@ -110,6 +110,10 @@ update!(ch, 0.0);
 # We define a function, `doassemble` to do the assembly, which takes our `cellvalues`,
 # the sparse matrix and our DofHandler as input arguments. The function returns the
 # assembled stiffness matrix, and the force vector.
+# Note that here `f` and `u` correspond to $\underline{\hat{f}}$ and $\underline{\hat{u}}$
+# from the introduction, since they represent the discretized versions. However, through
+# the code we use `f` and `u` instead to reflect the strong connection between the weak
+# form and the Ferrite implementation.
 function doassemble(cellvalues::CellScalarValues{dim}, K::SparseMatrixCSC, dh::DofHandler) where {dim}
     # We allocate the element stiffness matrix and element force vector
     # just once before looping over all the cells instead of allocating
@@ -151,6 +155,11 @@ function doassemble(cellvalues::CellScalarValues{dim}, K::SparseMatrixCSC, dh::D
             # For each quadrature point we loop over all the (local) shape functions.
             # We need the value and gradient of the testfunction `v` and also the gradient
             # of the trial function `u`. We get all of these from `cellvalues`.
+            # Please note that the variables named $\nabla v$ and $\nabla u$ are actually
+            # $\nabla \phi_i(\textbf{x}_q)$ and $\nabla \phi_j(\textbf{x}_q)$, and
+            # $v$ is actually $\phi_i(\textbf{x}_q)$. However, to underline the strong
+            # relation between the weak form and the implementation, we the code is written
+            # with the symbols in the weak form instead.
             #+
             for i in 1:n_basefuncs
                 v  = shape_value(cellvalues, q_point, i)

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -28,7 +28,7 @@
 # ```math
 # \int_{\Omega} \nabla \delta u \cdot \nabla u \ d\Omega = \int_{\Omega} \delta u \ d\Omega \quad \forall \delta u \in \mathbb{T},
 # ```
-# where $\mathbb{T}$ is a suitable test function space.
+# where $\delta u$ is a test function and $\mathbb{T}$ is a suitable test function space.
 #-
 # ## Commented Program
 #

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -13,10 +13,10 @@ TODO: Image of domain with boundary annotation and boundary normal vector.
 The strong form of the heat equation may be written as:
 
 ```math
-- \nabla \cdot \mathbf{q}(u) = b \quad \forall \, x \in \Omega,
+- \nabla \cdot \mathbf{q}(u) = f \quad \forall \, x \in \Omega,
 ```
 
-where $u$ is the unknown temperature field, $\mathbf{q}$ is the heat flux, $b$ is an
+where $u$ is the unknown temperature field, $\mathbf{q}$ is the heat flux, $f$ is an
 internal heat source, and $\Omega$ is the domain on which the equation is defined. To
 complete the problem we need to specify what happens at the domain boundary $\Gamma$.
 This set of specifications is called *boundary conditions*. There are different types of
@@ -74,55 +74,55 @@ and denote it with $\Omega_h$. In this example the corners of the triangles are 
 *nodes*.
 
 Next we introduce the finite element approximation $u_\mathrm{h} \approx u$ as a sum of N nodal
-shape functions, where we denote each of these function by $N_i$ and the corresponding nodal
-values $a_i$. In this example we choose to approximate the test function in the same way. This
+shape functions, where we denote each of these function by $\phi_i$ and the corresponding nodal
+values $\hat{u}_i$. In this example we choose to approximate the test function in the same way. This
 approach is known as the *Galerkin finite element method*. Formally we write the evaluation
 of our approximations at a specific point $\mathbf{x}$ in our domain $\Omega$ as:
 
 ```math
-u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} N_i(\mathbf{x}) \, a_i,\qquad
-\delta u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} N_i(\mathbf{x}) \, \delta a_i \, .
+u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} \phi_i(\mathbf{x}) \, \hat{u}_i,\qquad
+\delta u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} \phi_i(\mathbf{x}) \, \delta \hat{u}_i \, .
 ```
 
 In the following the argument $\mathbf{x}$ is dropped to keep the notation compact.
 We may now insert these approximations in the weak form, which results in
 
 ```math
-\sum_j^N \left(\sum_i^N \delta a_i \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \, \mathrm{d}\Omega \right) a_j =
-\sum_i^N \delta a_i \int_{\Gamma_\mathrm{N}} N_i \, q^\mathrm{p} \, \mathrm{d}\Gamma +
-\sum_i^N \delta a_i \int_{\Omega_\mathrm{h}} N_i \, b \, \mathrm{d}\Omega \, .
+\sum_j^N \left(\sum_i^N \delta \hat{u}_i \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \, \mathrm{d}\Omega \right) \hat{u}_j =
+\sum_i^N \delta \hat{u}_i \int_{\Gamma_\mathrm{N}} \phi_i \, q^\mathrm{p} \, \mathrm{d}\Gamma +
+\sum_i^N \delta \hat{u}_i \int_{\Omega_\mathrm{h}} \phi_i \, f \, \mathrm{d}\Omega \, .
 ```
 
 Since this equation must hold for arbitrary $\delta u_\mathrm{h}$, the equation must especially
-hold for the specific choice that only one of the nodal values $\delta a_i$ is fixed to 1 while
+hold for the specific choice that only one of the nodal values $\delta \hat{u}_i$ is fixed to 1 while
 an all other coefficients are fixed to 0. Repeating this argument for all $i$ from 1 to N we obtain
 N linear equations. This way the discrete problem can be written as a system of linear equations
 
 ```math
-\underline{K}\ \underline{a} = \underline{f} \, ,
+\underline{\underline{K}}\ \underline{\hat{u}} = \underline{\hat{f}} \, ,
 ```
 
-where we call $\underline{K}$ the (tangent) *stiffness matrix*, $\underline{a}$ the *solution
-vector* with the nodal values and $\underline{f}$ the *force vector*. The specific naming is for
+where we call $\underline{K}$ the (tangent) *stiffness matrix*, $\underline{\hat{u}}$ the *solution
+vector* with the nodal values and $\underline{\hat{f}}$ the *force vector*. The specific naming is for
 historical reasons, because the finite element method has its origins in mechanics. The elements
-of $\underline{K}$ and $\underline{f}$ are given by
+of $\underline{K}$ and $\underline{\hat{f}}$ are given by
 
 ```math
-\underline{K}_{ij} =
-    \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega \, , \\
+K_{ij} =
+    \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega \, , \\
 
-\underline{f}_{i} =
-    \int_{\Gamma_\mathrm{N}} N_i \, q^\mathrm{p} \, \mathrm{d}\Gamma + \int_{\Omega_\mathrm{h}} N_i \, b \, \mathrm{d}\Omega \, .
+\hat{f}_{i} =
+    \int_{\Gamma_\mathrm{N}} \phi_i \, q^\mathrm{p} \, \mathrm{d}\Gamma + \int_{\Omega_\mathrm{h}} \phi_i \, f \, \mathrm{d}\Omega \, .
 ```
 
 Finally we also need to take care of the Dirichlet boundary conditions. These are enforce by
-setting the corresponding $a_i$ to the prescribed values and eliminating the associated equations
+setting the corresponding $\hat{u}_i$ to the prescribed values and eliminating the associated equations
 from the system. Now, solving this equation system yields an the nodal values and thus an
 approximation to the true solution.
 
 ## Notes on the Implementation
 
-In practice, the shape functions $N_i$ are only non-zero on parts of the domain $\Omega_\mathrm{h}$.
+In practice, the shape functions $\phi_i$ are only non-zero on parts of the domain $\Omega_\mathrm{h}$.
 Thus, the integrals are evaluated on sub-domains, called *elements* or *cells*.
 
 TODO: Image of a linear basis function on the grid above.
@@ -131,9 +131,9 @@ Each cell gives a contribution to the global stiffness matrix and force vector. 
 of constructing the system of equations is also called *assembly*. For clarification,
 let us rewrite the formula for the stiffness matrix entries as follows:
 ```math
-\underline{K}_{ij}
-    = \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega
-    = \sum_{E \in \Omega_\mathrm{h}} \int_E \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega \, .
+K_{ij}
+    = \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega
+    = \sum_{E \in \Omega_\mathrm{h}} \int_E \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega \, .
 ```
 This formulation underlines the element-centric perspective of finite element methods and
 reflects how it is usually implemented in software.
@@ -148,11 +148,16 @@ To avoid the recomputation of just mentioned evaluation position of the integral
 individual element, we perform a coordinate transformation onto a so-called *reference element*.
 Formally we write
 ```math
-    \int_E \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega
-    \approx \sum_p \nabla N_i(x_p) \cdot (k(x_p) \nabla N_j(x_p)) \, w_p \, \textrm{det}(J(x_p)) \, ,
+    \int_E \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega
+    \approx \sum_p \nabla \phi_i(\textbf{x}_p) \cdot (k(\textbf{x}_p) \nabla \phi_j(\textbf{x}_p)) \, w_p \, \textrm{det}(J(\textbf{x}_p)) \, ,
 ```
 where J is the Jacobian of the coordinate transformation function. The computation of the
 transformation, weights, positions and of the Jacobi determinant is handled by Ferrite.
+On an intuitive level, and to explain the notation used in the implementation, we think of
+```math
+    \mathrm{d}\Omega \approx \, w \, \textrm{det}(J)
+```
+being the chosen approximation when changing from the integral to the finite summation.
 
 For an example of the implementation to solve a heat problem with `Ferrite` check out [this
 thoroughly commented example](@ref Heat-Equation).

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -136,8 +136,26 @@ let us rewrite the formula for the stiffness matrix entries as follows:
     = \sum_{E \in \Omega_\mathrm{h}} \int_E \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega \, .
 ```
 This formulation underlines the element-centric perspective of finite element methods and
-reflects how it is usually implemented in software. For an example of the implementation to
-solve a heat problem with `Ferrite` check out [this thoroughly commented example](@ref Heat-Equation).
+reflects how it is usually implemented in software.
+
+Computing the element integrals by hand can become a tedious task. To avoid this issue we
+approximate the element integrals with a technique called *numerical integration*. Skipping any
+of the mathematical details, the basic idea is to evaluate the function under the integral at
+specific points and weighting the evaluations accordingly, such that their sum approximates the
+volume properly. A very nice feature of these techniques is, that under quite general
+circumstances the formula is not just an approximation, but the exact evaluation of the integral.
+To avoid the recomputation of just mentioned evaluation position of the integral for each
+individual element, we perform a coordinate transformation onto a so-called *reference element*.
+Formally we write
+```math
+    \int_E \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega
+    \approx \sum_p \nabla N_i(x_p) \cdot (k(x_p) \nabla N_j(x_p)) \, w_p \, \textrm{det}(J(x_p)) \, ,
+```
+where J is the Jacobian of the coordinate transformation function. The computation of the
+transformation, weights, positions and of the Jacobi determinant is handled by Ferrite.
+
+For an example of the implementation to solve a heat problem with `Ferrite` check out [this
+thoroughly commented example](@ref Heat-Equation).
 
 ## More Details
 

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -85,7 +85,7 @@ u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} N_i(\mathbf{x}) \, a_i,\qquad
 ```
 
 In the following the argument $\mathbf{x}$ is dropped to keep the notation compact.
-We may now inserted these approximations in the weak form, which results in
+We may now insert these approximations in the weak form, which results in
 
 ```math
 \sum_j^N \left(\sum_i^N \delta a_i \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \, \mathrm{d}\Omega \right) a_j =

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -147,7 +147,7 @@ of the mathematical details, the basic idea is to evaluate the function under th
 specific points and weighting the evaluations accordingly, such that their sum approximates the
 volume properly. A very nice feature of these techniques is, that under quite general
 circumstances the formula is not just an approximation, but the exact evaluation of the integral.
-To avoid the recomputation of just mentioned evaluation position of the integral for each
+To avoid the recomputation of the just mentioned evaluation positions of the integral for each
 individual element, we perform a coordinate transformation onto a so-called *reference element*.
 Formally we write
 ```math

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -47,7 +47,7 @@ constant conductivity $k$.
 ## Weak Form
 
 The solution to the equation above is usually calculated from the corresponding weak
-form. By multiplying the equation with an arbitrary test function $\delta u$, integrating
+form. By multiplying the equation with an arbitrary *test function* $\delta u$, integrating
 over the domain and using partial integration we obtain the *weak form*. Now our problem
 can be stated as:
 
@@ -74,17 +74,20 @@ and denote it with $\Omega_h$. In this example the corners of the triangles are 
 *nodes*.
 
 Next we introduce the finite element approximation $u_\mathrm{h} \approx u$ as a sum of N nodal
-shape functions, where we denote each of these function by $\phi_i$ and the corresponding nodal
-values $\hat{u}_i$. In this example we choose to approximate the test function in the same way. This
-approach is known as the *Galerkin finite element method*. Formally we write the evaluation
-of our approximations at a specific point $\mathbf{x}$ in our domain $\Omega$ as:
+*shape functions*, where we denote each of these function by $\phi_i$ and the corresponding *nodal
+values* $\hat{u}_i$. Depending on the community, shape functions are also called *trial functions*.
+In this example we choose to approximate the test function in the same way. This approach is known
+as the *Galerkin finite element method*. Formally we write the evaluation of our approximations
+at a specific point $\mathbf{x}$ in our domain $\Omega$ as:
 
 ```math
 u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} \phi_i(\mathbf{x}) \, \hat{u}_i,\qquad
 \delta u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} \phi_i(\mathbf{x}) \, \delta \hat{u}_i \, .
 ```
 
-In the following the argument $\mathbf{x}$ is dropped to keep the notation compact.
+Since test and trial functions are usually chosen in such a way, that they build the basis of
+some function space (basis as in basis of a vector space), sometimes are they are also called *basis
+functions*. In the following the argument $\mathbf{x}$ is dropped to keep the notation compact.
 We may now insert these approximations in the weak form, which results in
 
 ```math

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -173,11 +173,12 @@ and concise. There is a large corpus of literature and online tutorials containi
 the finite element method. To give a few recommendations there is:
 * [Hans Petter Langtangen's Script](http://hplgit.github.io/INF5620/doc/pub/sphinx-fem/index.html)
 * [Wolfgang Bangerth's Lecture Series](https://www.math.colostate.edu/~bangerth/videos.html)
+* *Introduction to the Finite Element Method* by Niels Ottosen and Hans Petersson
 * *The Finite Element Method for Elliptic Problems* by Philippe Ciarlet
 * *Finite Elements: Theory, Fast Solvers, and Applications in Elasticity Theory* by Dietrich Braess
 * *An Analysis of the Finite Element Method* by Gilbert Strang and George Fix
-* *Finite Element Procedures* by K.J. Bathe
-* *The Finite Element Method: Its Basis and Fundamentals* by Olek Zienkiewicz, Robert Taylor and J.Z. Zhu
+* *Finite Element Procedures* by Klaus-Jürgen Bathe
+* *The Finite Element Method: Its Basis and Fundamentals* by Olgierd Cecil Zienkiewicz, Robert Taylor and J.Z. Zhu
 * *Higher-Order Finite Element Methods* by Pavel Šolín, Karel Segeth and Ivo Doležel
 This list is neither meant to be exhaustive, nor does the absence of a work mean that it is in any way
-bad or not recommendable.
+bad or not recommendable. The ordering of the articles also has no particular meaning.

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -1,111 +1,157 @@
 # Introduction to FEM
 
 Here we will present a very brief introduction to partial differential equations (PDEs) and
-to the finite element method (FEM). Perhaps the simplest PDE of all is the (linear) heat
-equation, also known as the Laplace equation. We will use this equation as a demonstrative
-example of the method, and demonstrate how we go from the strong format of the equation, to
+to the finite element method (FEM). Perhaps the simplest PDE of all is the (steady-state, linear)
+heat equation, also known as the Poisson equation. We will use this equation as a demonstrative
+example of the method, and demonstrate how we go from the strong form of the equation, to
 the weak form, and then finally to the discrete FE problem.
 
-## Strong format
+## Strong Form
 
-The strong format of the heat equation may be written as:
+TODO: Image of domain with boundary annotation and boundary normal vector.
 
-```math
-- \mathbf{\nabla} \cdot \mathbf{q}(u) = b \quad x \in \Omega,
-```
-
-where $u$ is the unknown temperature field, $\mathbf{q}$ is the heat flux and $b$ is an
-internal heat source. To complete the system of equations we need boundary conditions.
-There are different types of boundary conditions, but the most common ones are Dirichlet
--- which means that the solution $u$ is known at some part of the boundary, and Neumann
--- which means that the gradient of the solution, $\mathbf{\nabla}$ is known. For example
+The strong form of the heat equation may be written as:
 
 ```math
-u = u^\mathrm{p} \quad \forall \mathbf{x} \in \Gamma_\mathrm{D},\\
-\mathbf{q} \cdot \mathbf{n} = q^\mathrm{p} \quad \forall \mathbf{x} \in \Gamma_\mathrm{N},
+- \nabla \cdot \mathbf{q}(u) = b \quad \forall \, x \in \Omega,
 ```
 
-i.e. the temperature is presribed to $u^\mathrm{p}$ at the Dirichlet part of the boundary,
-$\Gamma_\mathrm{D}$, and the heat flux is prescribed to $q^\mathrm{p}$ at the Neumann part
-of the boundary, $\Gamma_\mathrm{N}$.
+where $u$ is the unknown temperature field, $\mathbf{q}$ is the heat flux, $b$ is an
+internal heat source, and $\Omega$ is the domain on which the equation is defined. To
+complete the problem we need to specify what happens at the domain boundary $\Gamma$.
+This set of specifications is called *boundary conditions*. There are different types of
+boundary conditions, where the most common ones are Dirichlet -- which means that the solution
+$u$ is known at some part of the boundary, and Neumann -- which means that the gradient
+of the solution, $\nabla$ is known. Formally we write for our example
+
+```math
+u = u^\mathrm{p} \quad \forall \, \mathbf{x} \in \Gamma_\mathrm{D},\\
+\mathbf{q} \cdot \mathbf{n} = q^\mathrm{p} \quad \forall \, \mathbf{x} \in \Gamma_\mathrm{N},
+```
+
+i.e. the temperature is prescribed to a known function $u^\mathrm{p}$ at the Dirichlet part
+of the boundary, $\Gamma_\mathrm{D}$, and the heat flux is prescribed to $q^\mathrm{p}$ at
+the Neumann part of the boundary, $\Gamma_\mathrm{N}$, where $\mathbf{n}$ describes the outward
+pointing normal vector at the boundary.
 
 We also need a constitutive equation which links the temperature field, $u$, to the heat
 flux, $\mathbf{q}$. The simplest case is to use Fourier's law
 
 ```math
-\mathbf{q} = -k \mathbf{\nabla}u
+\mathbf{q}(u) = -k \nabla u
 ```
 
 where $k$ is the conductivity of the material. For simplicity we will consider only
 constant conductivity $k$.
 
-## Weak format
+## Weak Form
 
 The solution to the equation above is usually calculated from the corresponding weak
-format. By multiplying the equation with an arbitrary test function $\delta u$, integrating
-over the domain and using partial integration we obtain the *weak form*;
+form. By multiplying the equation with an arbitrary test function $\delta u$, integrating
+over the domain and using partial integration we obtain the *weak form*. Now our problem
+can be stated as:
+
 Find $u \in \mathbb{U}$ s.t.
 
 ```math
-\int_\Omega \mathbf{\delta u} \cdot (k \mathbf{u}) \mathrm{d}\Omega =
-\int_{\Gamma_\mathrm{N}} \delta u q^\mathrm{p} \mathrm{d}\Gamma +
-\int_\Omega \delta u b \mathrm{d}\Omega \quad \forall \delta u \in \mathbb{U}^0
+\int_\Omega \nabla \delta u \cdot (k \nabla u) \, \mathrm{d}\Omega =
+\int_{\Gamma_\mathrm{N}} \delta u \, q^\mathrm{p} \, \mathrm{d}\Gamma +
+\int_\Omega \delta u \, b \, \mathrm{d}\Omega \quad \forall \, \delta u \in \mathbb{T}
 ```
 
-where $\mathbb{U}, \mathbb{U}^0$ are function spaces with sufficiently regular functions.
-It can be shown that the solution to the weak form is identical to the solution to the
-strong format.
+where $\mathbb{U}, \mathbb{T}$ are suitable function spaces with sufficiently regular
+functions. Under very general assumptions it can be shown that the solution to the weak
+form is identical to the solution to the strong form.
 
-## FE-approximation
+## Finite Element Approximation
 
-We now introduce the finite element approximation $u_h \approx u$ as a sum of shape
-functions, $N_i$ and nodal values, $a_i$. We approximate the test function in the same way
-(known as the Galerkin method):
+TODO: Image of geometric discretization with triangles.
+
+Using the finite element method to solve partial differential equations is usually
+preceded with the construction of a discretization of the domain $\Omega$ into a finite
+set of *elements* or *cells*. We call this geometric discretization *grid* (or *mesh*)
+and denote it with $\Omega_h$. In this example the corners of the triangles are called
+*nodes*.
+
+Next we introduce the finite element approximation $u_\mathrm{h} \approx u$ as a sum of N nodal
+shape functions, where we denote each of these function by $N_i$ and the corresponding nodal
+values $a_i$. In this example we choose to approximate the test function in the same way. This
+approach is known as the *Galerkin finite element method*. Formally we write the evaluation
+of our approximations at a specific point $\mathbf{x}$ in our domain $\Omega$ as:
 
 ```math
-u_\mathrm{h} = \sum_{i=1}^{\mathrm{N}} N_i a_i,\qquad
-\delta u_\mathrm{h} = \sum_{i=1}^{\mathrm{N}} N_i \delta a_i
+u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} N_i(\mathbf{x}) \, a_i,\qquad
+\delta u_\mathrm{h}(\mathbf{x}) = \sum_{i=1}^{\mathrm{N}} N_i(\mathbf{x}) \, \delta a_i \, .
 ```
 
-We may now inserted these approximations in the weak format, which results in
+In the following the argument $\mathbf{x}$ is dropped to keep the notation compact.
+We may now inserted these approximations in the weak form, which results in
 
 ```math
-\sum_i^N \sum_j^N \delta a_i \int_\Omega \mathbf{\nabla} N_i \cdot (k \cdot \mathbf{\nabla} N_j) \mathrm{d}\Omega a_j =
-\sum_i^N \delta a_i \int_\Gamma N_i q^\mathrm{p} \mathrm{d}\Gamma +
-\sum_i^N \delta a_i \int_\Omega N_i b \mathrm{d}\Omega
+\sum_j^N \left(\sum_i^N \delta a_i \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \, \mathrm{d}\Omega \right) a_j =
+\sum_i^N \delta a_i \int_{\Gamma_\mathrm{N}} N_i \, q^\mathrm{p} \, \mathrm{d}\Gamma +
+\sum_i^N \delta a_i \int_{\Omega_\mathrm{h}} N_i \, b \, \mathrm{d}\Omega \, .
 ```
 
-Since $\delta u$ can be chosen arbitrary, the nodal values $\delta a_i$ can be chosen
-arbitrary. Thus, the equation can be written as a linear system of equations
+Since this equation must hold for arbitrary $\delta u_\mathrm{h}$, the equation must especially
+hold for the specific choice that only one of the nodal values $\delta a_i$ is fixed to 1 while
+an all other coefficients are fixed to 0. Repeating this argument for all $i$ from 1 to N we obtain
+N linear equations. This way the discrete problem can be written as a system of linear equations
 
 ```math
-\underline{K}\ \underline{a} = \underline{f}
+\underline{K}\ \underline{a} = \underline{f} \, ,
 ```
 
-where $\underline{K}$ is the (tangent) stiffness matrix, $\underline{a}$ is the solution
-vector with the nodal values and $\underline{f}$ is the force vector. The elements of
-$\underline{K}$ and $\underline{f}$ are given by
+where we call $\underline{K}$ the (tangent) *stiffness matrix*, $\underline{a}$ the *solution
+vector* with the nodal values and $\underline{f}$ the *force vector*. The specific naming is for
+historical reasons, because the finite element method has its origins in mechanics. The elements
+of $\underline{K}$ and $\underline{f}$ are given by
 
 ```math
 \underline{K}_{ij} =
-    \int_\Omega \mathbf{\nabla}N_i \cdot (k \cdot \mathbf{\nabla}N_j) \mathrm{d}\Omega\\
+    \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega \, , \\
 
 \underline{f}_{i} =
-    \int_\Gamma N_i q^\mathrm{p} \mathrm{d}\Gamma + \int_\Omega N_i b \mathrm{d}\Omega
+    \int_{\Gamma_\mathrm{N}} N_i \, q^\mathrm{p} \, \mathrm{d}\Gamma + \int_{\Omega_\mathrm{h}} N_i \, b \, \mathrm{d}\Omega \, .
 ```
 
-The solution to the system (which in this case is linear) is simply given by inverting the
-matrix $\underline{K}$. We also need to take care of the Dirichlet boundary conditions, by
-enforcing the correct nodal values $a_i$ to the prescribed values.
+Finally we also need to take care of the Dirichlet boundary conditions. These are enforce by
+setting the corresponding $a_i$ to the prescribed values and eliminating the associated equations
+from the system. Now, solving this equation system yields an the nodal values and thus an
+approximation to the true solution.
 
+## Notes on the Implementation
+
+In practice, the shape functions $N_i$ are only non-zero on parts of the domain $\Omega_\mathrm{h}$.
+Thus, the integrals are evaluated on sub-domains, called *elements* or *cells*.
+
+TODO: Image of a linear basis function on the grid above.
+
+Each cell gives a contribution to the global stiffness matrix and force vector. The process
+of constructing the system of equations is also called *assembly*. For clarification,
+let us rewrite the formula for the stiffness matrix entries as follows:
 ```math
-\underline{a} = \underline{K}^{-1}\ \underline{f}
+\underline{K}_{ij}
+    = \int_{\Omega_\mathrm{h}} \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega
+    = \sum_{E \in \Omega_\mathrm{h}} \int_E \nabla N_i \cdot (k \nabla N_j) \mathrm{d}\Omega \, .
 ```
+This formulation underlines the element-centric perspective of finite element methods and
+reflects how it is usually implemented in software. For an example of the implementation to
+solve a heat problem with `Ferrite` check out [this thoroughly commented example](@ref Heat-Equation).
 
-## Implementation
+## More Details
 
-In practice, the shape functions $N$ are only non-zero on parts of the domain $\Omega$.
-Thus, the integrals are evaluated on sub-domains, called *elements* or *cells*. Each cell
-gives a contribution to the global stiffness matrix and force vector. For a solution of the
-heat equation, as implemented in `Ferrite`, check out
-[this thoroughly commented example](@ref Heat-Equation).
+We finally want to note that this quick introduction barely scratches the surface of the finite element
+method. Also, we presented some things in a simplified way for the sake of keeping this article short
+and concise. There is a large corpus of literature and online tutorials containing more details about
+the finite element method. To give a few recommendations there is:
+* [Hans Petter Langtangen's Script](http://hplgit.github.io/INF5620/doc/pub/sphinx-fem/index.html)
+* [Wolfgang Bangerth's Lecture Series](https://www.math.colostate.edu/~bangerth/videos.html)
+* *The Finite Element Method for Elliptic Problems* by Philippe Ciarlet
+* *Finite Elements: Theory, Fast Solvers, and Applications in Elasticity Theory* by Dietrich Braess
+* *An Analysis of the Finite Element Method* by Gilbert Strang and George Fix
+* *Finite Element Procedures* by K.J. Bathe
+* *The Finite Element Method: Its Basis and Fundamentals* by Olek Zienkiewicz, Robert Taylor and J.Z. Zhu
+* *Higher-Order Finite Element Methods* by Pavel Šolín, Karel Segeth and Ivo Doležel
+This list is neither ment to be exhaustive, nor does the absence of a work mean that it is in any way
+bad or not recommendable.

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -6,14 +6,13 @@ heat equation, also known as the Poisson equation. We will use this equation as 
 example of the method, and demonstrate how we go from the strong form of the equation, to
 the weak form, and then finally to the discrete FE problem.
 
-## Strong Form
+## Strong form
 
-TODO: Image of domain with boundary annotation and boundary normal vector.
 
 The strong form of the heat equation may be written as:
 
 ```math
-- \nabla \cdot \mathbf{q}(u) = f \quad \forall \, x \in \Omega,
+- \nabla \cdot \mathbf{q}(u) = f \quad \forall \, \mathbf{x} \in \Omega,
 ```
 
 where $u$ is the unknown temperature field, $\mathbf{q}$ is the heat flux, $f$ is an
@@ -22,7 +21,7 @@ complete the problem we need to specify what happens at the domain boundary $\Ga
 This set of specifications is called *boundary conditions*. There are different types of
 boundary conditions, where the most common ones are Dirichlet -- which means that the solution
 $u$ is known at some part of the boundary, and Neumann -- which means that the gradient
-of the solution, $\nabla$ is known. Formally we write for our example
+of the solution, $\nabla u$ is known. Formally we write for our example
 
 ```math
 u = u^\mathrm{p} \quad \forall \, \mathbf{x} \in \Gamma_\mathrm{D},\\
@@ -44,7 +43,7 @@ flux, $\mathbf{q}$. The simplest case is to use Fourier's law
 where $k$ is the conductivity of the material. For simplicity we will consider only
 constant conductivity $k$.
 
-## Weak Form
+## Weak form
 
 The solution to the equation above is usually calculated from the corresponding weak
 form. By multiplying the equation with an arbitrary *test function* $\delta u$, integrating
@@ -63,9 +62,8 @@ where $\mathbb{U}, \mathbb{T}$ are suitable function spaces with sufficiently re
 functions. Under very general assumptions it can be shown that the solution to the weak
 form is identical to the solution to the strong form.
 
-## Finite Element Approximation
+## Finite Element approximation
 
-TODO: Image of geometric discretization with triangles.
 
 Using the finite element method to solve partial differential equations is usually
 preceded with the construction of a discretization of the domain $\Omega$ into a finite
@@ -74,8 +72,8 @@ and denote it with $\Omega_h$. In this example the corners of the triangles are 
 *nodes*.
 
 Next we introduce the finite element approximation $u_\mathrm{h} \approx u$ as a sum of N nodal
-*shape functions*, where we denote each of these function by $\phi_i$ and the corresponding *nodal
-values* $\hat{u}_i$. Depending on the community, shape functions are also called *trial functions*.
+*shape functions*, where we denote each of these function by $\phi_i$ and the corresponding *nodal values*
+$\hat{u}_i$. Note that *shape functions* are sometimes referred to as *base functions* or *trial functions*, and instead of $\phi_i$ they are sometimes denoted $N_i$.
 In this example we choose to approximate the test function in the same way. This approach is known
 as the *Galerkin finite element method*. Formally we write the evaluation of our approximations
 at a specific point $\mathbf{x}$ in our domain $\Omega$ as:
@@ -91,7 +89,7 @@ functions*. In the following the argument $\mathbf{x}$ is dropped to keep the no
 We may now insert these approximations in the weak form, which results in
 
 ```math
-\sum_j^N \left(\sum_i^N \delta \hat{u}_i \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \, \mathrm{d}\Omega \right) \hat{u}_j =
+\sum_i^N \left(\sum_j^N \delta \hat{u}_i \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \, \mathrm{d}\Omega \right) \hat{u}_j =
 \sum_i^N \delta \hat{u}_i \int_{\Gamma_\mathrm{N}} \phi_i \, q^\mathrm{p} \, \mathrm{d}\Gamma +
 \sum_i^N \delta \hat{u}_i \int_{\Omega_\mathrm{h}} \phi_i \, f \, \mathrm{d}\Omega \, .
 ```
@@ -105,36 +103,35 @@ N linear equations. This way the discrete problem can be written as a system of 
 \underline{\underline{K}}\ \underline{\hat{u}} = \underline{\hat{f}} \, ,
 ```
 
-where we call $\underline{K}$ the (tangent) *stiffness matrix*, $\underline{\hat{u}}$ the *solution
+where we call $\underline{\underline{K}}$ the (tangent) *stiffness matrix*, $\underline{\hat{u}}$ the *solution
 vector* with the nodal values and $\underline{\hat{f}}$ the *force vector*. The specific naming is for
 historical reasons, because the finite element method has its origins in mechanics. The elements
-of $\underline{K}$ and $\underline{\hat{f}}$ are given by
+of $\underline{\underline{K}}$ and $\underline{\hat{f}}$ are given by
 
 ```math
-K_{ij} =
+(\underline{\underline{K}})_{ij} =
     \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega \, , \\
 
-\hat{f}_{i} =
+(\underline{\hat{f}})_{i} =
     \int_{\Gamma_\mathrm{N}} \phi_i \, q^\mathrm{p} \, \mathrm{d}\Gamma + \int_{\Omega_\mathrm{h}} \phi_i \, f \, \mathrm{d}\Omega \, .
 ```
 
-Finally we also need to take care of the Dirichlet boundary conditions. These are enforce by
+Finally we also need to take care of the Dirichlet boundary conditions. These are enforced by
 setting the corresponding $\hat{u}_i$ to the prescribed values and eliminating the associated equations
-from the system. Now, solving this equation system yields an the nodal values and thus an
+from the system. Now, solving this equation system yields the nodal values and thus an
 approximation to the true solution.
 
-## Notes on the Implementation
+## Notes on the implementation
 
 In practice, the shape functions $\phi_i$ are only non-zero on parts of the domain $\Omega_\mathrm{h}$.
 Thus, the integrals are evaluated on sub-domains, called *elements* or *cells*.
 
-TODO: Image of a linear basis function on the grid above.
 
 Each cell gives a contribution to the global stiffness matrix and force vector. The process
 of constructing the system of equations is also called *assembly*. For clarification,
 let us rewrite the formula for the stiffness matrix entries as follows:
 ```math
-K_{ij}
+(\underline{\underline{K}})_{ij}
     = \int_{\Omega_\mathrm{h}} \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega
     = \sum_{E \in \Omega_\mathrm{h}} \int_E \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega \, .
 ```
@@ -154,7 +151,7 @@ Formally we write
     \int_E \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega
     \approx \sum_q \nabla \phi_i(\textbf{x}_q) \cdot (k(\textbf{x}_q) \nabla \phi_j(\textbf{x}_q)) \, w_q \, \textrm{det}(J(\textbf{x}_q)) \, ,
 ```
-where J is the Jacobian of the coordinate transformation function. The computation of the
+where ``J`` is the Jacobian of the coordinate transformation function. The computation of the
 transformation, weights, positions and of the Jacobi determinant is handled by Ferrite.
 On an intuitive level, and to explain the notation used in the implementation, we think of
 ```math

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -153,5 +153,5 @@ the finite element method. To give a few recommendations there is:
 * *Finite Element Procedures* by K.J. Bathe
 * *The Finite Element Method: Its Basis and Fundamentals* by Olek Zienkiewicz, Robert Taylor and J.Z. Zhu
 * *Higher-Order Finite Element Methods* by Pavel Šolín, Karel Segeth and Ivo Doležel
-This list is neither ment to be exhaustive, nor does the absence of a work mean that it is in any way
+This list is neither meant to be exhaustive, nor does the absence of a work mean that it is in any way
 bad or not recommendable.

--- a/docs/src/manual/fe_intro.md
+++ b/docs/src/manual/fe_intro.md
@@ -149,7 +149,7 @@ individual element, we perform a coordinate transformation onto a so-called *ref
 Formally we write
 ```math
     \int_E \nabla \phi_i \cdot (k \nabla \phi_j) \mathrm{d}\Omega
-    \approx \sum_p \nabla \phi_i(\textbf{x}_p) \cdot (k(\textbf{x}_p) \nabla \phi_j(\textbf{x}_p)) \, w_p \, \textrm{det}(J(\textbf{x}_p)) \, ,
+    \approx \sum_q \nabla \phi_i(\textbf{x}_q) \cdot (k(\textbf{x}_q) \nabla \phi_j(\textbf{x}_q)) \, w_q \, \textrm{det}(J(\textbf{x}_q)) \, ,
 ```
 where J is the Jacobian of the coordinate transformation function. The computation of the
 transformation, weights, positions and of the Jacobi determinant is handled by Ferrite.


### PR DESCRIPTION
Ferrite.jl is growing and gains more and more shape. In an effort to simplify the access to the framework for new users I updated the introduction page. This It is a WIP and suggestions are welcome. For now I mostly outlined the general idea already on how to improve and left some TODOs in the code. Also, I fixed some minor issues regarding the spacing and minor mistakes which has sneaked in (e.g. missing derivatives).

## Goal of the Introduction Page
We should quickly discuss the purpose of the introduction page. IMHO this page should...
1. pick up new users which are currently hearing a FEM lecture and want to implement something by themselves
2. be a first contact point for possible users which are genuinely interested in the FEM, but have no formal education of it
by introducing them (with a quick recap of the used FEM terminology and idea) to the first example ("heat equation"). I am also open to different goals.

## Open TODOs

* [ ] An image of a domain with boundary condition annotations
* [ ] Image visualizing the geometric discretization (which was previously missing)
* [ ] Image visualizing a basis function over several elements
* [x] Introduce synonym ~~"basis" and~~ "trial" function.

## Some Issues on Notation and Terminology

~~For the sake of consistency, do you agree that we should enforce the same notation and terminology in the heat example and the introduction?~~ I just left comments instead of enforcing the notation, to leave the reflection between the weak form and the implementation.

Regarding the notation, I would vote for using \phi instead of N for the basis functions. For me this was less confusing. However, if you think N is more suitable, then I can leave it. If you spot more inconsistencies in the introduction and heat example (also inconsistencies introduced by this PR), then please let me know.