### PR TITLE
Remove export of ScalarValues and VectorValues

### DIFF
--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -111,8 +111,8 @@ curl(∇v) = Vec{3}((∇v[3,2] - ∇v[2,3], ∇v[1,3] - ∇v[3,1], ∇v[2,1] - �
 
 Compute the value of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
-For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
-or `u` can be a vector of `Vec`s (for use with ScalarValues).
+For a vector valued function, `u` can be a vector of scalars (for use of `CellVectorValues` or `FaceVectorValues`)
+or `u` can be a vector of `Vec`s (for use with `CellScalarValues` or `FaceScalarValues`).
 
 The value of a scalar valued function is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
 where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function the value is calculated as
@@ -153,21 +153,20 @@ _valuetype(t::T, v) where T = _valuetype(FieldTrait(T), t, v)
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{T}) where {dim,T} = T
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
 _valuetype(::VectorValued, ::Values{dim}, ::AbstractVector{T}) where {dim,T} = Vec{dim,T}
-# _valuetype(::VectorValues{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
 
 """
     function_gradient(fe_v::Values{dim}, q_point::Int, u::AbstractVector)
 
 Compute the gradient of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
-For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
-or `u` can be a vector of `Vec`s (for use with ScalarValues).
+For a vector valued function, `u` can be a vector of scalars (for use of `CellVectorValues` or `FaceVectorValues`)
+or `u` can be a vector of `Vec`s (for use with `CellScalarValues` or `FaceScalarValues`).
 
-The gradient of a scalar function or a vector valued function with use of `VectorValues` is computed as
+The gradient of a scalar function or a vector valued function with use of `CellVectorValues`/`FaceVectorValues` is computed as
 ``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i`` or
 ``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
 where ``u_i`` are the nodal values of the function.
-For a vector valued function with use of `ScalarValues` the gradient is computed as
+For a vector valued function with use of `CellScalarValues`/`FaceScalarValues` the gradient is computed as
 ``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{u}_i \\otimes \\mathbf{\\nabla} N_i (\\mathbf{x})``
 where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 """

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -111,8 +111,8 @@ curl(∇v) = Vec{3}((∇v[3,2] - ∇v[2,3], ∇v[1,3] - ∇v[3,1], ∇v[2,1] - �
 
 Compute the value of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
-For a vector valued function, `u` can be a vector of scalars (for use of `CellVectorValues` or `FaceVectorValues`)
-or `u` can be a vector of `Vec`s (for use with `CellScalarValues` or `FaceScalarValues`).
+For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
+or `u` can be a vector of `Vec`s (for use with ScalarValues).
 
 The value of a scalar valued function is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
 where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function the value is calculated as
@@ -153,20 +153,21 @@ _valuetype(t::T, v) where T = _valuetype(FieldTrait(T), t, v)
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{T}) where {dim,T} = T
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
 _valuetype(::VectorValued, ::Values{dim}, ::AbstractVector{T}) where {dim,T} = Vec{dim,T}
+# _valuetype(::VectorValues{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
 
 """
     function_gradient(fe_v::Values{dim}, q_point::Int, u::AbstractVector)
 
 Compute the gradient of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
-For a vector valued function, `u` can be a vector of scalars (for use of `CellVectorValues` or `FaceVectorValues`)
-or `u` can be a vector of `Vec`s (for use with `CellScalarValues` or `FaceScalarValues`).
+For a vector valued function, `u` can be a vector of scalars (for use of `VectorValues`)
+or `u` can be a vector of `Vec`s (for use with ScalarValues).
 
-The gradient of a scalar function or a vector valued function with use of `CellVectorValues`/`FaceVectorValues` is computed as
+The gradient of a scalar function or a vector valued function with use of `VectorValues` is computed as
 ``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i`` or
 ``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
 where ``u_i`` are the nodal values of the function.
-For a vector valued function with use of `CellScalarValues`/`FaceScalarValues` the gradient is computed as
+For a vector valued function with use of `ScalarValues` the gradient is computed as
 ``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{u}_i \\otimes \\mathbf{\\nabla} N_i (\\mathbf{x})``
 where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 """

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -17,8 +17,6 @@ export
 
 # FEValues
     CellValues,
-    ScalarValues,
-    VectorValues,
     CellScalarValues,
     CellVectorValues,
     FaceValues,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,4 @@ include("test_pointevaluation.jl")
 # include("test_notebooks.jl")
 include("test_apply_rhs.jl")
 include("test_examples.jl")
-@test isa([eval(type) for type in names(Ferrite)], Vector)  # Test that all exported symbols are defined
+@test isa([Core.eval(Ferrite,type) for type in names(Ferrite)], Vector)  # Test that all exported symbols are defined

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,3 +22,4 @@ include("test_pointevaluation.jl")
 # include("test_notebooks.jl")
 include("test_apply_rhs.jl")
 include("test_examples.jl")
+@test isa([eval(type) for type in names(Ferrite)], Vector)  # Test that all exported symbols are defined

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,4 @@ include("test_pointevaluation.jl")
 # include("test_notebooks.jl")
 include("test_apply_rhs.jl")
 include("test_examples.jl")
-@test isa([Core.eval(Ferrite,type) for type in names(Ferrite)], Vector)  # Test that all exported symbols are defined
+@test all(x -> isdefined(Ferrite, x), names(Ferrite))  # Test that all exported symbols are defined


### PR DESCRIPTION
`ScalarValues` and `VectorValues` are exported but don't seem to be defined.
I also added a test to check that no symbols are exported that haven't been defined. Not sure where to put this test though...