### PR TITLE
More efficient way of creating condensed sparsity pattern

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -594,8 +594,8 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, acs::Vector{AffineCo
     # Store linear constraint index for each constrained dof
     distribute = Dict{Int,Int}(acs[c].constrained_dof => c for c in 1:length(acs))
 
-    #Adding new entries to K was extremely slow, so craete a new sparsity triplet for the condensed sparsity pattern
-    N = length(acs)*10 # TODO: Better size estimate for additional condensed sparsity pattern.
+    #Adding new entries to K is extremely slow, so create a new sparsity triplet for the condensed sparsity pattern
+    N = length(acs)*2 # TODO: Better size estimate for additional condensed sparsity pattern.
     I = Int[]; resize!(I, N)
     J = Int[]; resize!(J, N)
 
@@ -650,8 +650,7 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, acs::Vector{AffineCo
     resize!(J, cnt)
 
     # Fill the sparse matrix with a non-zero value so that :+ operation does not remove entries with value zero.
-    # Use eps(T) so that the it does not affect the current values of the sparse matrix (I need to call _condense_sparsity_pattern() in other places of my code /Elias)
-    V = fill(eps(T), length(I))
+    V = fill(1.0, length(I))
     K2 = sparse(I, J, V, ndofs, ndofs)
 
     K .+= K2
@@ -748,7 +747,7 @@ function _addindex_sparsematrix!(A::SparseMatrixCSC{Tv,Ti}, v::Tv, i::Ti, j::Ti)
         nonzeros(A)[searchk] += v
         return true
     end
-        return false
+    return false
 end
 
 """

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -394,21 +394,18 @@ function _create_sparsity_pattern(dh::DofHandler, ch#=::Union{ConstraintHandler,
     resize!(I, cnt)
     resize!(J, cnt)
 
-    #If ConstraintHandler is given, create the condensation pattern due to affine constraints
+    # If ConstraintHandler is given, create the condensation pattern due to affine constraints
     if ch !== nothing
         @assert isclosed(ch)
 
-        #Make V equal to ones instead of zeros because :+-operator removes entries with zeros.
         V = ones(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))
-        
         _condense_sparsity_pattern!(K, ch.acs)
         fill!(K.nzval, 0.0)
     else
         V = zeros(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))
     end
-    
     return K
 end
 

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -356,6 +356,7 @@ See the [Sparsity Pattern](@ref) section of the manual.
 create_symmetric_sparsity_pattern(dh::DofHandler) = Symmetric(_create_sparsity_pattern(dh, nothing, true), :U)
 
 function _create_sparsity_pattern(dh::DofHandler, ch#=::Union{ConstraintHandler, Nothing}=#, sym::Bool)
+    @assert isclosed(dh)
     ncells = getncells(dh.grid)
     n = ndofs_per_cell(dh)
     N = sym ? div(n*(n+1), 2) * ncells : n^2 * ncells
@@ -392,17 +393,22 @@ function _create_sparsity_pattern(dh::DofHandler, ch#=::Union{ConstraintHandler,
 
     resize!(I, cnt)
     resize!(J, cnt)
-    V = zeros(length(I))
-    K = sparse(I, J, V)
 
-    # Add entries to K corresponding to condensation due the linear constraints
-    # Note, this requires the K matrix, which is why we can't push!() to the I,J,V
-    # triplet directly.
+    #If ConstraintHandler is given, create the condensation pattern due to affine constraints
     if ch !== nothing
         @assert isclosed(ch)
-        _condense_sparsity_pattern!(K, ch.acs)
-    end
 
+        #Make V equal to ones instead of zeros because :+-operator removes entries with zeros.
+        V = ones(length(I))
+        K = sparse(I, J, V, ndofs(dh), ndofs(dh))
+        
+        _condense_sparsity_pattern!(K, ch.acs)
+        fill!(K.nzval, 0.0)
+    else
+        V = zeros(length(I))
+        K = sparse(I, J, V, ndofs(dh), ndofs(dh))
+    end
+    
     return K
 end
 

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -412,26 +412,20 @@ function _create_sparsity_pattern(dh::MixedDofHandler, ch#=::Union{ConstraintHan
     end
     resize!(I, cnt)
     resize!(J, cnt)
-    V = zeros(length(I))
-    K = sparse(I, J, V)
 
-    #If ConstraintHandler is given, create the condensation pattern due to affine constraints
+    # If ConstraintHandler is given, create the condensation pattern due to affine constraints
     if ch !== nothing
         @assert isclosed(ch)
 
-        #Make V equal to ones instead of zeros because :+-operator removes entries with zeros.
         V = ones(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))
-        
         _condense_sparsity_pattern!(K, ch.acs)
         fill!(K.nzval, 0.0)
     else
         V = zeros(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))
     end
-    
     return K
-
 end
 
 create_sparsity_pattern(dh::MixedDofHandler) = _create_sparsity_pattern(dh, nothing, false)

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -371,6 +371,8 @@ end
 
 # TODO if not too slow it can replace the "Grid-version"
 function _create_sparsity_pattern(dh::MixedDofHandler, ch#=::Union{ConstraintHandler,Nothing}=#, sym::Bool)
+    @assert isclosed(dh)
+
     ncells = getncells(dh.grid)
     N::Int = 0
     for element_id = 1:ncells  # TODO check for correctness
@@ -413,14 +415,21 @@ function _create_sparsity_pattern(dh::MixedDofHandler, ch#=::Union{ConstraintHan
     V = zeros(length(I))
     K = sparse(I, J, V)
 
-    # Add entries to K corresponding to condensation due the linear constraints
-    # Note, this requires the K matrix, which is why we can't push!() to the I,J,V
-    # triplet directly.
+    #If ConstraintHandler is given, create the condensation pattern due to affine constraints
     if ch !== nothing
         @assert isclosed(ch)
-        _condense_sparsity_pattern!(K, ch.acs)
-    end
 
+        #Make V equal to ones instead of zeros because :+-operator removes entries with zeros.
+        V = ones(length(I))
+        K = sparse(I, J, V, ndofs(dh), ndofs(dh))
+        
+        _condense_sparsity_pattern!(K, ch.acs)
+        fill!(K.nzval, 0.0)
+    else
+        V = zeros(length(I))
+        K = sparse(I, J, V, ndofs(dh), ndofs(dh))
+    end
+    
     return K
 
 end


### PR DESCRIPTION

Creating the sparsity pattern with affine constraints was extremely slow. 

```
grid = generate_grid(Quadrilateral, (300,300))

dh = DofHandler(grid)
push!(dh, :u, 2)
close!(dh);

ch_periodic = ConstraintHandler(dh);
periodic = PeriodicDirichlet(
    :u,
    ["left" => "right", "bottom" => "top"],
    [1, 2]
)
add!(ch_periodic, periodic)
close!(ch_periodic)
update!(ch_periodic, 0.0)

@time K = create_sparsity_pattern(dh, ch_periodic)
```

```
Before:  11.439089 seconds (239.59 k allocations: 355.780 MiB, 0.22% gc time)
Now:       0.244780 seconds (181.27 k allocations: 411.271 MiB, 10.16% gc time)
```

A lot of %gc time still which I dont understand

