### PR TITLE
Kam/assemble docs

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -88,7 +88,7 @@ function start_assemble(K::SparseMatrixCSC, f::Vector=Float64[]; fillzero::Bool=
     fillzero && (fill!(K.nzval, 0.0); fill!(f, 0.0))
     AssemblerSparsityPattern(K, f, Int[], Int[])
 end
-function start_assemble(K::Symmetric, f::Vector=Float64[]; fillzero::Bool=true)
+function start_assemble(K::Symmetric{Td,SparseMatrixCSC{Td,Ti}}, f::Vector=Float64[]; fillzero::Bool=true) where{Td,Ti}
     fillzero && (fill!(K.data.nzval, 0.0); fill!(f, 0.0))
     AssemblerSymmetricSparsityPattern(K, f, Int[], Int[])
 end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -91,12 +91,12 @@ Create a `AssemblerSparsityPattern` or `AssemblerSymmetricSparsityPattern` assem
 The keyword argument fillzero can be set to false if `K` and `f` should keep their current values. 
 
 """
-start_assemble(f::Vector{Td}, K::Union{SparseMatrixCSC, Symmetric{Td,SparseMatrixCSC{Td,Int}}}; fillzero::Bool=true)  where{Td} = start_assemble(K, f; fillzero=fillzero)
+start_assemble(f::Vector{Td}, K::Union{SparseMatrixCSC, Symmetric{Td,SparseMatrixCSC{Td,Ti}}}; fillzero::Bool=true)  where{Td,Ti} = start_assemble(K, f; fillzero=fillzero)
 function start_assemble(K::SparseMatrixCSC{Td}, f::Vector=Td[]; fillzero::Bool=true) where{Td}
     fillzero && (fill!(K.nzval, zero(Td)); fill!(f, zero(Td)))
     AssemblerSparsityPattern(K, f, Int[], Int[])
 end
-function start_assemble(K::Symmetric{Td,SparseMatrixCSC{Td,Int}}, f::Vector=Td[]; fillzero::Bool=true) where{Td}
+function start_assemble(K::Symmetric{Td,SparseMatrixCSC{Td,Ti}}, f::Vector=Td[]; fillzero::Bool=true) where{Td,Ti}
     fillzero && (fill!(K.data.nzval, zero(Td)); fill!(f, zero(Td)))
     AssemblerSymmetricSparsityPattern(K, f, Int[], Int[])
 end


### PR DESCRIPTION
The docs for the assembling confused me a bit, so here is an attempt at making them more clear. 
Furthermore, in master, if one calls `start_assemble` with a dense symmetric matrix, this fails because accessing `data.nzval` fails. To "fix" this I changed the signature of `start_assemble` to not allow dense symmetric matrices, giving a better error message:
```julia
K = Symmetric(rand(4,4));
start_assemble(K)
ERROR: type Array has no field nzval # master
MethodError: no method matching start_assemble(::Symmetric{Float64, Matrix{Float64}}) # PR
```
