### PR TITLE
Speed-boost for close!(dh::MixedDofHandler)

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -57,7 +57,8 @@ struct MixedDofHandler{dim,T,G<:AbstractGrid{dim}} <: AbstractDofHandler
 end
 
 function MixedDofHandler(grid::Grid{dim,C,T}) where {dim,C,T}
-    MixedDofHandler{dim,T,typeof(grid)}(FieldHandler[], CellVector(Int[],Int[],Int[]), CellVector(Int[],Int[],Int[]), CellVector(Vec{dim,T}[],Int[],Int[]), Ferrite.ScalarWrapper(false), grid, Ferrite.ScalarWrapper(-1))
+    ncells = getncells(grid)
+    MixedDofHandler{dim,T,typeof(grid)}(FieldHandler[], CellVector(Int[],zeros(Int,ncells),zeros(Int,ncells)), CellVector(Int[],Int[],Int[]), CellVector(Vec{dim,T}[],Int[],Int[]), Ferrite.ScalarWrapper(false), grid, Ferrite.ScalarWrapper(-1))
 end
 
 getfieldnames(fh::FieldHandler) = [field.name for field in fh.fields]
@@ -218,9 +219,6 @@ function __close!(dh::MixedDofHandler{dim}) where {dim}
 
     # Set initial values
     nextdof = 1  # next free dof to distribute
-
-    append!(dh.cell_dofs.offset, zeros(getncells(dh.grid)))
-    append!(dh.cell_dofs.length, zeros(getncells(dh.grid)))
 
     @debug "\n\nCreating dofs\n"
     for fh in dh.fieldhandlers

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -211,10 +211,10 @@ function __close!(dh::MixedDofHandler{dim}) where {dim}
 
     # Create dicts that store created dofs
     # Each key should uniquely identify the given type
-    vertexdicts = [Dict{Int, Array{Int}}() for _ in 1:numfields]
-    edgedicts = [Dict{Tuple{Int,Int}, Array{Int}}() for _ in 1:numfields]
-    facedicts = [Dict{Tuple{Int,Int}, Array{Int}}() for _ in 1:numfields]
-    celldicts = [Dict{Int, Array{Int}}() for _ in 1:numfields]
+    vertexdicts = [Dict{Int, UnitRange{Int}}() for _ in 1:numfields]
+    edgedicts = [Dict{Tuple{Int,Int}, UnitRange{Int}}() for _ in 1:numfields]
+    facedicts = [Dict{Tuple{Int,Int}, UnitRange{Int}}() for _ in 1:numfields]
+    celldicts = [Dict{Int, UnitRange{Int}}() for _ in 1:numfields]
 
     # Set initial values
     nextdof = 1  # next free dof to distribute
@@ -274,11 +274,12 @@ function _close!(dh::MixedDofHandler{dim}, cellnumbers, global_field_names, fiel
     end
 
     # loop over all the cells, and distribute dofs for all the fields
+    cell_dofs = Int[]  # list of global dofs for each cell
     for ci in cellnumbers
         dh.cell_dofs.offset[ci] = length(dh.cell_dofs.values)+1
 
         cell = dh.grid.cells[ci]
-        cell_dofs = Int[]  # list of global dofs for each cell
+        empty!(cell_dofs)
         @debug "Creating dofs for cell #$ci"
 
         for (local_num, field_name) in enumerate(field_names)
@@ -304,7 +305,7 @@ function _close!(dh::MixedDofHandler{dim}, cellnumbers, global_field_names, fiel
 
         end
         # after done creating dofs for the cell, push them to the global list
-        push!(dh.cell_dofs.values, cell_dofs...)
+        append!(dh.cell_dofs.values, cell_dofs)
         dh.cell_dofs.length[ci] = length(cell_dofs)
 
         @debug "Dofs for cell #$ci:\n\t$cell_dofs"
@@ -325,7 +326,7 @@ function get_or_create_dofs!(nextdof, field_dim; dict, key)
         return nextdof, dict[key]
 
     else  # create new dofs
-        dofs = collect(nextdof : nextdof + field_dim-1)
+        dofs = nextdof : (nextdof + field_dim-1)
         @debug "\t\tkey: $key dofs: $dofs"
         Base._setindex!(dict, dofs, key, -token) #
         nextdof += field_dim
@@ -337,7 +338,7 @@ function add_vertex_dofs(cell_dofs, cell, vertexdict, field_dim, nvertexdofs, ne
     for vertex in Ferrite.vertices(cell)
         @debug "\tvertex #$vertex"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=vertexdict, key=vertex)
-        push!(cell_dofs, dofs...)
+        append!(cell_dofs, dofs)
     end
     return nextdof
 end
@@ -349,7 +350,7 @@ function add_face_dofs(cell_dofs, cell, facedict, field_dim, nfacedofs, nextdof)
         sface = Ferrite.sortface(face)
         @debug "\tface #$sface"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=facedict, key=sface)
-        push!(cell_dofs, dofs...)
+        append!(cell_dofs, dofs)
     end
     return nextdof
 end
@@ -360,7 +361,7 @@ function add_edge_dofs(cell_dofs, cell, edgedict, field_dim, nedgedofs, nextdof)
         sedge, dir = Ferrite.sortedge(edge)
         @debug "\tedge #$sedge"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=edgedict, key=sedge)
-        push!(cell_dofs, dofs...)
+        append!(cell_dofs, dofs)
     end
     return nextdof
 end
@@ -369,7 +370,7 @@ function add_cell_dofs(cell_dofs, cell, celldict, field_dim, ncelldofs, nextdof)
     for celldof in 1:ncelldofs
         @debug "\tcell #$cell"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=celldict, key=cell)
-        push!(cell_dofs, dofs...)
+        append!(cell_dofs, dofs)
     end
     return nextdof
 end


### PR DESCRIPTION
Edges out a couple of anti-patterns in `close!(dh::MixedDofHandler)`. 

Example benchmark:
```
function construct_mixed_dof_handler(grid)
    mixed_dh = MixedDofHandler(grid)
    push!(mixed_dh, :f1, 1, Lagrange{2,RefCube,1}())
    push!(mixed_dh, :f2, 2, Lagrange{2,RefCube,1}())
    push!(mixed_dh, :f3, 1, Lagrange{2,RefCube,2}())
    close!(mixed_dh);
end
```
```
small_grid = generate_grid(Quadrilateral, (10, 10))
@btime construct_mixed_dof_handler($small_grid); 

# master: 196.791 μs (4493 allocations: 324.43 KiB)
# this PR: 52.959 μs (153 allocations: 186.04 KiB)
```
or for a bigger grid:
```
big_grid = generate_grid(Quadrilateral, (1000, 1000))
@btime construct_mixed_dof_handler($big_grid); 

# master: 3.821 s (70005918 allocations: 2.69 GiB)
# this PR: 1.229 s (454 allocations: 1.05 GiB)
```


_Sidenote_: Unfortunately the MixedDofHandler is still twice as slow as the DofHandler even with this PR, for comparison:
```
function construct_dof_handler(grid)
    dh = DofHandler(grid)
    push!(dh, :f1, 1, Lagrange{2,RefCube,1}())
    push!(dh, :f2, 2, Lagrange{2,RefCube,1}())
    push!(dh, :f3, 1, Lagrange{2,RefCube,2}())
    close!(dh)
end
@btime construct_dof_handler($small_grid) # 28.209 μs (140 allocations: 119.84 KiB)
@btime construct_dof_handler($big_grid) # 751.856 ms (341 allocations: 630.22 MiB)
```
