### PR TITLE
Add notes in doc about mesh parser

### DIFF
--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -47,7 +47,7 @@ using Ferrite, SparseArrays
 # so we don't need to specify the corners of the domain.
 grid = generate_grid(Quadrilateral, (20, 20));
 
-# Create or importing more advanced meshes is possible with the [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) or 
+# Creating or importing more advanced meshes is possible with the [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) or 
 # [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) packages. 
 
 # ### Trial and test functions

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -47,9 +47,6 @@ using Ferrite, SparseArrays
 # so we don't need to specify the corners of the domain.
 grid = generate_grid(Quadrilateral, (20, 20));
 
-# Creating or importing more advanced meshes is possible with the [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) or 
-# [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) packages. 
-
 # ### Trial and test functions
 # A `CellValues` facilitates the process of evaluating values and gradients of
 # test and trial functions (among other things). Since the problem

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -47,6 +47,9 @@ using Ferrite, SparseArrays
 # so we don't need to specify the corners of the domain.
 grid = generate_grid(Quadrilateral, (20, 20));
 
+# Create or importing more advanced meshes is possible with the [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) or 
+# [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) packages. 
+
 # ### Trial and test functions
 # A `CellValues` facilitates the process of evaluating values and gradients of
 # test and trial functions (among other things). Since the problem

--- a/docs/src/manual/grid.md
+++ b/docs/src/manual/grid.md
@@ -3,7 +3,7 @@ DocTestSetup = :(using Ferrite)
 ```
 
 # Grid
-A Ferrite `Grid` can be generated with the generate_grid` function. 
+A Ferrite `Grid` can be generated with the `generate_grid` function. 
 More advanced meshes can be imported with the 
 [`FerriteMeshParser.jl`](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) (currently for Abaqus .inp files),
 or even created with the [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package. 

--- a/docs/src/manual/grid.md
+++ b/docs/src/manual/grid.md
@@ -3,6 +3,10 @@ DocTestSetup = :(using Ferrite)
 ```
 
 # Grid
+A Ferrite `Grid` can be generated with the [`Ferrite.generate_grid`](@ref) function. 
+More advanced meshes can be imported with the 
+[`FerriteMeshParser.jl`](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) (currently for Abaqus .inp files),
+or even created with the [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package. 
 
 In Ferrite a Grid is a collection of `Node`s and `Cell`s and is parameterized in its physical dimensionality and cell type.
 `Node`s are points in the physical space and can be initialized by a N-Tuple, where N corresponds to the dimensions.

--- a/docs/src/manual/grid.md
+++ b/docs/src/manual/grid.md
@@ -3,7 +3,7 @@ DocTestSetup = :(using Ferrite)
 ```
 
 # Grid
-A Ferrite `Grid` can be generated with the [`Ferrite.generate_grid`](@ref) function. 
+A Ferrite `Grid` can be generated with the generate_grid` function. 
 More advanced meshes can be imported with the 
 [`FerriteMeshParser.jl`](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) (currently for Abaqus .inp files),
 or even created with the [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package. 


### PR DESCRIPTION
After discussions on FerriteCon, good to highlight that there are packages that can do this. 

Currently adding in manual + in the first example. 