### PR TITLE
Quick fix for threaded assembly example on Julia 1.8

### DIFF
--- a/docs/src/literate/threaded_assembly.jl
+++ b/docs/src/literate/threaded_assembly.jl
@@ -127,7 +127,7 @@ function doassemble(K::SparseMatrixCSC, colors, grid::Grid, dh::DofHandler, C::S
 
     for color in colors
         ## Each color is safe to assemble threaded
-        Threads.@threads for i in 1:length(color)
+        Threads.@threads :static for i in 1:length(color)
             assemble_cell!(scratches[Threads.threadid()], color[i], K, grid, dh, C, b)
         end
     end


### PR DESCRIPTION
This guarantees the threaded assembly example to work correctly even on Julia 1.8. I am not really sure though what's the best practice pattern to use now - a channel with scratch values I guess?