### PR TITLE
RFC: Attempt at complex dofs with Helmholtz eqn

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -67,14 +67,14 @@ struct ConstraintHandler{DH<:AbstractDofHandler,T}
     free_dofs::Vector{Int}
     inhomogeneities::Vector{T}
     dofmapping::Dict{Int,Int} # global dof -> index into dofs and inhomogeneities
-    bcvalues::Vector{BCValues{T}}
+    bcvalues::Vector{BCValues{Float64}} # BCValues are just the shape functions, not the BCs themselves
     dh::DH
     closed::ScalarWrapper{Bool}
 end
 
-function ConstraintHandler(dh::AbstractDofHandler)
+function ConstraintHandler(dh::AbstractDofHandler;bctype=Float64)
     @assert isclosed(dh)
-    ConstraintHandler(Dirichlet[], AffineConstraint[], Int[], Int[], Float64[], Dict{Int,Int}(), BCValues{Float64}[], dh, ScalarWrapper(false))
+    ConstraintHandler(Dirichlet[], AffineConstraint[], Int[], Int[], bctype[], Dict{Int,Int}(), BCValues{Float64}[], dh, ScalarWrapper(false))
 end
 
 """
@@ -357,7 +357,7 @@ function update!(ch::ConstraintHandler, time::Real=0.0)
 end
 
 # for faces
-function _update!(inhomogeneities::Vector{Float64}, f::Function, faces::Set{<:BoundaryIndex}, field::Symbol, local_face_dofs::Vector{Int}, local_face_dofs_offset::Vector{Int},
+function _update!(inhomogeneities::Vector, f::Function, faces::Set{<:BoundaryIndex}, field::Symbol, local_face_dofs::Vector{Int}, local_face_dofs_offset::Vector{Int},
                   components::Vector{Int}, dh::AbstractDofHandler, facevalues::BCValues,
                   dofmapping::Dict{Int,Int}, time::T) where {T}
 

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -84,7 +84,7 @@ end
 abstract type AbstractGrid{dim} end
 
 """
-    Grid{dim, C<:AbstractCell, T<:Real} <: AbstractGrid}
+    Grid{dim, C<:AbstractCell, T<:Number} <: AbstractGrid}
 
 A `Grid` is a collection of `Cells` and `Node`s which covers the computational domain, together with Sets of cells, nodes and faces.
 There are multiple helper structures to apply boundary conditions or define subdomains. They are gathered in the `cellsets`, `nodesets`,
@@ -100,7 +100,7 @@ There are multiple helper structures to apply boundary conditions or define subd
 - `vertexsets::Dict{String,Set{VertexIndex}}`: maps a `String` key to a `Set` of local vertex ids
 - `boundary_matrix::SparseMatrixCSC{Bool,Int}`: optional, only needed by `onboundary` to check if a cell is on the boundary, see, e.g. Helmholtz example
 """
-mutable struct Grid{dim,C<:AbstractCell,T<:Real} <: AbstractGrid{dim}
+mutable struct Grid{dim,C<:AbstractCell,T<:Number} <: AbstractGrid{dim}
     cells::Vector{C}
     nodes::Vector{Node{dim,T}}
     # Sets


### PR DESCRIPTION
Hi, first I want to say thank you for creating this package!

I was looking to use it to solve the complex valued Helmholtz equation, however I can't find any references to using complex numbers with the library. One solution is to register the real and imaginary parts separately as 2 real unknowns, however, this is not as elegant and produces a matrix twice as large as it needs to be.

So I hacked around with the library and got it to accept complex numbers. I modified the Helmholtz example to demonstrate the solution, although I suspect it would be better to create another to demonstrate complex values. My solution doesn't feel particularly correct so I wanted to submit it as an RFC to hopefully get some pointers. In particular, I feel like the `DofHandler` should know the nodal type, and should pass this through to the assembly process and `ConstraintHandler`.

NB: Support for mixed precision has been discussed (#195), but I couldn't find any code related to it.