### PR TITLE
Improvements to local condensation of constraints

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1777,7 +1777,7 @@ function _condense_local!(local_matrix::AbstractMatrix, local_vector::AbstractVe
                 local_mcol = findfirst(==(global_mcol), global_dofs)
                 if local_mcol === nothing
                     has_global_arrays || missing_global()
-                    global_vector[global_mcol] += vw
+                    addindex!(global_vector, vw, global_mcol)
                 else
                     local_vector[local_mcol] += vw
                 end

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -18,8 +18,19 @@ This method avoids the double lookup.
 
 Zeros are ignored (i.e. if `iszero(v)`) by returning early. If the index `(i, j)` is not
 existing in the sparsity pattern of `A` this method throws a `SparsityError`.
+
+Fallback: `A[i, j] += v`.
 """
-addindex!(A, v, i, j)
+addindex!
+
+function addindex!(A::AbstractMatrix{T}, v, i::Integer, j::Integer) where T
+    return addindex!(A, T(v), Int(i), Int(j))
+end
+function addindex!(A::AbstractMatrix{T}, v::T, i::Int, j::Int) where T
+    iszero(v) && return A
+    A[i, j] += v
+    return A
+end
 
 """
     fillzero!(A::AbstractVecOrMat{T})
@@ -38,9 +49,6 @@ end
 ## SparseArrays.SparseMatrixCSC ##
 ##################################
 
-function addindex!(A::SparseMatrixCSC{Tv}, v, i::Integer, j::Integer) where Tv
-    return addindex!(A, Tv(v), Int(i), Int(j))
-end
 function addindex!(A::SparseMatrixCSC{Tv}, v::Tv, i::Int, j::Int) where Tv
     @boundscheck checkbounds(A, i, j)
     # Return early if v is 0

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -9,6 +9,7 @@ end
 
 """
     addindex!(A::AbstractMatrix{T}, v::T, i::Int, j::Int)
+    addindex!(b::AbstractVector{T}, v::T, i::Int)
 
 Equivalent to `A[i, j] += v` but more efficient.
 
@@ -30,6 +31,15 @@ function addindex!(A::AbstractMatrix{T}, v::T, i::Int, j::Int) where T
     iszero(v) && return A
     A[i, j] += v
     return A
+end
+
+function addindex!(b::AbstractVector{T}, v, i::Integer) where T
+    return addindex!(b, T(v), Int(i))
+end
+function addindex!(b::AbstractVector{T}, v::T, i::Int) where T
+    iszero(v) && return b
+    b[i] += v
+    return b
 end
 
 """

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -82,10 +82,7 @@ Assembles the element residual `ge` into the global residual vector `g`.
 @propagate_inbounds function assemble!(g::AbstractVector{T}, dofs::AbstractVector{Int}, ge::AbstractVector{T}) where {T}
     @boundscheck checkbounds(g, dofs)
     @inbounds for i in 1:length(dofs)
-        val = ge[i]
-        if !iszero(val)
-            g[dofs[i]] += val
-        end
+        addindex!(g, ge[i], dofs[i])
     end
 end
 


### PR DESCRIPTION
Some changes extracted from #567, see commits and commit messages.

Perhaps `addindex!` should just be methods of `assemble!`, they do the same thing, really (with argument order reversed since `addindex!` matches `Base.setindex!`).