### PR TITLE
Error when pushing fields to cells which already are in `MixedDofHandler`

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -113,6 +113,7 @@ nfields(dh::MixedDofHandler) = length(getfieldnames(dh))
 function Base.push!(dh::MixedDofHandler, fh::FieldHandler)
     @assert !isclosed(dh)
     _check_same_celltype(dh.grid, collect(fh.cellset))
+    _check_cellset_intersections(dh, fh)
     # the field interpolations should have the same refshape as the cells they are applied to
     refshapes_fh = getrefshape.(getfieldinterpolations(fh))
     # extract the celltype from the first cell as the celltypes are all equal
@@ -124,6 +125,12 @@ function Base.push!(dh::MixedDofHandler, fh::FieldHandler)
 
     push!(dh.fieldhandlers, fh)
     return dh
+end
+
+function _check_cellset_intersections(dh::MixedDofHandler, fh::FieldHandler)
+    for _fh in dh.fieldhandlers
+        isempty(intersect(_fh.cellset, fh.cellset)) || error("Each cell can only belong to a single FieldHandler.")
+    end
 end
 
 function Base.push!(dh::MixedDofHandler, name::Symbol, dim::Int)

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -1,5 +1,5 @@
 """
-Field(name::Symbol, interpolation::Interpolation, dim::Int)
+    Field(name::Symbol, interpolation::Interpolation, dim::Int)
 
 Construct `dim`-dimensional `Field` called `name` which is approximated by `interpolation`.
 
@@ -19,6 +19,8 @@ Construct a `FieldHandler` based on an array of [`Field`](@ref)s and assigns it 
 A `FieldHandler` must fullfill the following requirements:
 - All [`Cell`](@ref)s in `cellset` are of the same type.
 - Each field only uses a single interpolation on the `cellset`.
+- Each cell belongs only to a single `FieldHandler`, i.e. all fields on a cell must be added
+within the same `FieldHandler`.
 
 Notice that a `FieldHandler` can hold several fields.
 """

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -576,6 +576,20 @@ function test_separate_fields_on_separate_domains()
 
 end
 
+function test_unique_cellsets()
+    grid = generate_grid(Quadrilateral, (2, 1))
+    set_u = Set(1:2)
+    set_v = Set(1:1)
+
+    dim = Ferrite.getdim(grid)
+    ip = Lagrange{dim,RefCube,1}()
+
+    # bug
+    dh = MixedDofHandler(grid)
+    push!(dh, FieldHandler([Field(:u, ip, 1)], set_u))
+    @test_throws ErrorException push!(dh, FieldHandler([Field(:v, ip, 1)], set_v))
+end
+
 @testset "MixedDofHandler" begin
 
     test_1d_bar_beam();
@@ -600,4 +614,5 @@ end
     test_reshape_to_nodes()
     test_mixed_grid_show()
     test_separate_fields_on_separate_domains();
+    test_unique_cellsets()
 end


### PR DESCRIPTION
closes #429 

The current way of distributing degrees of freedom does not allow to add fields to the same cell in different `FieldHandler`s, so we should throw an error when someone tries to do that.