### PR TITLE
rename `L2Projector.set` to `cell_idxs` and remove internal collect

### DIFF
--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -152,7 +152,7 @@ function test_projection_mixedgrid()
     # Assume f would only exist on the first cell, we project it to the nodes of the
     # 1st cell while ignoring the rest of the domain. NaNs should be stored in all
     # nodes that do not belong to the 1st cell
-    proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=1:1)
+    proj = L2Projector(ip, mesh; geom_ip=ip_geom, cell_idxs=1:1)
     point_vars = project(proj, qp_values, qr)
     point_vars_2 = project(proj, qp_values_matrix, qr)
     ## Old API with fe values as first arg
@@ -201,7 +201,7 @@ function test_projection_mixedgrid()
     end
 
     #tria
-    proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=triaset)
+    proj = L2Projector(ip, mesh; geom_ip=ip_geom, cell_idxs=triaset)
     point_vars = project(proj, qp_values_tria, qr)
     point_vars_2 = project(proj, qp_values_matrix_tria, qr)
     for cellid in triaset
@@ -261,7 +261,7 @@ function test_export(;subset::Bool)
             qpdata_stens[cellid(cell)][qp] = SymmetricTensor{2,2}((i,j) -> i * j * f(x))
         end
     end
-    p = subset ? L2Projector(ip, grid; set=1:1) : L2Projector(ip, grid)
+    p = subset ? L2Projector(ip, grid; cell_idxs=1:1) : L2Projector(ip, grid)
     p_scalar = project(p, qpdata_scalar, qr; project_to_nodes=false)::Vector{Float64}
     p_vec = project(p, qpdata_vec, qr; project_to_nodes=false)::Vector{<:Vec{2}}
     p_tens = project(p, qpdata_tens, qr; project_to_nodes=false)::Vector{<:Tensor{2,2}}

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -252,7 +252,7 @@ function mixed_grid()
     end
 
     # construct projector 
-    projector = L2Projector(ip_quad, mesh; set=getcellset(mesh, "quads"))
+    projector = L2Projector(ip_quad, mesh; cell_idxs=sort!(collect(getcellset(mesh, "quads"))))
 
     points = [Vec((x, 2x)) for x in range(0.0; stop=1.0, length=10)]
 


### PR DESCRIPTION
I've been tricking myself by the `set` kwarg of the L2Projector again yesterday. `set` isn't actually a `Set`, it is a `Vector{Int}`. It is internally collected, but `project` assumes that the gauss point values are given in the same order as the cells (that have possibly just been collected from a Set, so no specific order is guaranteed).

This PR renames the `set` field and keyword argument to `cell_idxs` and removes the internal collecting. I think it is better if the user collects the corresponding set and takes care of ordering the gauss point data in the same way.
This is clearly breaking, so if we merge it, we could consider removing all the deprecated constructors for the `L2Projector` at the same time.