### PR TITLE
Rework CellIterator by extracting out the caching part

### DIFF
--- a/docs/src/reference/dofhandler.md
+++ b/docs/src/reference/dofhandler.md
@@ -35,5 +35,6 @@ Ferrite.getfielddim(::MixedDofHandler, ::Symbol)
 
 # CellIterator
 ```@docs
+CellCache
 CellIterator
 ```

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -474,11 +474,10 @@ function reshape_to_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol) where
     return data
 end
 
-function reshape_field_data!(data::Matrix{T}, dh::AbstractDofHandler, u::Vector{T}, field_offset::Int, field_dim::Int, cellset=Set{Int}(1:getncells(dh.grid))) where T
+function reshape_field_data!(data::Matrix{T}, dh::AbstractDofHandler, u::Vector{T}, field_offset::Int, field_dim::Int, cellset=1:getncells(dh.grid)) where T
 
-    _celldofs = Vector{Int}(undef, ndofs_per_cell(dh, first(cellset)))
-    for cell in CellIterator(dh, collect(cellset))
-        celldofs!( _celldofs, cell)
+    for cell in CellIterator(dh, cellset, UpdateFlags(; nodes=true, coords=false, dofs=true))
+        _celldofs = celldofs(cell)
         counter = 1
         for node in getnodes(cell)
             for d in 1:field_dim

--- a/src/Dofs/DofRenumbering.jl
+++ b/src/Dofs/DofRenumbering.jl
@@ -176,8 +176,8 @@ function compute_renumber_permutation(dh::DofHandler, _, order::DofOrder.Compone
     dofs_for_blocks = [Set{Int}() for _ in 1:nblocks]
     dof_ranges = [dof_range(dh, f) for f in dh.field_names]
     component_offsets = pushfirst!(cumsum(dh.field_dims), 0)
-    flags = UpdateFlags(nodes=false, coords=false, celldofs=true)
-    @inbounds for cell in CellIterator(dh, #=cellset=# nothing, flags)
+    flags = UpdateFlags(nodes=false, coords=false, dofs=true)
+    @inbounds for cell in CellIterator(dh, flags)
         cdofs = celldofs(cell)
         for i in eachindex(dh.field_names)
             rng = dof_ranges[i]

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -39,7 +39,9 @@ end
 @noinline function throw_incompatible_coord_length(length_x, n_base_funcs)
     throw(ArgumentError(
         "the number of (geometric) base functions ($(n_base_funcs)) does not match " *
-        "the number of coordinates in the vector ($(length_x))."
+        "the number of coordinates in the vector ($(length_x)). Perhaps you forgot to " *
+        "use an appropriate geometric interpolation when creating FE values? See " *
+        "https://github.com/Ferrite-FEM/Ferrite.jl/issues/265 for more details."
     ))
 end
 

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -290,10 +290,9 @@ function reshape_to_nodes(proj::L2Projector, vals::AbstractVector{S}) where {ord
     @assert ndofs(dh) == length(vals)
     nout = S <: Vec{2} ? 3 : M # Pad 2D Vec to 3D
     data = fill(T(NaN), nout, getnnodes(dh.grid))
-    _celldofs = Vector{Int}(undef, ndofs_per_cell(dh, first(proj.set)))
     for cell in CellIterator(dh, proj.set)
+        _celldofs = celldofs(cell)
         @assert length(getnodes(cell)) == length(_celldofs)
-        celldofs!(_celldofs, cell)
         for (node, dof) in zip(getnodes(cell), _celldofs)
             v = @view data[:, node]
             fill!(v, 0) # remove NaNs for this node

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -132,6 +132,7 @@ export
     ApplyStrategy,
 
 # iterators
+    CellCache,
     CellIterator,
     UpdateFlags,
     cellid,

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,145 +1,190 @@
-# this file defines iterators used for looping over a grid
+# This file defines iterators used for looping over a grid
+
 struct UpdateFlags
     nodes::Bool
     coords::Bool
-    celldofs::Bool
+    dofs::Bool
 end
 
-UpdateFlags(; nodes::Bool=true, coords::Bool=true, celldofs::Bool=true) =
-    UpdateFlags(nodes, coords, celldofs)
+UpdateFlags(; nodes::Bool=true, coords::Bool=true, dofs::Bool=true) =
+    UpdateFlags(nodes, coords, dofs)
+
+
+###############
+## CellCache ##
+###############
 
 """
-    CellIterator(grid::Grid)
-    CellIterator(dh::DofHandler)
-    CellIterator(mdh::MixedDofHandler)
+    CellCache(grid::Grid)
+    CellCache(dh::AbstractDofHandler)
 
-Return a `CellIterator` to conveniently loop over all the cells in a grid.
+Create a cache object with pre-allocated memory for the nodes, coordinates, and dofs of a
+cell. The cache is updated for a new cell by calling `reinit!(cache, cellid)` where
+`cellid::Int` is the cell id.
 
-# Examples
-```julia
-for cell in CellIterator(dh)      # dh::DofHandler
-    coords = getcoordinates(cell) # get the coordinates
-    dofs = celldofs(cell)         # get the dofs for this cell
-    reinit!(cv, cell)             # reinit! the FE-base with a CellIterator
-end
-```
-Here, `cell::CellIterator`. Looking at a specific cell (instead of 
-looping over all), e.g. nr 10, can be done by
-```julia
-cell = CellIterator(dh)     # Uninitialized upon creation
-reinit!(cell, 10)           # Update to cell nr. 10
-dofs = celldofs(cell)       # Get the dofs for cell nr. 10
-```
+**Struct fields of `CellCache`**
+ - `cc.nodes :: Vector{Int}`: global node ids
+ - `cc.coords :: Vector{<:Vec}`: node coordinates
+ - `cc.dofs :: Vector{Int}`: global dof ids (empty when constructing the cache from a grid)
+
+**Methods with `CellCache`**
+ - `reinit!(cc, i)`: reinitialize the cache for cell `i`
+ - `cellid(cc)`: get the cell id of the currently cached cell
+ - `getnodes(cc)`: get the global node ids of the cell
+ - `getcoordinates(cc)`: get the coordinates of the cell
+ - `celldofs(cc)`: get the global dof ids of the cell
+ - `reinit!(fev, cc)`: reinitialize [`CellValues`](@ref) or [`FaceValues`](@ref)
+
+See also [`CellIterator`](@ref).
 """
-struct CellIterator{dim,C,T,DH<:Union{AbstractDofHandler,Nothing}}
+struct CellCache{X,G<:AbstractGrid,DH<:Union{AbstractDofHandler,Nothing}}
     flags::UpdateFlags
-    grid::Grid{dim,C,T}
-    current_cellid::ScalarWrapper{Int}
+    grid::G
+    # Pretty useless to store this since you have it already for the reinit! call, but
+    # needed for the CellIterator(...) workflow since the user doesn't necessarily control
+    # the loop order in the cell subset.
+    cellid::ScalarWrapper{Int}
     nodes::Vector{Int}
-    coords::Vector{Vec{dim,T}}
-    cellset::Union{Vector{Int},Nothing}
-    dh::Union{DH,Nothing}
-    celldofs::Vector{Int}
-
-    function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,T,G},MixedDofHandler{dim,T,G},Nothing}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T,G}
-        isconcretetype(C) || _check_same_celltype(dh.grid, cellset)
-        N = nnodes_per_cell(dh.grid, cellset === nothing ? 1 : first(cellset))
-        cell = ScalarWrapper(0)
-        nodes = zeros(Int, N)
-        coords = zeros(Vec{dim,T}, N)
-        n = ndofs_per_cell(dh, cellset === nothing ? 1 : first(cellset))
-        celldofs = zeros(Int, n)
-        return new{dim,C,T,typeof(dh)}(flags, dh.grid, cell, nodes, coords, cellset, dh, celldofs)
-    end
-
-    function CellIterator{dim,C,T}(grid::Grid{dim,C,T}, cellset::Union{AbstractVector{Int},Nothing}, flags::UpdateFlags) where {dim,C,T}
-        isconcretetype(C) || _check_same_celltype(grid, cellset)
-        N = nnodes_per_cell(grid, cellset === nothing ? 1 : first(cellset))
-        cell = ScalarWrapper(0)
-        nodes = zeros(Int, N)
-        coords = zeros(Vec{dim,T}, N)
-        return new{dim,C,T,Nothing}(flags, grid, cell, nodes, coords, cellset)
-    end
+    coords::Vector{X}
+    dh::DH
+    dofs::Vector{Int}
 end
 
-CellIterator(grid::Grid{dim,C,T}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,C,T} =
-    CellIterator{dim,C,T}(grid, cellset, flags)
-CellIterator(dh::DofHandler{dim,T}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,T} =
-    CellIterator{dim,getcelltype(dh.grid),T}(dh, cellset, flags)
-CellIterator(dh::MixedDofHandler{dim,T}, cellset::Union{AbstractVector{Int},Nothing}=nothing, flags::UpdateFlags=UpdateFlags()) where {dim,T} =
-    CellIterator{dim,getcelltype(dh.grid),T}(dh, cellset, flags)
-
-# iterator interface
-function Base.iterate(ci::CellIterator, state = 1)
-    if state > (ci.cellset === nothing ? getncells(ci.grid) : length(ci.cellset))
-        return nothing
-    else
-        return (reinit!(ci, state), state+1)
-    end
-end
-Base.length(ci::CellIterator)  = ci.cellset === nothing ? length(ci.grid.cells) : length(ci.cellset)
-
-Base.IteratorSize(::Type{T})   where {T<:CellIterator} = Base.HasLength() # this is default in Base
-Base.IteratorEltype(::Type{T}) where {T<:CellIterator} = Base.HasEltype() # this is default in Base
-Base.eltype(::Type{T})         where {T<:CellIterator} = T
-
-# utility
-@inline getnodes(ci::CellIterator) = ci.nodes
-@inline getcoordinates(ci::CellIterator) = ci.coords
-@inline nfaces(ci::CellIterator) = nfaces(eltype(ci.grid.cells))
-@inline onboundary(ci::CellIterator, face::Int) = ci.grid.boundary_matrix[face, ci.current_cellid[]]
-@inline cellid(ci::CellIterator) = ci.current_cellid[]
-@inline celldofs!(v::Vector, ci::CellIterator) = celldofs!(v, ci.dh, ci.current_cellid[])
-@inline celldofs(ci::CellIterator) = ci.celldofs
-
-function reinit!(ci::CellIterator{dim,C}, i::Int) where {dim,C}
-    ci.current_cellid[] = ci.cellset === nothing ? i : ci.cellset[i]
-
-    if ci.flags.nodes
-        if ci.dh !== nothing && ci.dh isa MixedDofHandler
-            cellnodes!(ci.nodes, ci.dh, ci.current_cellid[])
-        else
-            cellnodes!(ci.nodes, ci.grid, ci.current_cellid[])
-        end
-    end
-    if ci.flags.coords
-        if ci.dh !== nothing && ci.dh isa MixedDofHandler
-            cellcoords!(ci.coords, ci.dh, ci.current_cellid[])
-        else
-            cellcoords!(ci.coords, ci.grid, ci.current_cellid[])
-        end
-    end
-
-    if ci.dh !== nothing && ci.flags.celldofs # update celldofs
-        celldofs!(ci.celldofs, ci.dh, ci.current_cellid[])
-    end
-    return ci
+function CellCache(grid::Grid{dim,C,T}, flags::UpdateFlags=UpdateFlags()) where {dim,C,T}
+    N = nnodes_per_cell(grid)
+    nodes = zeros(Int, N)
+    coords = zeros(Vec{dim,T}, N)
+    return CellCache(flags, grid, ScalarWrapper(-1), nodes, coords, nothing, Int[])
 end
 
-function check_compatible_geointerpolation(cv::Union{CellValues, FaceValues}, ci::CellIterator)
-    if length(getnodes(ci)) != getngeobasefunctions(cv)
-        msg = """The given CellValues and CellIterator are incompatiblet.
-        Likely an appropriate geometry interpolate must be passed when constructing the CellValues.
-        See also issue #265: https://github.com/Ferrite-FEM/Ferrite.jl/issues/265"""
-        throw(ArgumentError(msg))
+function CellCache(dh::Union{DofHandler{dim,T},MixedDofHandler{dim,T}}, flags::UpdateFlags=UpdateFlags()) where {dim,T}
+    N = nnodes_per_cell(dh.grid)
+    nodes = zeros(Int, N)
+    coords = zeros(Vec{dim,T}, N)
+    n = ndofs_per_cell(dh)
+    celldofs = zeros(Int, n)
+    return CellCache(flags, dh.grid, ScalarWrapper(-1), nodes, coords, dh, celldofs)
+end
+
+# TODO: Can always resize and combine the two reinit! methods maybe?
+function reinit!(cc::CellCache, i::Int)
+    cc.cellid[] = i
+    if cc.flags.nodes
+        cellnodes!(cc.nodes, cc.grid, i)
     end
+    if cc.flags.coords
+        cellcoords!(cc.coords, cc.grid, i)
+    end
+    if cc.dh !== nothing && cc.flags.dofs
+        @assert cc.dh isa DofHandler
+        celldofs!(cc.dofs, cc.dh, i)
+    end
+    return cc
+end
+function reinit!(cc::CellCache{<:Any,<:AbstractGrid,<:MixedDofHandler}, i::Int)
+    @assert cc.dh isa MixedDofHandler
+    cc.cellid[] = i
+    if cc.flags.nodes
+        resize!(cc.nodes, nnodes_per_cell(cc.dh, i))
+        cellnodes!(cc.nodes, cc.dh, i)
+    end
+    if cc.flags.coords
+        resize!(cc.coords, nnodes_per_cell(cc.dh, i))
+        cellcoords!(cc.coords, cc.dh, i)
+    end
+    if cc.flags.dofs
+        resize!(cc.dofs, ndofs_per_cell(cc.dh, i))
+        celldofs!(cc.dofs, cc.dh, i)
+    end
+    return cc
 end
 
-@inline function reinit!(cv::CellValues{dim,T}, ci::CellIterator{dim,N,T}) where {dim,N,T}
-    check_compatible_geointerpolation(cv, ci)
-    reinit!(cv, ci.coords)
+# reinit! FEValues with CellCache
+reinit!(cv::CellValues, cc::CellCache) = reinit!(cv, cc.coords)
+reinit!(fv::FaceValues, cc::CellCache, f::Int) = reinit!(fv, cc.coords, f)
+
+# Accessor functions (TODO: Deprecate? We are so inconsistent with `getxx` vs `xx`...)
+getnodes(cc::CellCache) = cc.nodes
+getcoordinates(cc::CellCache) = cc.coords
+celldofs(cc::CellCache) = cc.dofs
+cellid(cc::CellCache) = cc.cellid[]
+
+# TODO: This can definitely be deprecated
+celldofs!(v::Vector, cc::CellCache) = copyto!(v, cc.dofs) # celldofs!(v, cc.dh, cc.cellid[])
+
+# TODO: These should really be replaced with something better...
+nfaces(cc::CellCache) = nfaces(eltype(cc.grid.cells))
+onboundary(cc::CellCache, face::Int) = cc.grid.boundary_matrix[face, cc.cellid[]]
+
+##################
+## CellIterator ##
+##################
+
+const IntegerCollection = Union{Set{<:Integer}, AbstractVector{<:Integer}}
+
+"""
+    CellIterator(grid::Grid, cellset=1:getncells(grid))
+    CellIterator(dh::AbstractDofHandler, cellset=1:getncells(dh))
+
+Create a `CellIterator` to conveniently iterate over all, or a subset, of the cells in a
+grid. The elements of the iterator are [`CellCache`](@ref)s which are properly
+`reinit!`ialized. See [`CellCache`](@ref) for more details.
+
+Looping over a `CellIterator`, i.e.:
+```julia
+for cc in CellIterator(grid, cellset)
+    # ...
+end
+```
+is thus simply convenience for the following equivalent snippet:
+```julia
+cc = CellCache(grid)
+for idx in cellset
+    reinit!(cc, idx)
+    # ...
+end
+```
+"""
+struct CellIterator{CC<:CellCache, IC<:IntegerCollection}
+    cc::CC
+    set::IC
 end
 
-@inline function reinit!(fv::FaceValues{dim,T}, ci::CellIterator{dim,N,T}, face::Int) where {dim,N,T}
-    check_compatible_geointerpolation(fv, ci)
-    reinit!(fv, ci.coords, face)
+function CellIterator(gridordh::Union{Grid,AbstractDofHandler},
+                      set::Union{IntegerCollection,Nothing}=nothing,
+                      flags::UpdateFlags=UpdateFlags())
+    if set === nothing
+        grid = gridordh isa AbstractDofHandler ? gridordh.grid : gridordh
+        set = 1:getncells(grid)
+    end
+    if gridordh isa MixedDofHandler
+        # TODO: Since the CellCache is resizeable this is not really necessary to check
+        #       here, but might be useful to catch slow code paths?
+        _check_same_celltype(gridordh.grid, set)
+    end
+    return CellIterator(CellCache(gridordh, flags), set)
+end
+function CellIterator(gridordh::Union{Grid,AbstractDofHandler}, flags::UpdateFlags)
+    return CellIterator(gridordh, nothing, flags)
 end
 
-function _check_same_celltype(grid::AbstractGrid, cellset::AbstractVector{Int})
+# Iterator interface
+function Base.iterate(ci::CellIterator, state_in...)
+    it = iterate(ci.set, state_in...)
+    it === nothing && return nothing
+    cellid, state_out = it
+    reinit!(ci.cc, cellid)
+    return (ci.cc, state_out)
+end
+Base.IteratorSize(::Type{<:CellIterator}) = Base.HasLength()
+Base.IteratorEltype(::Type{<:CellIterator}) = Base.HasEltype()
+Base.eltype(::Type{<:CellIterator{CC}}) where CC = CC
+Base.length(ci::CellIterator) = length(ci.set)
+
+
+function _check_same_celltype(grid::AbstractGrid, cellset)
     celltype = typeof(grid.cells[first(cellset)])
-    for cellid in cellset
-        if celltype != typeof(grid.cells[cellid])
-            error("The cells in your cellset are not all of the same celltype.")
-        end
+    if !all(typeof(grid.cells[i]) == celltype for i in cellset)
+        error("The cells in the cellset are not all of the same celltype.")
     end
 end

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -91,7 +91,7 @@ for (func_interpol, quad_rule) in  (
     end
 end
 
-@testset "#265" begin
+@testset "#265: error message for incompatible geometric interpolation" begin
     dim = 1
     deg = 1
     grid = generate_grid(Line, (2,))
@@ -104,7 +104,7 @@ end
     qr = QuadratureRule{dim, RefCube}(deg+1)
     cv = CellScalarValues(qr, ip_fe, ip_geo)
     res = @test_throws ArgumentError reinit!(cv, cell)
-    @test occursin("#265", res.value.msg)
+    @test occursin("265", res.value.msg)
     ip_geo = Lagrange{dim, RefCube, 1}()
     cv = CellScalarValues(qr, ip_fe, ip_geo)
     reinit!(cv, cell)


### PR DESCRIPTION
This patch reworks the CellIterator by extracting out the caching parts to its own CellCache struct that can be used independently. Elements of a CellIterator are now CellCache instead of the CellIterator itself.