### PR TITLE
AffineConstraint for nonzero b and nonlinear problem + docfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - New function `apply_analytical!` for setting the values of the degrees of freedom for a 
    specific field according to a spatial function `f(x)`. ([#532][github-532])
 
+### Fixed
+ - Fix `apply_zero!(Δa, ch)` when using inhomogeneous affine constraints
+
 
 ## [0.3.10] - 2022-12-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    specific field according to a spatial function `f(x)`. ([#532][github-532])
 
 ### Fixed
- - Fix `apply_zero!(Δa, ch)` when using inhomogeneous affine constraints
+ - Fix `apply_zero!(Δa, ch)` when using inhomogeneous affine constraints ([#575][github-575])
 
 
 ## [0.3.10] - 2022-12-11
@@ -232,6 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-547]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/547
 [github-549]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/549
 [github-550]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/550
+[github-575]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/575
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.10...HEAD
 [0.3.10]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.9...v0.3.10

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -7,10 +7,10 @@ DocTestSetup = :(using Ferrite)
 PDEs can in general be subjected to a number of constraints, 
 
 ```math
-g_I(\boldsymbol{a}) = 0, \quad I = 1 \text{ to } n_c
+g_I(\underline{a}) = 0, \quad I = 1 \text{ to } n_c
 ```
 
-where $g$ are (non-linear) constraint equations, $\boldsymbol{a}$ is a vector of the
+where $g$ are (non-linear) constraint equations, $\underline{a}$ is a vector of the
 degrees of freedom, and $n_c$ is the number of constraints. There are many ways to
 enforce these constraints, e.g. penalty methods and Lagrange multiplier methods. 
 
@@ -43,7 +43,7 @@ K = create_sparsity_pattern(dh, ch)
 ```
 
 ### Solving linear problems
-To solve the system ``\boldsymbol{K}\boldsymbol{a}=\boldsymbol{f}``, account for affine constraints the same way as for 
+To solve the system ``\underline{\underline{K}}\underline{a}=\underline{f}``, account for affine constraints the same way as for 
 `Dirichlet` boundary conditions; first call `apply!(K, f, ch)`. This will condense `K` and `f` inplace (i.e
 no new matrix will be created). Note however that we must also call `apply!` on the solution vector after 
 solving the system to enforce the affine constraints:

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -58,13 +58,12 @@ apply!(a, ch) # enforces affine constraints
 
 ```
 
-Note that replacing `f` with `r=-f` and solving `a = -K\r` in the example above will not work correctly for affine constraints.
-In this case, use the procedure for nonlinear problems below. 
+Note: Replacing `f` with `r=-f` and solving `a = -K\r` in the example above may give the wrong result.
+Instead, use the procedure for nonlinear problems when applying affine constraints to such problem formulations.
 
 ### Solving nonlinear problems
-When solving the nonlinear system `r(a)=0` using a Newton-type of method
-the updated guess is given by `Δa=-K\r` 
-(where `K=∂r/∂a` if the standard Newton's method is used).
+A Newton-type solution method for the nonlinear system `r(a)=0` uses the 
+update `Δa=-K\r` (where `K=∂r/∂a` if the standard Newton's method is used).
 ```julia
 a = initial_guess(...)  # Make any initial guess for a here, e.g. `a=zeros(ndofs(dh))`
 apply!(a, ch)           # Make the guess fulfill all constraints in `ch`

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -63,7 +63,7 @@ It is important to check the residual **after** applying boundary conditions whe
 solving nonlinear problems with affine constraints. 
 `apply_zero!(K, r, ch)` modifies the residual entries for dofs that are involved 
 in constraints to account for constraint forces. 
-The following pseudo-code shows a typical pattern for solving a non-linear problem with Newtons method:
+The following pseudo-code shows a typical pattern for solving a non-linear problem with Newton's method:
 ```julia
 a = initial_guess(...)  # Make any initial guess for a here, e.g. `a=zeros(ndofs(dh))`
 Δa = similar(a)         # Preallocate Δa

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -72,7 +72,8 @@ for iter in 1:maxiter
     apply_zero!(K, r, ch)   # Modify `K` and `r` to account for the constraints. 
     check_convergence(r, ...) && break # Only check convergence after `apply_zero!(K, r, ch)`
     Δa = K \ r              # Calculate the (negative) update
-    apply_zero!(Δa, ch)     # Change constrained values such that `a+Δa` fullfills constraints provided that `a` does.
+    apply_zero!(Δa, ch)     # Change the constrained values in `Δa` such that `a-Δa`
+                            # fullfills constraints if `a` did.
     a .-= Δa
 end
 ```

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -58,9 +58,6 @@ apply!(a, ch) # enforces affine constraints
 
 ```
 
-Note: Replacing `f` with `r=-f` and solving `a = -K\r` in the example above may give the wrong result.
-Instead, use the procedure for nonlinear problems when applying affine constraints to such problem formulations.
-
 ### Solving nonlinear problems
 It is important to check the residual **after** applying boundary conditions when 
 solving nonlinear problems with affine constraints. 

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -66,14 +66,13 @@ in constraints to account for constraint forces.
 The following pseudo-code shows a typical pattern for solving a non-linear problem with Newton's method:
 ```julia
 a = initial_guess(...)  # Make any initial guess for a here, e.g. `a=zeros(ndofs(dh))`
-Δa = similar(a)         # Preallocate Δa
 apply!(a, ch)           # Make the guess fulfill all constraints in `ch`
 for iter in 1:maxiter
     doassemble!(K, r, ...)  # Assemble the residual, r, and stiffness, K=∂r/∂a.
     apply_zero!(K, r, ch)   # Modify `K` and `r` to account for the constraints. 
     check_convergence(r, ...) && break # Only check convergence after `apply_zero!(K, r, ch)`
-    Δa .= .- (K \ r)        # Calculate update
+    Δa = K \ r              # Calculate the (negative) update
     apply_zero!(Δa, ch)     # Change constrained values such that `a+Δa` fullfills constraints provided that `a` does.
-    a .+= Δa
+    a .-= Δa
 end
 ```

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -72,7 +72,7 @@ for iter in 1:maxiter
     doassemble!(K, r, ...)  # Assemble the residual, r, and stiffness, K=∂r/∂a.
     apply_zero!(K, r, ch)   # Modify `K` and `r` to account for the constraints. 
     check_convergence(r, ...) && break # Only check convergence after `apply_zero!(K, r, ch)`
-    Δa .-= K \ r            # Calculate update
+    Δa .= .- (K \ r)        # Calculate update
     apply_zero!(Δa, ch)     # Change constrained values such that `a+Δa` fullfills constraints provided that `a` does.
     a .+= Δa
 end

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -16,7 +16,7 @@ enforce these constraints, e.g. penalty methods and Lagrange multiplier methods.
 
 ## Affine constraints
 
-Affine constraints can be handled directly in Ferrite. Affine (first) and linear (second) constraints can typically
+Affine or linear constraints can be handled directly in Ferrite. Such constraints can typically
 be expressed as:
 
 ```math

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -69,7 +69,7 @@ a = initial_guess(...)  # Make any initial guess for a here, e.g. `a=zeros(ndofs
 Δa = similar(a)         # Preallocate Δa
 apply!(a, ch)           # Make the guess fulfill all constraints in `ch`
 for iter in 1:maxiter
-    doassemble!(K, r, ...)
+    doassemble!(K, r, ...)  # Assemble the residual, r, and stiffness, K=∂r/∂a.
     apply_zero!(K, r, ch)   # Modify `K` and `r` to account for the constraints. 
     check_convergence(r, ...) && break # Only check convergence after `apply_zero!(K, r, ch)`
     Δa .-= K \ r            # Calculate update

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -62,8 +62,11 @@ Note: Replacing `f` with `r=-f` and solving `a = -K\r` in the example above may 
 Instead, use the procedure for nonlinear problems when applying affine constraints to such problem formulations.
 
 ### Solving nonlinear problems
-A Newton-type solution method for the nonlinear system `r(a)=0` uses the 
-update `Δa=-K\r` (where `K=∂r/∂a` if the standard Newton's method is used).
+It is important to check the residual **after** applying boundary conditions when 
+solving nonlinear problems with affine constraints. 
+`apply_zero!(K, r, ch)` modifies the residual entries for dofs that are involved 
+in constraints to account for constraint forces. 
+The following pseudo-code shows the typical pattern for solving a non-linear problem with Newtons method:
 ```julia
 a = initial_guess(...)  # Make any initial guess for a here, e.g. `a=zeros(ndofs(dh))`
 apply!(a, ch)           # Make the guess fulfill all constraints in `ch`
@@ -72,7 +75,7 @@ for iter in 1:maxiter
     apply_zero!(K, r, ch)   # Modify `K` and `r` to account for the constraints. 
     check_convergence(r, ...) && break # Only check convergence after `apply_zero!(K, r, ch)`
     Δa=-K\r                 # Calculate update
-    apply_zero!(Δa, ch)     # Change prescribed values such that `a+Δa` fullfills constraints provided that `a` does.
+    apply_zero!(Δa, ch)     # Change constrained values such that `a+Δa` fullfills constraints provided that `a` does.
     a .+= Δa
 end
 ```

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -58,6 +58,9 @@ apply!(a, ch) # enforces affine constraints
 
 ```
 
+Note that replacing `f` with `r=-f` and solving `a = -K\r` in the example above will not work correctly for affine constraints.
+In this case, use the procedure for nonlinear problems below. 
+
 ### Solving nonlinear problems
 When solving the nonlinear system `r(a)=0` using a Newton-type of method
 the updated guess is given by `Δa=-K\r` 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -610,7 +610,7 @@ function _apply_v(v::AbstractVector, ch::ConstraintHandler, apply_zero::Bool)
     for (dof, dofcoef, h) in zip(ch.prescribed_dofs, ch.dofcoefficients, ch.affine_inhomogeneities)
         dofcoef === nothing && continue
         @assert h !== nothing
-        v[dof] = h
+        v[dof] = apply_zero ? 0.0 : h
         for (d, s) in dofcoef
             v[dof] += s * v[d]
         end

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -925,10 +925,22 @@ function _check_cellset_dirichlet(grid::AbstractGrid, cellset::Set{Int}, nodeset
     end
 end
 
+"""
+    create_symmetric_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler, coupling)
+
+Create a symmetric sparsity pattern accounting for affine constraints in `ch`. See 
+the Affine Constraints section of the manual for further details. 
+"""
 function create_symmetric_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler;
         keep_constrained::Bool=true, coupling=nothing)
     return Symmetric(_create_sparsity_pattern(dh, ch, true, keep_constrained, coupling), :U)
 end
+"""
+    create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler; coupling)
+
+Create a symmetric sparsity pattern accounting for affine constraints in `ch`. See 
+the Affine Constraints section of the manual for further details. 
+"""
 function create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler;
         keep_constrained::Bool=true, coupling=nothing)
     return _create_sparsity_pattern(dh, ch, false, keep_constrained, coupling)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -580,7 +580,7 @@ apply!
 
 Adjust the matrix `K` and the right hand side `rhs` to account for prescribed Dirichlet
 boundary conditions and affine constraints such that `du = K \\ rhs` gives the expected 
-result (e.g. `du` zero for all degrees of freedom prescribed by Dirichlet conditions).
+result (e.g. `du` zero for all prescribed degrees of freedom).
 
     apply_zero!(v::AbstractVector, ch::ConstraintHandler)
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -585,8 +585,8 @@ result (e.g. `du` zero for all degrees of freedom prescribed by Dirichlet condit
     apply_zero!(v::AbstractVector, ch::ConstraintHandler)
 
 Zero-out values in `v` corresponding to prescribed degrees of freedom and update values 
-prescribed by affine constraints, such that if `a` fullfilled the affine constraints, 
-`a±v` also will. 
+prescribed by affine constraints, such that if `a` fullfills the constraints,
+`a ± v` also will.
 
 These methods are typically used in e.g. a Newton solver where the increment, `du`, should
 be prescribed to zero even for non-homogeneouos boundary conditions.

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -938,7 +938,7 @@ end
 """
     create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler; coupling)
 
-Create a symmetric sparsity pattern accounting for affine constraints in `ch`. See 
+Create a sparsity pattern accounting for affine constraints in `ch`. See 
 the Affine Constraints section of the manual for further details. 
 """
 function create_sparsity_pattern(dh::AbstractDofHandler, ch::ConstraintHandler;

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -547,10 +547,13 @@ Adjust the matrix `K` and right hand side `rhs` to account for the Dirichlet bou
 conditions specified in `ch` such that `K \\ rhs` gives the expected solution.
 
 !!! note
-    `apply!(K, rhs, ch)` essentially calculates 
+    `apply!(K, rhs, ch)` essentially calculates
+
     `rhs[free_dofs] = rhs[free_dofs] - K[free_dofs, constrained_dofs] * a[constrained]`
+    
     where `a[constrained]` are the inhomogeneities. 
     Consequently, the sign of `rhs` matters (in contrast to for `apply_zero!`).
+
 
     apply!(v::AbstractVector, ch::ConstraintHandler)
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -56,9 +56,11 @@ end
 
 const DofCoefficients{T} = Vector{Pair{Int,T}}
 """
-    AffineConstraint(constrained_dofs::Int, master_dofs::Vector{Int}, coeffs::Vector{T}, b::T) where T
+    AffineConstraint(constrained_dof::Int, entires::Vector{Pair{Int,T}}, b::T) where T
 
-Define an affine/linear constraint to constrain dofs of the form `u_i = ∑(u[j] * a[j]) + b`.
+Define an affine/linear constraint to constrain one degree of freedom, `u[i]`, 
+such that `u[i] = ∑(u[j] * a[j]) + b`, 
+where `i=constrained_dof` and each element in `entries` are `j => a[j]`
 """
 struct AffineConstraint{T}
     constrained_dof::Int

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -577,7 +577,7 @@ apply!
 
 Adjust the matrix `K` and the right hand side `rhs` to account for prescribed Dirichlet
 boundary conditions and affine constraints such that `du = K \\ rhs` gives the expected 
-result (e.g. `Δu` zero for all degrees of freedom prescribed by Dirichlet conditions).
+result (e.g. `du` zero for all degrees of freedom prescribed by Dirichlet conditions).
 
     apply_zero!(v::AbstractVector, ch::ConstraintHandler)
 
@@ -585,7 +585,7 @@ Zero-out values in `v` corresponding to prescribed degrees of freedom and update
 prescribed by affine constraints, such that if `a` fullfilled the affine constraints, 
 `a±v` also will. 
 
-These methods are typically used in e.g. a Newton solver where the increment, `Δu`, should
+These methods are typically used in e.g. a Newton solver where the increment, `du`, should
 be prescribed to zero even for non-homogeneouos boundary conditions.
 
 See also: [`apply!`](@ref).

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -266,7 +266,7 @@ end
     @testset "nonlinear" begin
         params = (k=1.0, f=1.0, a=1.0, b=0.2, tol=1e-10, maxiter=2)
         grid = generate_grid(Line, (2,)); addfaceset!(grid, "center", x->x[1]≈0.0)
-        dh = DofHandler(grid); push!(dh, :u, 1); close!(dh)
+        dh = DofHandler(grid); add!(dh, :u, 1); close!(dh)
 
         function doassemble!(K, r, dh, a, params)
             # Spring elements 


### PR DESCRIPTION
This PR fixes an issue recently discussed on Slack. The test code and derivations are included here for reference.
In addition, it adds further docstrings relevant when using AffineConstraints. 

<details>
<summary>Test code</summary>
Without this PR, the nonlinear problem doesn't converge. 
With this PR, the code shows how the wrong results are obtained if using the `a=-K\r` instead of `a=K\f` for the linear solution method, which this PR documents. 

```julia
using Ferrite

params = (k=1.0, f=1.0, a=1.0, b=0.2, tol=1e-10, maxiter=2)

grid = generate_grid(Line, (2,))
addfaceset!(grid, "center", x->x[1]≈0.0)

dh = DofHandler(grid)
push!(dh, :u, 1)
close!(dh)

eval_norm(r, ch) = sqrt(sum(i->r[i]^2, Ferrite.free_dofs(ch)))

function doassemble!(K, r, dh, a, params)
    # Spring elements 
    k = params.k
    Ke = [k -k; -k k]
    # Quick and dirty assem
    assembler = start_assemble(K, r)
    for cell in CellIterator(dh)
        ae = a[celldofs(cell)]
        re = Ke*ae
        assemble!(assembler, celldofs(cell), Ke, re)
    end
    r[3] -= params.f # Force on the main dof (right side)
end

ch = ConstraintHandler(dh)
add!(ch, Dirichlet(:u, getfaceset(grid, "center"), (x,t)->Vec{1}((0.0,))))
add!(ch, AffineConstraint(1, [3=>params.a], params.b))
close!(ch)

K = create_sparsity_pattern(dh, ch)
r = zeros(ndofs(dh))

a = zeros(ndofs(dh))
update!(ch, 0.0)

# Nonlinear solution
apply!(a, ch) 
for niter = 0:params.maxiter
    doassemble!(K, r, dh, a, params)
    apply_zero!(K, r, ch)
    rnorm = eval_norm(r, ch)
    println("$niter: $rnorm, $r, $a")
    rnorm < params.tol && break
    Δa = -K\r 
    apply_zero!(Δa, ch)
    a .+= Δa
end
eval_norm(r, ch) > params.tol && @warn "Did not converge"
a_nonlinear = copy(a)

# Linear solution (r)
a_linear_r = zero(a)
doassemble!(K, r, dh, a_linear_r, params)
apply!(K, r, ch)
a_linear_r = -K\r 
apply!(a_linear_r, ch)

# Linear solution (f)
a_linear_f = zero(a)
doassemble!(K, r, dh, a_linear_f, params)
f = -r
apply!(K, f, ch)
a_linear_f = K\f
apply!(a_linear_f, ch)

# Analytical comparison
a3 = (params.f/params.k - params.b)/(1 + params.a)
a_analytical = [params.a*a3+params.b 0.0 a3]
@show a_linear_r
@show a_linear_f
@show a_nonlinear
@show a_analytical
```
</details>

<details>
<summary>Analytical solution</summary>

# Spring
   |------ $c$ ------| 

   |-- $k$ --|-- $k$ --|--> $f$

   $u_1$ -> $u_2$ -> $u_3$ ->

 **Kinematical constraints**
 - Dirichlet: $u_2 = 0$
 - Affine: $u_1 = au_3 + b$
  
 **Free body diagrams**
 
 <- $ku_1$ -- (1) -- $f_c$ ->
 
 <- $(f_c+ku_3)$ -- (3) -- $f$ -> 

where $f_c$ is the affine constraint force and $f$ is the external force

**Equilibrium**
- $0 = f_1 = -k u_1 + f_c$
- $0 = f_3 = -k u_3 - f_c + f$
- $0 = f_1+f_3 = -k (u_1 + u_3)$
- $f = k u_1 + k u_3$
- $f = k (u_3 (a+1) + b)$
- $u_3 = (f/k - b)/(1+a)$ 

</details>