### PR TITLE
Fix PointEvalHandler when first point is missing + add some kwargs

### DIFF
--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -55,7 +55,7 @@ function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid,
 
     # set up tree structure for finding nearest nodes to points
     kdtree = KDTree(reinterpret(Vec{dim,T}, getnodes(grid)))
-    nearest_nodes, _ = knn(kdtree, points, serach_nneighbors, true) #TODO 3 is a random value, it shouldn't matter because likely the nearest node is the one we want
+    nearest_nodes, _ = knn(kdtree, points, serach_nneighbors, true) 
 
     cells = Vector{Union{Nothing, Int}}(nothing, length(points))
     local_coords = Vector{Union{Nothing, Vec{dim, T}}}(nothing, length(points))

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -51,11 +51,11 @@ function PointEvalHandler(grid::AbstractGrid, points::AbstractVector{Vec{dim,T}}
     return PointEvalHandler(grid, cells, local_coords)
 end
 
-function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid, node_cell_dicts::Dict{C,Dict{Int, Vector{Int}}}, serach_nneighbors, warn) where {dim, T<:Real, C}
+function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid, node_cell_dicts::Dict{C,Dict{Int, Vector{Int}}}, search_nneighbors, warn) where {dim, T<:Real, C}
 
     # set up tree structure for finding nearest nodes to points
     kdtree = KDTree(reinterpret(Vec{dim,T}, getnodes(grid)))
-    nearest_nodes, _ = knn(kdtree, points, serach_nneighbors, true) 
+    nearest_nodes, _ = knn(kdtree, points, search_nneighbors, true) 
 
     cells = Vector{Union{Nothing, Int}}(nothing, length(points))
     local_coords = Vector{Union{Nothing, Vec{dim, T}}}(nothing, length(points))
@@ -266,7 +266,9 @@ function _get_point_values!(
     # extract variables
     local_coords = ph.local_coords
     # preallocate some stuff specific to this cellset
-    pv = PointScalarValuesInternal(local_coords[findfirst(x->!isnothing(x), local_coords)], ip)
+    idx = findfirst(!isnothing, local_coords)
+    idx === nothing && return out_vals
+    pv = PointScalarValuesInternal(local_coords[idx], ip)
     first_cell = cellset === nothing ? 1 : first(cellset)
     cell_dofs = Vector{Int}(undef, ndofs_per_cell(dh, first_cell))
 

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -1,8 +1,13 @@
 """
-    PointEvalHandler(grid::Grid, points::AbstractVector{Vec{dim,T}}) where {dim, T}
+    PointEvalHandler(grid::Grid, points::AbstractVector{Vec{dim,T}}; kwargs...) where {dim, T}
 
 The `PointEvalHandler` can be used for function evaluation in *arbitrary points* in the
 domain -- not just in quadrature points or nodes.
+
+The `PointEvalHandler` takes the following keyword arguments:
+ - `search_nneighbors`: How many nodes should be found in the nearest neighbor search for each
+   point. Usually there is no need to change this setting. Default value: `3`.
+ - `warn`: Show a warning if a point is not found. Default value: `true`.
 
 The constructor takes a grid and a vector of coordinates for the points. The
 `PointEvalHandler` computes i) the corresponding cell, and ii) the (local) coordinate
@@ -40,17 +45,17 @@ function Base.show(io::IO, ::MIME"text/plain", ph::PointEvalHandler)
     end
 end
 
-function PointEvalHandler(grid::AbstractGrid, points::AbstractVector{Vec{dim,T}}; search_nneighbours=3, warn=true) where {dim, T}
+function PointEvalHandler(grid::AbstractGrid, points::AbstractVector{Vec{dim,T}}; search_nneighbors=3, warn=true) where {dim, T}
     node_cell_dicts = _get_node_cell_map(grid)
-    cells, local_coords = _get_cellcoords(points, grid, node_cell_dicts, search_nneighbours, warn)
+    cells, local_coords = _get_cellcoords(points, grid, node_cell_dicts, search_nneighbors, warn)
     return PointEvalHandler(grid, cells, local_coords)
 end
 
-function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid, node_cell_dicts::Dict{C,Dict{Int, Vector{Int}}}, search_nneighbours, warn) where {dim, T<:Real, C}
+function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid, node_cell_dicts::Dict{C,Dict{Int, Vector{Int}}}, serach_nneighbors, warn) where {dim, T<:Real, C}
 
     # set up tree structure for finding nearest nodes to points
     kdtree = KDTree(reinterpret(Vec{dim,T}, getnodes(grid)))
-    nearest_nodes, _ = knn(kdtree, points, search_nneighbours, true) #TODO 3 is a random value, it shouldn't matter because likely the nearest node is the one we want
+    nearest_nodes, _ = knn(kdtree, points, serach_nneighbors, true) #TODO 3 is a random value, it shouldn't matter because likely the nearest node is the one we want
 
     cells = Vector{Union{Nothing, Int}}(nothing, length(points))
     local_coords = Vector{Union{Nothing, Vec{dim, T}}}(nothing, length(points))

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -326,6 +326,15 @@ function oneD()
     # @test f.(points) ≈ vals
 end
 
+function first_point_missing()
+    mesh = generate_grid(Quadrilateral, (1, 1))
+    points = [Vec(2.0, 0.0), Vec(0.0, 0.0)]
+    ph = PointEvalHandler(mesh, points; warn=false)
+    
+    @test isnothing(ph.local_coords[1])
+    @test ph.local_coords[2] == Vec(0.0, 0.0)
+end
+
 @testset "PointEvalHandler" begin
     scalar_field()
     vector_field()
@@ -334,6 +343,7 @@ end
     superparametric()
     mixed_grid()
     oneD()
+    first_point_missing()
 end
 
 @testset "PointValues" begin


### PR DESCRIPTION
The `PointEvalHandler` could not be constructed when the first point was not found.

Also adds keyword arguments for how many neigboring points to use and whether or not to print warnings for not found points. The former was a random hard-coded choice in the first place (so perhaps better allow the user to change it if necessary) and the latter is useful if many points are expected to not be found.