### PR TITLE
improve performance of `apply!` be rewriting the part that zero out rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - Runtime and allocations for application of boundary conditions in `apply!` and
+   `apply_zero!` have been improved. As a result, the `strategy` keyword argument is
+   obsolete and thus ignored. ([#489][github-489])
 
 ## [0.3.9] - 2022-10-19
 ### Added


### PR DESCRIPTION
As a consequence the `strategy` kwarg is no longer useful.

Benchmark code:

```julia
grid = generate_grid(Hexahedron, (100, 100, 100));
dim = 3
ip = Lagrange{dim, RefCube, 1}()
qr = QuadratureRule{dim, RefCube}(2)
cellvalues = CellScalarValues(qr, ip);
dh = DofHandler(grid)
push!(dh, :u, 1)
close!(dh);
K = create_sparsity_pattern(dh)
ch = ConstraintHandler(dh);
∂Ω = union(
    getfaceset(grid, "left"),
    getfaceset(grid, "right"),
    getfaceset(grid, "top"),
    getfaceset(grid, "bottom"),
);
dbc = Dirichlet(:u, ∂Ω, (x, t) -> 0)
add!(ch, dbc);
close!(ch)
update!(ch, 0.0);
f = zeros(size(K, 1))

using BenchmarkTools
@btime apply_zero!(K, f, ch)
```

```julia
julia> @btime apply_zero!(K, f, ch) # master
  692.526 ms (16 allocations: 423.98 MiB)

julia> @btime apply_zero!(K, f, ch)
  687.897 ms (4 allocations: 544 bytes)
```

Time is approx the same but we no longer need to keep two copies of the stiffness matrix in memory at the same time.
