### PR TITLE
Remove some unnecessary allocations in affine constraint condensation

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -686,7 +686,7 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
         col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, col)
         if col_coeffs === nothing
             for ri in nzrange(K, col)
-                row = @inbounds K.rowval[ri]
+                row = K.rowval[ri]
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 row_coeffs === nothing && continue
                 for (d, _) in row_coeffs
@@ -698,7 +698,7 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
             end
         else
             for ri in nzrange(K, col)
-                row = @inbounds K.rowval[ri]
+                row = K.rowval[ri]
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 if row_coeffs === nothing
                     for (d, _) in col_coeffs

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -683,13 +683,10 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
 
     cnt = 0
     for col in 1:ndofs
-        # Since we will possibly be pushing new entries to K, the field K.rowval will grow.
-        # Therefor we must extract this before iterating over K
-        range = nzrange(K, col)
-        _rows = K.rowval[range]
         col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, col)
         if col_coeffs === nothing
-            for row in _rows
+            for ri in nzrange(K, col)
+                row = @inbounds K.rowval[ri]
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 row_coeffs === nothing && continue
                 for (d, _) in row_coeffs
@@ -700,7 +697,8 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
                 end
             end
         else
-            for row in _rows
+            for ri in nzrange(K, col)
+                row = @inbounds K.rowval[ri]
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 if row_coeffs === nothing
                     for (d, _) in col_coeffs


### PR DESCRIPTION
This patch removes some unnecessary allocations of a sparse matrix column which was needed before when the sparse matrix changed in-place. Since #436 we create a new matrix for the new entries and then add them in the end instead.

Comparison for the Stoke example in the docs:
- Master:
  ```julia
  julia> @time create_sparsity_pattern(dh, ch);
    0.009940 seconds (2.91 k allocations: 13.387 MiB)
  ```
- PR:
  ```julia
  julia> @time create_sparsity_pattern(dh, ch);
    0.004960 seconds (66 allocations: 12.581 MiB)
  ```