### PR TITLE
Fix wrong docs: CellIterator, assemble!

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -61,7 +61,7 @@ function end_assemble(a::Assembler)
 end
 
 """
-    assemble!(g, ge, edof)
+    assemble!(g, edof, ge)
 
 Assembles the element residual `ge` into the global residual vector `g`.
 """

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -35,17 +35,17 @@ function start_assemble(N::Int=0)
 end
 
 """
-    assemble!(a::Assembler, Ke, edof)
+    assemble!(a::Assembler, dofs, Ke)
 
 Assembles the element matrix `Ke` into `a`.
 """
-function assemble!(a::Assembler{T}, edof::AbstractVector{Int}, Ke::AbstractMatrix{T}) where {T}
-    n_dofs = length(edof)
+function assemble!(a::Assembler{T}, dofs::AbstractVector{Int}, Ke::AbstractMatrix{T}) where {T}
+    n_dofs = length(dofs)
     append!(a.V, Ke)
     @inbounds for j in 1:n_dofs
-        append!(a.I, edof)
+        append!(a.I, dofs)
         for i in 1:n_dofs
-            push!(a.J, edof[j])
+            push!(a.J, dofs[j])
         end
     end
 end
@@ -61,14 +61,14 @@ function end_assemble(a::Assembler)
 end
 
 """
-    assemble!(g, edof, ge)
+    assemble!(g, dofs, ge)
 
 Assembles the element residual `ge` into the global residual vector `g`.
 """
-@propagate_inbounds function assemble!(g::AbstractVector{T}, edof::AbstractVector{Int}, ge::AbstractVector{T}) where {T}
-    @boundscheck checkbounds(g, edof)
-    @inbounds for i in 1:length(edof)
-        g[edof[i]] += ge[i]
+@propagate_inbounds function assemble!(g::AbstractVector{T}, dofs::AbstractVector{Int}, ge::AbstractVector{T}) where {T}
+    @boundscheck checkbounds(g, dofs)
+    @inbounds for i in 1:length(dofs)
+        g[dofs[i]] += ge[i]
     end
 end
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -26,7 +26,7 @@ end
 Here, `cell::CellIterator`. Looking at a specific cell (instead of 
 looping over all), e.g. nr 10, can be done by
 ```julia
-cell = CellIterator(dh)     # Refers to cell nr. 1 upon creation
+cell = CellIterator(dh)     # Uninitialized upon creation
 reinit!(cell, 10)           # Update to cell nr. 10
 dofs = celldofs(cell)       # Get the dofs for cell nr. 10
 ```


### PR DESCRIPTION
```julia
grid=generate_grid(Quadrilateral, (20, 20));
dh=DofHandler(grid); push!(dh, :u, 2); close!(dh);
CellIterator(dh).current_cellid[]
```
gives 0
(Fixing my own mistakes, ref #414 )

Edit: Added another doc error I discovered for `assemble!(g, edof, ge)` and `assemble!(K, edof, Ke)`
I also suggest renaming `edof` here to `dofs` to be consistent with the other `assemble!` methods