### PR TITLE
Default to constraining all components for (Periodic)Dirichlet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - The default components to constrain in `Dirichlet` and `PeriodicDirichlet` have changed
+   from component 1 to all components of the field. For scalar problems this has no effect.
+   ([#506][github-506], [#509][github-509])
 
 ## [0.3.8] - 2022-10-05
 ### Added
@@ -123,6 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-501]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/501
 [github-503]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/503
 [github-505]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/505
+[github-506]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/506
+[github-509]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/509
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.8...HEAD
 [0.3.8]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.7...v0.3.8

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -55,7 +55,7 @@ getfieldnames(dh::AbstractDofHandler) = dh.field_names
 ndim(dh::AbstractDofHandler, field_name::Symbol) = dh.field_dims[find_field(dh, field_name)]
 function find_field(dh::DofHandler, field_name::Symbol)
     j = findfirst(i->i == field_name, dh.field_names)
-    j == 0 && error("did not find field $field_name")
+    j === nothing && error("could not find field :$field_name in DofHandler (existing fields: $(getfieldnames(dh)))")
     return j
 end
 

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -102,9 +102,7 @@ Returns the union of all the fields. Can be used as an iterable over all the fie
 function getfieldnames(dh::MixedDofHandler)
     fieldnames = Vector{Symbol}()
     for fh in dh.fieldhandlers
-        for name in getfieldnames(fh)
-            push!(fieldnames, name)
-        end
+        append!(fieldnames, getfieldnames(fh))
     end
     return unique!(fieldnames)
 end
@@ -441,7 +439,7 @@ create_symmetric_sparsity_pattern(dh::MixedDofHandler) = Symmetric(_create_spars
 
 function find_field(fh::FieldHandler, field_name::Symbol)
     j = findfirst(i->i == field_name, getfieldnames(fh))
-    j === nothing && error("did not find field $field_name")
+    j === nothing && error("could not find field :$field_name in FieldHandler (existing fields: $(getfieldnames(fh)))")
     return j
 end
 


### PR DESCRIPTION
This patch changes the default components to prescribe for (Periodic)Dirichlet from component one to all components. This change does not affect scalar problems, and judging by tests, does not really affect vector valued problems either since it was already rather strange to rely on the default behavior of prescribing only the first component. Fixes #506.