### PR TITLE
Improve `get_coordinates!`

### DIFF
--- a/docs/src/manual/grid.md
+++ b/docs/src/manual/grid.md
@@ -168,7 +168,7 @@ Next, we define some helper functions that take care of the node handling.
 Ferrite.getnodes(grid::SmallGrid) = grid.nodes_test
 Ferrite.getnodes(grid::SmallGrid, v::Union{Int, Vector{Int}}) = grid.nodes_test[v]
 Ferrite.getnnodes(grid::SmallGrid) = length(grid.nodes_test)
-Ferrite.getnodenumbertype(::SmallGrid) = Float64
+Ferrite.get_coordinate_eltype(::SmallGrid) = Float64
 Ferrite.nnodes_per_cell(grid::SmallGrid, i::Int=1) = Ferrite.nnodes(grid.cells_test[i])
 Ferrite.n_faces_per_cell(grid::SmallGrid) = nfaces(eltype(grid.cells_test))
 ```

--- a/docs/src/manual/grid.md
+++ b/docs/src/manual/grid.md
@@ -168,26 +168,13 @@ Next, we define some helper functions that take care of the node handling.
 Ferrite.getnodes(grid::SmallGrid) = grid.nodes_test
 Ferrite.getnodes(grid::SmallGrid, v::Union{Int, Vector{Int}}) = grid.nodes_test[v]
 Ferrite.getnnodes(grid::SmallGrid) = length(grid.nodes_test)
+Ferrite.getnodenumbertype(::SmallGrid) = Float64
 Ferrite.nnodes_per_cell(grid::SmallGrid, i::Int=1) = Ferrite.nnodes(grid.cells_test[i])
 Ferrite.n_faces_per_cell(grid::SmallGrid) = nfaces(eltype(grid.cells_test))
 ```
 
-Finally, we define `getcoordinates`, which is an important function, if we want to assemble a problem.
-The transformation from the reference space to the physical one requires information about the coordinates in order to construct the
-Jacobian. The return of this part is later handled over to `reinit!`.
-
-```julia
-function Ferrite.getcoordinates!(x::Vector{Vec{dim,T}}, grid::SmallGrid, cell::Int) where {dim,T}
-    for i in 1:length(x)
-        x[i] = Vec{dim,T}(grid.nodes_test[grid.cells_test[cell].nodes[i]])
-    end
-end
-
-function Ferrite.getcoordinates(grid::SmallGrid{dim}, cell::Int) where dim
-    nodeidx = grid.cells_test[cell].nodes
-    return [Vec{dim,Float64}(grid.nodes_test[i]) for i in nodeidx]::Vector{Vec{dim,Float64}}
-end
-```
+These definitions make many of `Ferrite`s functions work out of the box, e.g. you can now call 
+`getcoordinates(grid, cellid)` on the `SmallGrid`. 
 
 Now, you would be able to assemble the heat equation example over the new custom `SmallGrid` type.
 Note that this particular subtype isn't able to handle boundary entity sets and so, you can't describe boundaries with it.

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -312,16 +312,6 @@ function cellnodes!(global_nodes::Vector{Int}, grid::AbstractGrid{dim}, i::Int) 
     return global_nodes
 end
 
-function cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid{dim}, i::Int) where {dim,T}
-    nodes = getcells(grid,i).nodes
-    N = length(nodes)
-    @assert length(global_coords) == N
-    for j in 1:N
-        global_coords[j] = getcoordinates(getnodes(grid,nodes[j]))
-    end
-    return global_coords
-end
-
 cellcoords!(global_coords::Vector{<:Vec}, dh::DofHandler, i::Int) = cellcoords!(global_coords, dh.grid, i)
 
 function celldofs(dh::DofHandler, i::Int)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -14,7 +14,7 @@ struct Node{dim,T}
 end
 Node(x::NTuple{dim,T}) where {dim,T} = Node(Vec{dim,T}(x))
 getcoordinates(n::Node) = n.x
-
+getnodenumbertype(::Node{dim,T}) where {dim,T} = T
 
 abstract type AbstractCell{dim,N,M} end
 """
@@ -429,6 +429,8 @@ to a Node.
 @inline getnnodes(grid::AbstractGrid) = length(grid.nodes)
 "Returns the number of nodes of the `i`-th cell."
 @inline nnodes_per_cell(grid::AbstractGrid, i::Int=1) = nnodes(grid.cells[i])
+"Return the number type of the nodal coordinates."
+@inline getnodenumbertype(grid::AbstractGrid) = getnodenumbertype(first(getnodes(grid)))
 
 """
     getcellset(grid::AbstractGrid, setname::String)
@@ -677,7 +679,7 @@ end
 
 @inline function getcoordinates!(x::Vector{Vec{dim,T}}, grid::Ferrite.AbstractGrid, cell::Ferrite.AbstractCell) where {dim,T}
     @inbounds for i in 1:length(x)
-        x[i] = grid.nodes[cell.nodes[i]].x
+        x[i] = getcoordinates(getnodes(grid, cell.nodes[i]))
     end
     return x
 end
@@ -691,7 +693,7 @@ Return a vector with the coordinates of the vertices of cell number `cell`.
 """
 @inline function getcoordinates(grid::AbstractGrid, cell::Int)
     dim = getdim(grid)
-    T = typeof(grid).parameters[3] #TODO: should be part of the grid interface
+    T = getnodenumbertype(grid)
     _cell = getcells(grid, cell)
     N = nnodes(_cell)
     x = Vector{Vec{dim, T}}(undef, N)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -687,6 +687,9 @@ end
 @inline getcoordinates!(x::Vector{Vec{dim,T}}, grid::AbstractGrid, cell::CellIndex) where {dim, T} = getcoordinates!(x, grid, cell.idx)
 @inline getcoordinates!(x::Vector{Vec{dim,T}}, grid::AbstractGrid, face::FaceIndex) where {dim, T} = getcoordinates!(x, grid, face.idx[1])
 
+# TODO: Deprecate one of `cellcoords!` and `getcoordinates!`, as they do the same thing
+cellcoords!(global_coords::Vector{Vec{dim,T}}, grid::AbstractGrid{dim}, i::Int) where {dim,T} = getcoordinates!(global_coords, grid, i) 
+
 """
     getcoordinates(grid::AbstractGrid, cell)
 Return a vector with the coordinates of the vertices of cell number `cell`.

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -14,7 +14,7 @@ struct Node{dim,T}
 end
 Node(x::NTuple{dim,T}) where {dim,T} = Node(Vec{dim,T}(x))
 getcoordinates(n::Node) = n.x
-getnodenumbertype(::Node{dim,T}) where {dim,T} = T
+get_coordinate_eltype(::Node{dim,T}) where {dim,T} = T
 
 abstract type AbstractCell{dim,N,M} end
 """
@@ -430,7 +430,7 @@ to a Node.
 "Returns the number of nodes of the `i`-th cell."
 @inline nnodes_per_cell(grid::AbstractGrid, i::Int=1) = nnodes(grid.cells[i])
 "Return the number type of the nodal coordinates."
-@inline getnodenumbertype(grid::AbstractGrid) = getnodenumbertype(first(getnodes(grid)))
+@inline get_coordinate_eltype(grid::AbstractGrid) = get_coordinate_eltype(first(getnodes(grid)))
 
 """
     getcellset(grid::AbstractGrid, setname::String)
@@ -696,7 +696,7 @@ Return a vector with the coordinates of the vertices of cell number `cell`.
 """
 @inline function getcoordinates(grid::AbstractGrid, cell::Int)
     dim = getdim(grid)
-    T = getnodenumbertype(grid)
+    T = get_coordinate_eltype(grid)
     _cell = getcells(grid, cell)
     N = nnodes(_cell)
     x = Vector{Vec{dim, T}}(undef, N)

--- a/test/test_abstractgrid.jl
+++ b/test/test_abstractgrid.jl
@@ -15,7 +15,7 @@
     Ferrite.getnodes(grid::SmallGrid) = grid.nodes_test
     Ferrite.getnodes(grid::SmallGrid, v::Union{Int, Vector{Int}}) = grid.nodes_test[v]
     Ferrite.getnnodes(grid::SmallGrid) = length(grid.nodes_test)
-    Ferrite.getnodenumbertype(::SmallGrid) = Float64
+    Ferrite.get_coordinate_eltype(::SmallGrid) = Float64
     Ferrite.nnodes_per_cell(grid::SmallGrid, i::Int=1) = Ferrite.nnodes(grid.cells_test[i])
     Ferrite.n_faces_per_cell(grid::SmallGrid) = nfaces(eltype(grid.cells_test))
 

--- a/test/test_abstractgrid.jl
+++ b/test/test_abstractgrid.jl
@@ -15,17 +15,9 @@
     Ferrite.getnodes(grid::SmallGrid) = grid.nodes_test
     Ferrite.getnodes(grid::SmallGrid, v::Union{Int, Vector{Int}}) = grid.nodes_test[v]
     Ferrite.getnnodes(grid::SmallGrid) = length(grid.nodes_test)
+    Ferrite.getnodenumbertype(::SmallGrid) = Float64
     Ferrite.nnodes_per_cell(grid::SmallGrid, i::Int=1) = Ferrite.nnodes(grid.cells_test[i])
     Ferrite.n_faces_per_cell(grid::SmallGrid) = nfaces(eltype(grid.cells_test))
-    function Ferrite.getcoordinates!(x::Vector{Vec{dim,T}}, grid::SmallGrid, cell::Int) where {dim,T}
-        for i in 1:length(x)
-            x[i] = Vec{dim,T}(grid.nodes_test[grid.cells_test[cell].nodes[i]])
-        end
-    end
-    function Ferrite.getcoordinates(grid::SmallGrid{dim}, cell::Int) where dim
-        nodeidx = grid.cells_test[cell].nodes
-        return [Vec{dim,Float64}(grid.nodes_test[i]) for i in nodeidx]::Vector{Vec{dim,Float64}}
-    end
 
     nodes = [(-1.0,-1.0); (0.0,-1.0); (1.0,-1.0); (-1.0,0.0); (0.0,0.0); (1.0,0.0); (-1.0,1.0); (0.0,1.0); (1.0,1.0)]
     cells = (Quadrilateral((1,2,5,4)), Quadrilateral((2,3,6,5)), Quadrilateral((4,5,8,7)), Quadrilateral((5,6,9,8)))


### PR DESCRIPTION
Small improvements on the definition of `getcoordinates!`. In particular:
-  Compatible with `AbstractGrid` interface . See the `SmallGrid` example from the docs, that doesn't need to define `cellcoords!` anymore
-  Reduce code duplication. There is `getcoordinates!` working on grids and `cellcoords!` working on dofhandlers (but also on grids...). For `DofHandler` both fall back to one definition with this PR. We should deprecate one of them in the future. 
- Slightly better performance for coordinate queries on mixed grids. See micro-benchmarks below.

# Coordinate query benchmarks
This PR is part of making an effort to join the two different dofhandlers. Therefore, here are some interesting performance investigations on querying coordinates:
## Regular grid
The difference on a standard non-mixed grid is minor:
Regular Grid | #PR | #master
--- | --- | ---                                                      
`getcoordinates!(xe, grid, cellid)` |  4.291 ns (0 allocations: 0 bytes) | 4.584 ns (0 allocations: 0 bytes)                                                                     
`Ferrite.cellcoords!(xe, grid, cellid)` |   4.250 ns (0 allocations: 0 bytes) | 4.875 ns (0 allocations: 0 bytes)                                                     
`Ferrite.cellcoords!(xe, dh, cellid)` |   4.291 ns (0 allocations: 0 bytes) | 5.208 ns (0 allocations: 0 bytes) 

## Mixed grid
The PR performs much better than master on querying coordinates directly from the grid for a cell vector of type `AbstractCell`. However, that is still about twice as slow compared to querying coordinates from the `MixedDofHandler`.

`AbstractCell` | #PR | #master
--- | --- | ---                                                      
`getcoordinates!(xe, grid, cellid)` | 44.147 ns (0 allocations: 0 bytes) | 1.262 μs (20 allocations: 704 bytes)                                                   
`Ferrite.cellcoords!(xe, grid, cellid)` | 43.875 ns (0 allocations: 0 bytes) | 1.2 μs (14 allocations: 464 bytes)                                    
`Ferrite.cellcoords!(xe, dh, cellid)` | 20.687 ns (0 allocations: 0 bytes) | 20.687 ns (0 allocations: 0 bytes) 

_Notice:
For mixed grids (and thus `MixedDofHandler`) `cellcoords!(xe, dh, cellid)` is unchanged between the PR and master._

The more interesting result is that when using a union type for the cell vector instead of `AbstractCell`, the coordinate query from the grid is almost as fast as for a non-mixed grid and faster than querying the coordinates from the `MixedDofHandler`. (In fact, this has been the case even on master.)

I got similar results for grids with 4 and 5 different cell types, compare the benchmark code below. This surprised me, because I thought this worked well due to union splitting, [which seems to cover up to 4 types]( https://github.com/JuliaLang/julia/blob/3510eeb4c99b6daa42a27d0f7d96be8af21067ac/base/compiler/types.jl#L155). Perhaps someone can explain that. 🙂 
`Union{Quadrilateral, Triangle, Line}` | #PR | #master
--- | --- | ---                                                      
`getcoordinates!(xe, grid, cellid)` | 4.583 ns (0 allocations: 0 bytes) | 5.583 ns (0 allocations: 0 bytes)                                         
`Ferrite.cellcoords!(xe, grid, cellid)` | 5.541 ns (0 allocations: 0 bytes) | 7.083 ns (0 allocations: 0 bytes)                         
`Ferrite.cellcoords!(xe, dh, cellid)` | 20.645 ns (0 allocations: 0 bytes) | 20.687 ns (0 allocations: 0 bytes)

**Take away message:
As long as the cell vector is well typed, there seems to be no need for a specialized coordinate query for mixed grids (at least up to 5 different cell types). That would mean we could remove the grid representation from the `MixedDofHandler` and have it fall back to querying the coordinates directly from its grid as well. That would be a major step towards joining the dofhandlers.**


<details>
<summary>Benchmark code</summary>

```Julia
using Ferrite
using BenchmarkTools

xe = Vector{Vec{2,Float64}}(undef, 4)

# concrete grid
grid = generate_grid(Quadrilateral, (10, 10))
dh = DofHandler(grid)
push!(dh, :u, 2)
close!(dh)

cellid = 57

println("Regular Grid:")
print("getcoordinates(xe, grid, cellid): ");
@btime getcoordinates!($xe, $grid, $cellid) 
print("Ferrite.cellcoords!(xe, grid, cellid): ");
@btime Ferrite.cellcoords!($xe, $grid, $cellid) 
print("Ferrite.cellcoords!(xe, dh, cellid): ");
@btime Ferrite.cellcoords!($xe, $dh, $cellid) 

##############################################################
# Performance for mixed grids
##############################################################
# grid with AbstractCell vector
union3_cells = Union{Quadrilateral, Triangle, Line}[c for c in vcat(grid.cells, [Triangle(cell.nodes[1:3]) for cell in grid.cells], [Line(cell.nodes[1:2]) for cell in grid.cells])]
abstract_cells = Ferrite.AbstractCell[c for c in union3_cells]
grid_abstract = Grid(abstract_cells, grid.nodes)
dh_abstract = MixedDofHandler(grid_abstract)
field = Field(:u, Lagrange{2,RefCube,1}(), 2)
push!(dh_abstract, FieldHandler([field], Set(1:getncells(grid))))
close!(dh_abstract)

println()
println("Mixed Grid, AbstractCell")
print("getcoordinates(xe, grid, cellid): ");
@btime getcoordinates!($xe, $grid_abstract, $cellid) 
print("Ferrite.cellcoords!(xe, grid, cellid): ");
@btime Ferrite.cellcoords!($xe, $grid_abstract, $cellid) 
print("Ferrite.cellcoords!(xe, dh, cellid): ");
@btime Ferrite.cellcoords!($xe, $dh_abstract, $cellid)

# grid with 3 cell types
union3_cells = Union{Quadrilateral, Triangle, Line}[c for c in vcat(grid.cells, [Triangle(cell.nodes[1:3]) for cell in grid.cells], [Line(cell.nodes[1:2]) for cell in grid.cells])]
grid_union3 = Grid(union3_cells, grid.nodes)
dh_union3 = MixedDofHandler(grid_union3)
field = Field(:u, Lagrange{2,RefCube,1}(), 2)
push!(dh_union3, FieldHandler([field], Set(1:getncells(grid))))
close!(dh_union3)

println()
println("Mixed Grid, Union{Quadrilateral, Triangle, Line}")
print("getcoordinates(xe, grid, cellid): ");
@btime getcoordinates!($xe, $grid_union3, $cellid)
print("Ferrite.cellcoords!(xe, grid, cellid): ");
@btime Ferrite.cellcoords!($xe, $grid_union3, $cellid)
print("Ferrite.cellcoords!(xe, dh, cellid): ");
@btime Ferrite.cellcoords!($xe, $dh_union3, $cellid); 


# grid with 4 cell types
union4_cells = Union{Quadrilateral, Triangle, Line, QuadraticLine}[c for c in vcat(
                    grid.cells,
                    [Triangle(cell.nodes[1:3]) for cell in grid.cells],
                    [Line(cell.nodes[1:2]) for cell in grid.cells],
                    [QuadraticLine(cell.nodes[1:3]) for cell in grid.cells],
                   )]
grid_union4 = Grid(union4_cells, grid.nodes)
dh_union4 = MixedDofHandler(grid_union4)
field = Field(:u, Lagrange{2,RefCube,1}(), 2)
push!(dh_union4, FieldHandler([field], Set(1:getncells(grid))))
close!(dh_union4)

println()
println("Mixed Grid, Union{Quadrilateral, Triangle, Line, Quadratic}")
print("getcoordinates(xe, grid, cellid): ");
@btime getcoordinates!($xe, $grid_union4, $cellid)
print("Ferrite.cellcoords!(xe, grid, cellid): ");
@btime Ferrite.cellcoords!($xe, $grid_union4, $cellid)
print("Ferrite.cellcoords!(xe, dh, cellid): ");
@btime Ferrite.cellcoords!($xe, $dh_union4, $cellid); 

# ?? Union splitting only does up to 4 types: https://github.com/JuliaLang/julia/blob/3510eeb4c99b6daa42a27d0f7d96be8af21067ac/base/compiler/types.jl#L155
# grid with 5 cell types
union5_cells = Union{Quadrilateral, Triangle, Line, QuadraticLine, Line2D}[c for c in vcat(
                    grid.cells,
                    [Triangle(cell.nodes[1:3]) for cell in grid.cells],
                    [Line(cell.nodes[1:2]) for cell in grid.cells],
                    [QuadraticLine(cell.nodes[1:3]) for cell in grid.cells],
                    [Line2D(cell.nodes[1:2]) for cell in grid.cells],
                   )]
grid_union5 = Grid(union5_cells, grid.nodes)
dh_union5 = MixedDofHandler(grid_union5)
field = Field(:u, Lagrange{2,RefCube,1}(), 2)
push!(dh_union5, FieldHandler([field], Set(1:getncells(grid))))
close!(dh_union5)

println()
println("Mixed Grid, Union{Quadrilateral, Triangle, Line, Quadratic, Line2D}")
print("getcoordinates(xe, grid, cellid): ");
@btime getcoordinates!($xe, $grid_union5, $cellid)
print("Ferrite.cellcoords!(xe, grid, cellid): ");
@btime Ferrite.cellcoords!($xe, $grid_union5, $cellid)
print("Ferrite.cellcoords!(xe, dh, cellid): ");
@btime Ferrite.cellcoords!($xe, $dh_union5, $cellid);  
```

</details>