### PR TITLE
RFC: Introducing a `MixedGrid`

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -312,8 +312,9 @@ function cellnodes!(global_nodes::Vector{Int}, grid::Grid{dim,C}, i::Int) where 
     return global_nodes
 end
 
-function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::Grid{dim,C}, i::Int) where {dim,C,T}
-    nodes = grid.cells[i].nodes
+# shared implementation for all grids
+function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid, cell::C) where {dim,C<:Ferrite.AbstractCell,T}
+    nodes = cell.nodes
     N = length(nodes)
     @assert length(global_coords) == N
     for j in 1:N
@@ -321,6 +322,12 @@ function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::Grid{dim,C}, i::In
     end
     return global_coords
 end
+
+function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid, i) where {dim,T}
+    cell = getcells(grid, i)
+    cellcoords!(global_coords, grid, cell)
+end
+
 cellcoords!(global_coords::Vector{<:Vec}, dh::DofHandler, i::Int) = cellcoords!(global_coords, dh.grid, i)
 
 function celldofs(dh::DofHandler, i::Int)

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -51,6 +51,7 @@ include("FEValues/face_integrals.jl")
 include("Grid/grid.jl")
 include("Grid/grid_generators.jl")
 include("Grid/coloring.jl")
+include("Grid/mixed_grid.jl")
 
 # Dofs
 include("Dofs/DofHandler.jl")

--- a/src/Grid/mixed_grid.jl
+++ b/src/Grid/mixed_grid.jl
@@ -1,0 +1,51 @@
+mutable struct MixedGrid{dim, C, T<:Real} <: Ferrite.AbstractGrid{dim}
+    cells::C # Tuple of concretely typed cell vectors
+    ncells_per_vector::Vector{Int}
+    nodes::Vector{Node{dim,T}}
+    # Sets
+    cellsets::Dict{String,Set{Int}}
+    nodesets::Dict{String,Set{Int}}
+    facesets::Dict{String,Set{FaceIndex}} 
+    edgesets::Dict{String,Set{EdgeIndex}} 
+    vertexsets::Dict{String,Set{VertexIndex}} 
+    # Boundary matrix (faces per cell × cell)
+    boundary_matrix::SparseMatrixCSC{Bool,Int}
+end
+
+function MixedGrid(cells::C,
+        nodes::Vector{Node{dim,T}};
+        cellsets::Dict{String,Set{Int}}=Dict{String,Set{Int}}(),
+        nodesets::Dict{String,Set{Int}}=Dict{String,Set{Int}}(),
+        facesets::Dict{String,Set{FaceIndex}}=Dict{String,Set{FaceIndex}}(),
+        edgesets::Dict{String,Set{EdgeIndex}}=Dict{String,Set{EdgeIndex}}(),
+        vertexsets::Dict{String,Set{VertexIndex}}=Dict{String,Set{VertexIndex}}(),
+        boundary_matrix::SparseMatrixCSC{Bool,Int}=spzeros(Bool, 0, 0)) where {dim,C,T}
+        ncells_per_type = collect(length.(cells))
+    return MixedGrid(cells, ncells_per_type, nodes, cellsets, nodesets, facesets, edgesets, vertexsets, boundary_matrix)
+end
+
+struct CellId{I}
+    i::Int
+end
+
+function globalid(grid::MixedGrid, cellid::Ferrite.CellId{I}) where I
+    global_id = 0
+    for i=1:I-1
+        global_id += grid.ncells_per_vector[I]
+    end
+    global_id += cellid.i
+    return global_id
+end
+
+Ferrite.getcells(grid::MixedGrid, cellid::Ferrite.CellId{I}) where I = grid.cells[I][cellid.i]
+Ferrite.getncells(grid::MixedGrid) = sum(grid.ncells_per_vector)
+
+# Inherently type unstable
+function local_index(grid::MixedGrid, global_id::Int)
+    local_idx = global_id
+    for (i, ncells) in enumerate(grid.ncells_per_vector) 
+        local_idx - ncells < 1 && return NewCellIndex{i}(local_idx)
+        local_idx -= ncells
+    end
+    error("Local index corresponding to global_id=$global_id not found.")
+end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -41,7 +41,7 @@ struct CellIterator{dim,C,T,DH<:Union{AbstractDofHandler,Nothing}}
     dh::Union{DH,Nothing}
     celldofs::Vector{Int}
 
-    function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,C,T},MixedDofHandler{dim,T,G},Nothing}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T,G}
+    function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,C,T},MixedDofHandler{dim,G},Nothing}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T,G}
         isconcretetype(C) || _check_same_celltype(dh.grid, cellset)
         N = nnodes_per_cell(dh.grid, cellset === nothing ? 1 : first(cellset))
         cell = ScalarWrapper(0)


### PR DESCRIPTION
Following up on our discussion from last week, here comes a suggestion on how to handle mixed grids in a more data-oriented manner.

The main gripes about the current implementation are:
- Grids with several celltypes store their cells as `Vector{Union{CellType1, CelType2,...}}` or even worse as `Vector{AbstractCell}`. This makes extracting a cell based on its global id inherently type unstable.
- Due to the above reason, the `MixedDofHandler` stores its own grid representation so that it can efficiently access cell nodes and cell coordinates.
- `DofHandler` & `MixedDofHandler`. Mixed Celltypes in a grid are now reflected by need to use `MixedDofHandler`. It would be nice to reflect this in the `Grid` datatype instead and use a single `DofHandler` no matter what the grid type. _(Currently the `DofHandler` additionally does not support fields on subsets of the domain, while the `MixedDofHandler` does.)_   
- When assembling with a `MixedDofHandler`, it is crucial for performance to not iterate over all cells at once. Instead a function barrier should be set for each `FieldHandler`. This is not mentioned in our docs.

This PR attempts to solve the first two points and lay ground for solving the 3rd in the future.

# MixedGrid type
It introduces a `MixedGrid` that stores its cells as `Tuple{Vector{CellType1}, Vector{CellType2}, ...}`.
The cells in the grid are indexed by 
```julia
struct CellId{I}
    i::Int
end
```
where `I` is the index within the tuple and `i` is the index within the `Vector`. This can be seen as local cell id. Cells also have global cell ids (`Int`s), which count through the cells tuple from beginning to end. Global ids can thus easily computed from local ids. 

This means that cells will likely be renumbered when importing a mixed grid from an external grid generator. I don't see this as a huge problem, but an alternative approach could be to store a mapping local id -> global id.

# MixedDofHandler + MixedGrid
A grid with mixed celltypes should always be represented as `MixedGrid` and always be indexed by `CellId`. That is, the `FieldHandler`s then store a (concretely typed!) `Set{CellId{I}}` and all cellsets + facesets in the mixed grid should reference cells by `CellId` instead of their global id (the latter isn't implemented yet for this PR).

The `MixedDofHandler` does not store cell nodes and cell coordinates anymore. Methods for extracting them fall back to the implementations for the underlying grid.

The `MixedDofHandler` allows to use either `Grid` or `MixedGrid` with it. Therefore, the `celldofs` are still stored by global cell ids.


# DofHandler methods + Benchmarking
Here is a list of all functions that use the DofHandlers (to get an overview). Some methods are defined for `AbstractDofHandler`, but will only work for the `DofHandler`, thus they're listed on the left.

| DofHandler | MixedDofHandler |
| --- | --- |
| `getfielddim(dh::DofHandler, field_idx::Int)` | no exact equivalent |
| ` getfielddim(dh::DofHandler, name::Symbol)` |`getfielddim(dh::MixedDofHandler, name::Symbol)`|
| `ndim(dh::AbstractDofHandler, field_name::Symbol)`, same functionality as getfielddim | doesn't exist |
| `nfields(dh::AbstractDofHandler)`, see #444| `nfields(dh::MixedDofHandler)` |
| `ndofs_per_cell(dh::AbstractDofHandler, cell::Int=1)`|`ndofs_per_cell(dh::MixedDofHandler, cell::Int=1)` | 
| `getfieldnames(dh::AbstractDofHandler)` | `getfieldnames(dh::MixedDofHandler)`, `getfieldnames(fh::FieldHandler)` |
| | |
| `find_field(dh::DofHandler, field_name::Symbol)` | `find_field(fh::FieldHandler, field_name::Symbol)` |
| `field_offset(dh::DofHandler, field_name::Symbol)`|`field_offset(fh::FieldHandler, field_name::Symbol)` | 
| `dof_range(dh::DofHandler, field_name::Symbol)` | `dof_range(fh::FieldHandler, field_name::Symbol)` |
| `getfieldinterpolation(dh::DofHandler, field_idx::Int)` | no exact equivalent | 
| no excact equivalent | `getfieldinterpolations(fh::FieldHandler)`|
| | |
| ` cellcoords!(global_coords::Vector{<:Vec}, dh::DofHandler, i::Int)` | `cellcoords!(global_coords::Vector{Vec{dim,T}}, dh::MixedDofHandler, i::Int) where {dim,T}` |
| `celldofs!(global_dofs::Vector{Int}, dh::DofHandler, i::Int)` | `celldofs!(global_dofs::Vector{Int}, dh::MixedDofHandler, i::Int)` |
| `celldofs(dh::DofHandler, i::Int)` | `celldofs(dh::MixedDofHandler, i::Int)` |
| use grid version | `cellnodes!(global_nodes::Vector{Int}, dh::MixedDofHandler, i::Int)`|

Most of these are used for dof distribution, I'd expect that only `celldofs!` and `cellcoords!` are used in performance relevant code, so let's focus on these for some micro benchmarks. The benchmarks extract cellcoords and celldofs for a `Quadrilateral` in a mixed grid with `Triangle`s and `Quadrilateral`s.  

| | `DofHandler` | `MixedDofHandler#master` <br> + mixed grid |  `MixedDofHandler#thisPR` <br> + mixed grid | `MixedDofHandler#thisPR` <br> + concrete grid |
|---|---|---|---|---|
| `cellcoords!` | 4.100 ns (0 allocations: 0 bytes)| 9.300 ns (0 allocations: 0 bytes) | 4.300 ns (0 allocations: 0 bytes) | 4.100 ns (0 allocations: 0 bytes) |
| `celldofs!` | 9.500 ns (0 allocations: 0 bytes) | 9.810 ns (0 allocations: 0 bytes) | 9.300 ns (0 allocations: 0 bytes) | 9.300 ns (0 allocations: 0 bytes) |

For this case, the `MixedDofHandler` now performs equally well as the `DofHandler`, no matter if it is used with `Grid` or with `MixedGrid`. 


Technically, it was possible to use the grid version of `cellcoords!` before this PR (and thus get rid of the grid representation in the `MixedDofHandler`), however that can be (very) slow:
|cell type| `Quadrilateral` <br> (concretly typed) | `Union{Triangle, Quadrilateral}` | `AbstractCell` |
|---|---|---|---|
| `cellcoords!`<br>`(xe, grid, i)` | 3.700 ns (0 allocations: 0 bytes) | 6.700 ns (0 allocations: 0 bytes) | 1.710 μs (22 allocations: 720 bytes)|

# Usage
The usage pattern remains exactly the same as before. 
```julia
# e.g. for the quads and tris example above:
buffers_quads = (xe_quads, dofs_quads, cv_quads, ke_quads, re_quads)
buffers_tris = (xe_tris, dofs_tris, cv_tris, ke_tris, re_tris)
buffers = [buffers_quads, buffers_tris]

for (fh_idx, fh) in enumerate(dh.fieldhandlers)
    xe, dofs, cv, ke, re = buffers[fh_idx]
    loop_fh(dh, fh, ke, re, xe, dofs, cv)
end

function loop_fh(dh, fh, ke, re, xe, dofs, cv)
    for cellid in fh.cellset
        cellcoords!(xe, dh, cellid)
        celldofs!(dofs, dh, cellid)
        # ... do stuff like element routine
        # @views ue = u[dofs] 
        # assemble_cell!(ke, re, xe, cv, ue)
    end
end
```