### PR TITLE
fix triangle grid generator and correction in discontinuous lagrange reference coordinate for order 0

### DIFF
--- a/src/Grid/grid_generators.jl
+++ b/src/Grid/grid_generators.jl
@@ -311,16 +311,16 @@ function generate_grid(::Type{Triangle}, nel::NTuple{2,Int}, LL::Vec{2,T}, LR::V
     node_array = reshape(collect(1:n_nodes), (n_nodes_x, n_nodes_y))
     cells = Triangle[]
     for j in 1:nel_y, i in 1:nel_x
-        push!(cells, Triangle((node_array[i,j], node_array[i+1,j], node_array[i,j+1]))) # ◺
-        push!(cells, Triangle((node_array[i+1,j], node_array[i+1,j+1], node_array[i,j+1]))) # ◹
+        push!(cells, Triangle((node_array[i+1,j], node_array[i,j+1], node_array[i,j]))) # ◺
+        push!(cells, Triangle((node_array[i,j+1], node_array[i+1,j], node_array[i+1,j+1]))) # ◹
     end
 
     # Cell faces
     cell_array = reshape(collect(1:nel_tot),(2, nel_x, nel_y))
-    boundary = FaceIndex[[FaceIndex(cl, 1) for cl in cell_array[1,:,1]];
-                               [FaceIndex(cl, 1) for cl in cell_array[2,end,:]];
-                               [FaceIndex(cl, 2) for cl in cell_array[2,:,end]];
-                               [FaceIndex(cl, 3) for cl in cell_array[1,1,:]]]
+    boundary = FaceIndex[[FaceIndex(cl, 3) for cl in cell_array[1,:,1]];
+                               [FaceIndex(cl, 2) for cl in cell_array[2,end,:]];
+                               [FaceIndex(cl, 3) for cl in cell_array[2,:,end]];
+                               [FaceIndex(cl, 2) for cl in cell_array[1,1,:]]]
 
     boundary_matrix = boundaries_to_sparse(boundary)
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -153,9 +153,18 @@ function value(ip::DiscontinuousLagrange{dim,shape,order}, i::Int, ξ::Vec{dim})
 end
 
 # Excepting the L0 element.
-function reference_coordinates(ip::DiscontinuousLagrange{dim,shape,0}) where {dim,shape}
+function reference_coordinates(ip::DiscontinuousLagrange{dim,RefCube,0}) where dim
     return [Vec{dim, Float64}(ntuple(x->0.0, dim))]
 end
+
+function reference_coordinates(ip::DiscontinuousLagrange{2,RefTetrahedron,0})
+    return [Vec{2,Float64}((1/3,1/3))]
+end
+
+function reference_coordinates(ip::DiscontinuousLagrange{3,RefTetrahedron,0})
+   return [Vec{3,Float64}((1/4,1/4,1/4))]
+end
+
 function value(ip::DiscontinuousLagrange{dim,shape,0}, i::Int, ξ::Vec{dim}) where {dim,shape}
     return 1.0
 end


### PR DESCRIPTION
Found this with @termi-official 
## Triangle Grid Generator
Before this the `grid_generator` for `Triangle` constructed something like this:

```
4----5
|\   |
|  \ |
1----2

Triangle((1,2,4))
Triangle((2,5,4))
```

Now the following triangles are returned
```
Triangle((2,4,1))
Triangle((4,2,5))
```

which is in line with the definition of the interpolation
![image](https://user-images.githubusercontent.com/27497290/207664855-87b1ef5d-4d05-46a3-b5bc-a83a720b7305.png)

## Discontinuous Lagrange Reference coordinate

Dispatch was just wrong. (0,0) is not the middle node of the triangle