### PR TITLE
More complete support for periodic boundary conditions

### DIFF
--- a/docs/src/reference/boundary_conditions.md
+++ b/docs/src/reference/boundary_conditions.md
@@ -8,6 +8,8 @@ DocTestSetup = :(using Ferrite)
 ConstraintHandler
 Dirichlet
 PeriodicDirichlet
+collect_periodic_faces
+collect_periodic_faces!
 add!
 close!
 apply!

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -115,6 +115,8 @@ export
     ConstraintHandler,
     Dirichlet,
     PeriodicDirichlet,
+    collect_periodic_faces,
+    collect_periodic_faces!,
     AffineConstraint,
     update!,
     apply!,


### PR DESCRIPTION
This patch adds better support for specifying periodic boundary conditions. In particular, `collect_periodic_faces(!)` is added, which, for given input mirror and image sets computes the matching face. The result can be passed directly to the `PeriodicDirichlet` constructor. The existing limitation about full periodicity (i.e. all directions) is removed.