### PR TITLE
AffineConstraints: Fix usage with get_rhs_data.

### DIFF
--- a/docs/src/literate/computational_homogenization.jl
+++ b/docs/src/literate/computational_homogenization.jl
@@ -368,7 +368,6 @@ rhsdata = (
 )
 
 apply!(K.dirichlet, ch.dirichlet)
-Kp = copy(K.periodic) #hide
 apply!(K.periodic,  ch.periodic)
 
 # We can now solve the problem(s). Note that we only use `apply_rhs!` in the loops below.
@@ -388,14 +387,9 @@ for i in 1:size(rhs.dirichlet, 2)
     push!(u.dirichlet, u_i)                            # Save the solution vector
 end
 
-rhs_p = copy(rhs.periodic) #hide
 for i in 1:size(rhs.periodic, 2)
     rhs_i = @view rhs.periodic[:, i]                   # Extract this RHS
     apply_rhs!(rhsdata.periodic, rhs_i, ch.periodic)   # Apply BC
-    rhs_i = @view rhs_p[:, i] #hide
-    Kpp = copy(Kp) #hide
-    apply!(Kpp, rhs_i, ch.periodic) #hide
-    copy!(K.periodic, Kpp) #hide
     u_i = cholesky(Symmetric(K.periodic)) \ rhs_i      # Solve
     apply!(u_i, ch.periodic)                           # Apply BC on the solution
     push!(u.periodic, u_i)                             # Save the solution vector

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -150,6 +150,7 @@ end
         for cell in CellIterator(dh)
             K[celldofs(cell), celldofs(cell)] += 2.0 * [1 -1; -1 1]
         end
+        copies = (K = copy(K), f1 = copy(f), f2 = copy(f))
 
         # Solve by actually condensing the matrix
         ff  = C' * (f - K * g)
@@ -162,7 +163,15 @@ end
         a = K \ f
         apply!(a, ch)
 
-        @test a ≈ aa
+        # Solve with extracted RHS data
+        rhs = get_rhs_data(ch, copies.K)
+        apply!(copies.K, ch)
+        apply_rhs!(rhs, copies.f1, ch)
+        a_rhs1 = apply!(copies.K \ copies.f1, ch)
+        apply_rhs!(rhs, copies.f2, ch)
+        a_rhs2 = apply!(copies.K \ copies.f2, ch)
+
+        @test a ≈ aa ≈ a_rhs1 ≈ a_rhs2
     end
 
 end


### PR DESCRIPTION
This applies affine constraints also in apply_rhs! for solving a system
with multiple right hand sides. Also adds tests, and removes the
workarounds for this bug in computational homogenization example.

Fixes #419.