### PR TITLE
Condense sparsity pattern: don't check if entries already exist

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -690,10 +690,8 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 row_coeffs === nothing && continue
                 for (d, _) in row_coeffs
-                    if !Base.isstored(K, d, col)
-                        cnt += 1
-                        _add_or_grow(cnt, I, J, d, col)
-                    end
+                    cnt += 1
+                    _add_or_grow(cnt, I, J, d, col)
                 end
             end
         else
@@ -702,17 +700,13 @@ function _condense_sparsity_pattern!(K::SparseMatrixCSC{T}, dofcoefficients::Vec
                 row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
                 if row_coeffs === nothing
                     for (d, _) in col_coeffs
-                        if !Base.isstored(K, row, d)
-                            cnt += 1
-                            _add_or_grow(cnt, I, J, row, d)
-                        end
+                        cnt += 1
+                        _add_or_grow(cnt, I, J, row, d)
                     end
                 else
                     for (d1, _) in col_coeffs, (d2, _) in row_coeffs
-                        if !Base.isstored(K, d1, d2)
-                            cnt += 1
-                            _add_or_grow(cnt, I, J, d1, d2)
-                        end
+                        cnt += 1
+                        _add_or_grow(cnt, I, J, d1, d2)
                     end
                 end
             end


### PR DESCRIPTION
After #436 the condensation of the pattern is done by creating a new matrix which is added to the original matrix. Before this patch there is still a check for whether each new entry already exist in the original matrix before adding it to the new matrix. With the new approach implemented in #436 this seems unnecessary and this patch removes the check. This also removes some extra complexity from the code.

A datapoint, which support this, is the Stoke's flow example in the documentation. In that problem, the condensation adds 32k new entries, of which 30k are new, and 2k exist in the original matrix. Checking whether the 32k elements exist is much more expensive than simply including the extra 2k entries in the new matrix. The new approach reduces the time for creating the combined matrix from 4ms to 3.2ms.

Matrix creation isn't a bottleneck by any means, but it is nice to see that we with simpler code also get better performance.