### PR TITLE
Handle prescribed dofs in RHS of affine constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    always override any previous constraints. Conflicting constraints could previously cause
    problems when a DoF where prescribed by both `Dirichlet` and `AffineConstraint`.
    ([#529][github-529])
+### Fixed
+ - Fix affine constraints with prescribed dofs in the right-hand-side. In particular, dofs
+   that are prescribed by just an inhomogeneity are now handled correctly, and nested affine
+   constraints now give an error instead of silently giving the wrong result.
+   ([#530][github-530], [#535][github-535])
 
 ## [0.3.9] - 2022-10-19
 ### Added
@@ -153,6 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-514]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/514
 [github-524]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/524
 [github-529]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/529
+[github-530]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/530
+[github-535]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/535
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.9...HEAD
 [0.3.9]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.8...v0.3.9

--- a/docs/src/literate/stokes-flow.jl
+++ b/docs/src/literate/stokes-flow.jl
@@ -319,7 +319,7 @@ function setup_mean_constraint(dh, fvp)
     V ./= V[constrained_dof]
     mean_value_constraint = AffineConstraint(
         constrained_dof,
-        Pair{Int,Float64}[J[i] => -V[i] for i in 1:length(J) if i != constrained_dof],
+        Pair{Int,Float64}[J[i] => -V[i] for i in 1:length(J) if J[i] != constrained_dof],
         0.0,
     )
     return mean_value_constraint
@@ -460,7 +460,7 @@ function main()
     vtk_grid("stokes-flow", grid) do vtk
         vtk_point_data(vtk, dh, u)
     end
-    Sys.isapple() || @test norm(u) ≈ 0.32353713318639005 #src
+    Sys.isapple() || @test norm(u) ≈ 0.32254330524111213 #src
     return
 end
 #md nothing #hide


### PR DESCRIPTION
This patch fixes affine constraints with prescribed dofs in the RHS. In particular, we allow dofs that are prescribed by just an inhomogeneity (i.e. DBC) but disallow "nesting" affine constraints.

Concretely, consider e.g. the following two constraints:

    u2 = f(t)
    u3 = u2 + b3

Before this patch this was not handled correctly since the inhomogeneity for `u3` was taken as `b3`, but it should really be `b3 + f(t)` by substituting `u2` for `f(t)`. Since we allow for time-dependent inhomogeneities this substitution has to be done at runtime and not during `close!(::ConstraintHandler)`.

Nested constraints, e.g.

    u2 = u3
    u3 = u5

are still not allowed but in the future this can be resolved in `close!(::ConstraintHandler)` to

    u2 = u5
    u3 = u5

However, this patch checks for such nesting and raises an error instead of resulting in incorrect answers as is the case before.

Fixes #530.