### PR TITLE
Add internal function `fillzero!` for filling stored entries with 0

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -439,7 +439,7 @@ function _create_sparsity_pattern(dh::AbstractDofHandler, ch#=::Union{Constraint
         V = ones(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))
         _condense_sparsity_pattern!(K, ch.dofcoefficients, ch.dofmapping)
-        fill!(K.nzval, 0.0)
+        fillzero!(K)
     else
         V = zeros(length(I))
         K = sparse(I, J, V, ndofs(dh), ndofs(dh))

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -21,6 +21,23 @@ existing in the sparsity pattern of `A` this method throws a `SparsityError`.
 """
 addindex!(A, v, i, j)
 
+"""
+    fillzero!(A::AbstractVecOrMat{T})
+
+Fill the (stored) entries of the vector or matrix `A` with zeros.
+
+Fallback: `fill!(A, zero(T))`.
+"""
+fillzero!(A)
+
+function fillzero!(A::AbstractVecOrMat{T}) where T
+    return fill!(A, zero(T))
+end
+
+##################################
+## SparseArrays.SparseMatrixCSC ##
+##################################
+
 function addindex!(A::SparseMatrixCSC{Tv}, v, i::Integer, j::Integer) where Tv
     return addindex!(A, Tv(v), Int(i), Int(j))
 end
@@ -40,4 +57,13 @@ function addindex!(A::SparseMatrixCSC{Tv}, v::Tv, i::Int, j::Int) where Tv
         # (i, j) not stored. Throw.
         throw(SparsityError())
     end
+end
+
+function fillzero!(A::SparseMatrixCSC{T}) where T
+    fill!(nonzeros(A), zero(T))
+    return A
+end
+function fillzero!(A::Symmetric{T,<:SparseMatrixCSC}) where T
+    fillzero!(A.data)
+    return A
 end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -129,11 +129,11 @@ start_assemble(K::Union{SparseMatrixCSC, Symmetric{<:Any,SparseMatrixCSC}}, f::V
 
 start_assemble(f::Vector, K::Union{SparseMatrixCSC, Symmetric}; fillzero::Bool=true) = start_assemble(K, f; fillzero=fillzero)
 function start_assemble(K::SparseMatrixCSC{T}, f::Vector=T[]; fillzero::Bool=true) where {T}
-    fillzero && (fill!(K.nzval, zero(T)); fill!(f, zero(T)))
+    fillzero && (fillzero!(K); fillzero!(f))
     return AssemblerSparsityPattern(K, f, Int[], Int[])
 end
 function start_assemble(K::Symmetric{T,<:SparseMatrixCSC}, f::Vector=T[]; fillzero::Bool=true) where T
-    fillzero && (fill!(K.data.nzval, zero(T)); fill!(f, zero(T)))
+    fillzero && (fillzero!(K); fillzero!(f))
     return AssemblerSymmetricSparsityPattern(K, f, Int[], Int[])
 end
 


### PR DESCRIPTION
This patch adds a new internal function `fillzero!(A)` which fills (stored) entries of `A` with 0. This is part of breaking down the assembly procedure into smaller pieces such that each piece can be overriden more easily by other array types, similar to #548. `fillzero!(A)` falls back to `fill!(A, 0)`.