### PR TITLE
Local condensation of constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - New functions `apply_local!` and `apply_assemble!` for applying constraints locally on
+   the element level before assembling to the global system. ([#528][github-528])
 ### Changed
  - Runtime and allocations for application of boundary conditions in `apply!` and
    `apply_zero!` have been improved. As a result, the `strategy` keyword argument is
@@ -127,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-418]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/418
 [github-425]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/425
 [github-428]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/428
+[github-431]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/431
 [github-436]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/436
 [github-456]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/456
 [github-458]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/458
@@ -157,6 +161,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-512]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/512
 [github-514]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/514
 [github-524]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/524
+[github-528]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/528
 [github-529]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/529
 [github-530]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/530
 [github-535]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/535

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -9,6 +9,11 @@ git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+[[deps.AbstractTrees]]
+git-tree-sha1 = "52b3b436f8f73133d7bc3a6c71ee7ed6ab2ab754"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.3"
+
 [[deps.Adapt]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
@@ -272,10 +277,12 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.1"
 
 [[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "6030186b00a38e9d0434518627426570aac2ef95"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "f0d888fc646bbb2c2917c325eb27379c577d1afa"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaDocs/Documenter.jl.git"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.23"
+version = "0.28.0-DEV"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -827,6 +834,12 @@ version = "0.1.8"
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MarkdownAST]]
+deps = ["AbstractTrees", "Markdown"]
+git-tree-sha1 = "1dfa364acc47225afdc57c8998c988bc107ff0d2"
+uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+version = "0.1.0"
 
 [[deps.MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "Random", "Sockets"]
@@ -1587,9 +1600,9 @@ version = "0.29.0+0"
 
 [[deps.gmsh_jll]]
 deps = ["Artifacts", "Cairo_jll", "CompilerSupportLibraries_jll", "FLTK_jll", "FreeType2_jll", "GLU_jll", "GMP_jll", "HDF5_jll", "JLLWrappers", "JpegTurbo_jll", "LLVMOpenMP_jll", "Libdl", "Libglvnd_jll", "METIS_jll", "MMG_jll", "OCCT_jll", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "Xorg_libXft_jll", "Xorg_libXinerama_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "9774ebf68348b3b56c74a78b829051310163fd76"
+git-tree-sha1 = "d4cf3bb87fa0669f569e51f6f06cd083771bab65"
 uuid = "630162c2-fc9b-58b3-9910-8442a8a132e6"
-version = "4.10.2+0"
+version = "4.10.2+1"
 
 [[deps.libaom_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/docs/src/literate/linear_shell.jl
+++ b/docs/src/literate/linear_shell.jl
@@ -64,7 +64,7 @@ close!(ch)
 update!(ch, 0.0)
 
 # Next we define relevant data for the shell, such as shear correction factor and stiffness matrix for the material. 
-# In this linear shell, plane stress is assumed, ie $\\sigma_{zz} = 0 $. Therefor, the stiffness matrix is 5x5 (opposed to the normal 6x6).
+# In this linear shell, plane stress is assumed, ie $\\sigma_{zz} = 0$. Therefor, the stiffness matrix is 5x5 (opposed to the normal 6x6).
 #+
 κ = 5/6 # Shear correction factor
 E = 210.0

--- a/docs/src/reference/boundary_conditions.md
+++ b/docs/src/reference/boundary_conditions.md
@@ -4,6 +4,10 @@ DocTestSetup = :(using Ferrite)
 
 # Boundary Conditions
 
+```@index
+Pages = ["boundary_conditions.md"]
+```
+
 ```@docs
 ConstraintHandler
 Dirichlet
@@ -14,6 +18,8 @@ add!
 close!
 apply!
 apply_zero!
+apply_local!
+apply_assemble!
 get_rhs_data
 apply_rhs!
 Ferrite.RHSData

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -199,6 +199,43 @@ end
 end
 
 
+## assemble! with local condensation ##
+
+"""
+    apply_assemble!(
+        assembler::AbstractSparseAssembler, ch::ConstraintHandler,
+        global_dofs::AbstractVector{Int},
+        local_matrix::AbstractMatrix, local_vector::AbstractVector;
+        apply_zero::Bool = false
+    )
+
+Assemble `local_matrix` and `local_vector` into the global system in `assembler` by first
+doing constraint condensation using [`apply_local!`](@ref).
+
+This is similar to using [`apply_local!`](@ref) followed by [`assemble!`](@ref) with the
+advantage that non-local constraints can be handled, since this method can write to entries
+of the global matrix and vector outside of the indices in `global_dofs`.
+
+When the keyword argument `apply_zero` is `true` all inhomogeneities are set to `0` (cf.
+[`apply!`](@ref) vs [`apply_zero!`](@ref)).
+
+Note that this method is destructive since it modifies `local_matrix` and `local_vector`.
+"""
+function apply_assemble!(
+        assembler::AbstractSparseAssembler, ch::ConstraintHandler,
+        global_dofs::AbstractVector{Int},
+        local_matrix::AbstractMatrix, local_vector::AbstractVector;
+        apply_zero::Bool = false
+    )
+    _apply_local!(
+        local_matrix, local_vector, global_dofs, ch, apply_zero,
+        getsparsemat(assembler), assembler.f
+    )
+    assemble!(assembler, global_dofs, local_matrix, local_vector)
+    return
+end
+
+
 # Sort utilities
 
 function sortperm2!(B, ii)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -124,6 +124,8 @@ export
     apply_rhs!,
     get_rhs_data,
     apply_zero!,
+    apply_local!,
+    apply_assemble!,
     add!,
     free_dofs,
     ApplyStrategy,


### PR DESCRIPTION
This patch adds functionality for applying constraints locally on the
element matrix/vector before assembling them into the global
matrix/vector. When doing local condensation there is no need to apply
constraints on the global system after the assembly. The main motivation
for this functionality is when using "write-only" global arrays (for
example some array type in an external library such as HYPRE) where it
is expensive or impractical to modify the array after assembling.

Local constraint condensation can be done with `apply_local!` or
`apply_assemble!`:

    apply_local!(local_matrix, local_vector, global_dofs, ch)

`apply_local!` can be used when all constraints are local to the element
(e.g. Dirichlet boundary constraints) since the constraints do not
couple to dofs outside the dofs of the element itself.

    apply_assemble!(assembler, global_dofs, local_matrix, local_vector)

`apply_assemble!` condensates constraints and assembles the result into
the global system, i.e. performs `apply_local!` + `assemble!`. The advantage
with `apply_assemble!` is that it handles general constraints since it has
access to the global matrix/vector and can write to entries outside the
local matrix when necessary.