### PR TITLE
ConstraintHandler: More flexible update! for runtime parameters

### DIFF
--- a/docs/src/literate/computational_homogenization.jl
+++ b/docs/src/literate/computational_homogenization.jl
@@ -517,14 +517,14 @@ round.(ev; digits=-8)
 # also compute the macroscopic part of the displacement.
 
 chM = ConstraintHandler(dh)
-add!(chM, Dirichlet(:u, Set(1:getnnodes(grid)), (x, t) -> εᴹ[Int(t)] ⋅ x, [1, 2]))
+add!(chM, Dirichlet(:u, Set(1:getnnodes(grid)), (x, _, εᴹ) -> εᴹ ⋅ x, [1, 2]))
 close!(chM)
 uM = zeros(ndofs(dh))
 
 vtk_grid("homogenization", dh) do vtk
     for i in 1:3
         ## Compute macroscopic solution
-        update!(chM, i)
+        update!(chM, 0.0, εᴹ[i])
         apply!(uM, chM)
         ## Dirichlet
         vtk_point_data(vtk, dh, uM + u.dirichlet[i], "_dirichlet_$i")

--- a/docs/src/reference/boundary_conditions.md
+++ b/docs/src/reference/boundary_conditions.md
@@ -10,6 +10,7 @@ Dirichlet
 PeriodicDirichlet
 add!
 close!
+update!
 apply!
 apply_zero!
 get_rhs_data


### PR DESCRIPTION
This allows functions for Dirichlet boundary conditions to accept a
third argument with parameters that are not available when defining
the constraint (e.g. data that are computed/updated/changed during the
simulation). `update!` can now be called with a third argument which
is passed along to the constraint function `f`, for example
`update!(ch, t, p)` will call `f(x, t, p)`.

Fixes #207, closes #213.