### PR TITLE
Specifying coupling between fields/components in `create_sparsity_pattern`

### DIFF
--- a/docs/src/literate/stokes-flow.jl
+++ b/docs/src/literate/stokes-flow.jl
@@ -448,7 +448,8 @@ function main()
     ## Boundary conditions
     ch = setup_constraints(dh, fvp)
     ## Global tangent matrix and rhs
-    K = create_sparsity_pattern(dh, ch)
+    coupling = [true true; true false] # no coupling between pressure test/trial functions
+    K = create_sparsity_pattern(dh, ch; coupling=coupling)
     f = zeros(ndofs(dh))
     ## Assemble system
     assemble_system!(K, f, dh, cvu, cvp)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -934,8 +934,10 @@ function _check_cellset_dirichlet(grid::AbstractGrid, cellset::Set{Int}, nodeset
     end
 end
 
-create_symmetric_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler) = Symmetric(_create_sparsity_pattern(dh, ch, true), :U)
-create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler) = _create_sparsity_pattern(dh, ch, false)
+create_symmetric_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler; coupling=nothing) =
+    Symmetric(_create_sparsity_pattern(dh, ch, true, coupling), :U)
+create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler; coupling=nothing) =
+    _create_sparsity_pattern(dh, ch, false, coupling)
 
 struct PeriodicFacePair
     mirror::FaceIndex


### PR DESCRIPTION
This patch implements a new keyword argument `coupling` to `create_sparsity_pattern` where the coupling between fields or components in the DofHandler can be specified. `coupling` should be a matrix of booleans, where rows are test functions and columns the unknowns. Consider for example a system with (u, p) as unknowns, and (v, q) as the corresponding test functions. If there is no coupling between e.g. p and q the coupling matrix would be
```
    u      p
    -------------
v  | true  true
q  | true  false
```

i.e. `coupling = [true true; true false]`. The coupling can also be specified component wise (if one of the fields have multiple components). For example, if (u, v) have two components, the equivalent coupling specified by components would be
```
     u1     u2    p
    ------------------
v1 | true  true  true
v2 | true  true  true
q  | true  true  false
```

The resulting sparsity pattern will not have entries for components that do not couple. By default full coupling is assumed (just like before).