### PR TITLE
Remove onboundary from examples

### DIFF
--- a/docs/src/literate/helmholtz.jl
+++ b/docs/src/literate/helmholtz.jl
@@ -136,9 +136,8 @@ function doassemble(cellvalues::CellScalarValues{dim}, facevalues::FaceScalarVal
         # ```
         #+
         for face in 1:nfaces(cell)
-            if onboundary(cell, face) && 
-                   ((cellcount, face) ∈ getfaceset(grid, "left") || 
-                    (cellcount, face) ∈ getfaceset(grid, "bottom"))
+            if (cellcount, face) ∈ getfaceset(grid, "left") || 
+                (cellcount, face) ∈ getfaceset(grid, "bottom")
                 reinit!(facevalues, cell, face)
                 for q_point in 1:getnquadpoints(facevalues)
                     coords_qp = spatial_coordinate(facevalues, q_point, coords)

--- a/docs/src/literate/incompressible_elasticity.jl
+++ b/docs/src/literate/incompressible_elasticity.jl
@@ -160,7 +160,7 @@ function assemble_up!(Ke, fe, cell, cellvalues_u, cellvalues_p, facevalues_u, gr
     ## We loop over all the faces in the cell, then check if the face
     ## is in our `"traction"` faceset.
     @inbounds for face in 1:nfaces(cell)
-        if onboundary(cell, face) && (cellid(cell), face) ∈ getfaceset(grid, "traction")
+        if (cellid(cell), face) ∈ getfaceset(grid, "traction")
             reinit!(facevalues_u, cell, face)
             for q_point in 1:getnquadpoints(facevalues_u)
                 dΓ = getdetJdV(facevalues_u, q_point)

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -328,7 +328,7 @@ function solve()
         ## Update the old states with the converged values for next timestep
         states_old .= states
 
-        u_max[timestep] = maximum(abs.(u)) # maximum displacement in current timestep
+        u_max[timestep] = maximum(abs, u) # maximum displacement in current timestep
     end
 
     ## ## Postprocessing

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -228,7 +228,7 @@ function assemble_cell!(Ke, re, cell, cellvalues, facevalues, grid, material,
 
     ## Add traction as a negative contribution to the element residual `re`:
     for face in 1:nfaces(cell)
-        if onboundary(cell, face) && (cellid(cell), face) ∈ getfaceset(grid, "right")
+        if (cellid(cell), face) ∈ getfaceset(grid, "right")
             reinit!(facevalues, cell, face)
             for q_point in 1:getnquadpoints(facevalues)
                 dΓ = getdetJdV(facevalues, q_point)


### PR DESCRIPTION
If removed from Neumann example, probably good to remove from examples as well? Ref #473

Edit: Also adopted an unrelated doc change from @fredrikekre's comment in [#470](https://github.com/Ferrite-FEM/Ferrite.jl/pull/470#discussion_r928557474)