### PR TITLE
Rename internal curl to curl_from_gradient

### DIFF
--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -105,9 +105,9 @@ quadrature point `q_point`.
 shape_curl(cv::T, q_point, base_func) where T = shape_curl(FieldTrait(T), cv, q_point, base_func)
 
 function shape_curl(::VectorValued, cv::Values, q_point::Int, base_func::Int)
-    return curl(shape_gradient(cv, q_point, base_func))
+    return curl_from_gradient(shape_gradient(cv, q_point, base_func))
 end
-curl(∇v) = Vec{3}((∇v[3,2] - ∇v[2,3], ∇v[1,3] - ∇v[3,1], ∇v[2,1] - ∇v[1,2]))
+curl_from_gradient(∇v::SecondOrderTensor{3}) = Vec{3}((∇v[3,2] - ∇v[2,3], ∇v[1,3] - ∇v[3,1], ∇v[2,1] - ∇v[1,2]))
 
 """
     function_value(fe_v::Values, q_point::Int, u::AbstractVector)
@@ -269,10 +269,10 @@ function_divergence(::VectorValued, fe_v::Values{dim}, q_point::Int, u::Abstract
     tr(function_gradient(fe_v, q_point, u))
 
 function_curl(fe_v::Values, q_point::Int, u::AbstractVector, dof_range = eachindex(u)) =
-    curl(function_gradient(fe_v, q_point, u, dof_range))
+    curl_from_gradient(function_gradient(fe_v, q_point, u, dof_range))
 
 function_curl(fe_v::Values, q_point::Int, u::AbstractVector{Vec{3, T}}) where T =
-    curl(function_gradient(fe_v, q_point, u))
+    curl_from_gradient(function_gradient(fe_v, q_point, u))
 
 """
     spatial_coordinate(fe_v::Values{dim}, q_point::Int, x::AbstractVector)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -40,7 +40,7 @@ for (func_interpol, quad_rule) in  (
             @test function_gradient(cv, i, u) ≈ H
             @test function_symmetric_gradient(cv, i, u) ≈ 0.5(H + H')
             @test function_divergence(cv, i, u) ≈ tr(H)
-            ndim == 3 && @test function_curl(cv, i, u) ≈ Ferrite.curl(H)
+            ndim == 3 && @test function_curl(cv, i, u) ≈ Ferrite.curl_from_gradient(H)
             function_value(cv, i, u)
             if isa(cv, CellScalarValues)
                 @test function_gradient(cv, i, u_scal) ≈ V
@@ -49,7 +49,7 @@ for (func_interpol, quad_rule) in  (
                 @test function_gradient(cv, i, u_vector) ≈ function_gradient(cv, i, u) ≈ H
                 @test function_value(cv, i, u_vector) ≈ function_value(cv, i, u)
                 @test function_divergence(cv, i, u_vector) ≈ function_divergence(cv, i, u) ≈ tr(H)
-                ndim == 3 && @test function_curl(cv, i, u_vector) ≈ Ferrite.curl(H)
+                ndim == 3 && @test function_curl(cv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
             end
         end
 

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -43,7 +43,7 @@ for (func_interpol, quad_rule) in  (
                 @test function_gradient(fv, i, u) ≈ H
                 @test function_symmetric_gradient(fv, i, u) ≈ 0.5(H + H')
                 @test function_divergence(fv, i, u) ≈ tr(H)
-                ndim == 3 && @test function_curl(fv, i, u) ≈ Ferrite.curl(H)
+                ndim == 3 && @test function_curl(fv, i, u) ≈ Ferrite.curl_from_gradient(H)
                 function_value(fv, i, u)
                 if isa(fv, FaceScalarValues)
                     @test function_gradient(fv, i, u_scal) ≈ V
@@ -52,7 +52,7 @@ for (func_interpol, quad_rule) in  (
                     @test function_gradient(fv, i, u_vector) ≈ function_gradient(fv, i, u) ≈ H
                     @test function_value(fv, i, u_vector) ≈ function_value(fv, i, u)
                     @test function_divergence(fv, i, u_vector) ≈ function_divergence(fv, i, u) ≈ tr(H)
-                    ndim == 3 && @test function_curl(fv, i, u_vector) ≈ Ferrite.curl(H)
+                    ndim == 3 && @test function_curl(fv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
                 end
             end
 


### PR DESCRIPTION
`Ferrite.curl` and `Tensors.curl` cause a naming conflict, even if `Ferrite.curl` is not exported directly, because `Tensors` exports `curl`. 
From discussions on slack, this PR renames the `Ferrite.curl` function to `curl_from_gradient`, since it doesn't do any differentiation, but takes in the gradient and outputs the curl of the vector for which the gradient is given. 