### PR TITLE
Fix landau.jl

### DIFF
--- a/docs/src/literate/landau.jl
+++ b/docs/src/literate/landau.jl
@@ -205,12 +205,14 @@ function minimize!(model; kwargs...)
 
     od = TwiceDifferentiable(f, g!, h!, model.dofs, 0.0, ∇f, ∇²f)
 
-    # this way of minimizing is only beneficial when the initial guess is completely off,
-    # then a quick couple of ConjuageGradient steps brings us easily closer to the minimum.
-    # res = optimize(od, model.dofs, ConjugateGradient(linesearch=BackTracking()), Optim.Options(show_trace=true, show_every=1, g_tol=1e-20, iterations=10))
-    # model.dofs .= res.minimizer
-    # to get the final convergence, Newton's method is more ideal since the energy landscape should be almost parabolic
-    #+
+    ## this way of minimizing is only beneficial when the initial guess is completely off,
+    ## then a quick couple of ConjuageGradient steps brings us easily closer to the minimum.
+    ## ```julia
+    ## res = optimize(od, model.dofs, ConjugateGradient(linesearch=BackTracking()), Optim.Options(show_trace=true, show_every=1, g_tol=1e-20, iterations=10))
+    ## model.dofs .= res.minimizer
+    ## ```
+    ## to get the final convergence, Newton's method is more ideal since the energy landscape should be almost parabolic
+    ##+
     res = optimize(od, model.dofs, Newton(linesearch=BackTracking()), Optim.Options(show_trace=true, show_every=1, g_tol=1e-20))
     model.dofs .= res.minimizer
     return res

--- a/docs/src/literate/landau.jl
+++ b/docs/src/literate/landau.jl
@@ -207,10 +207,8 @@ function minimize!(model; kwargs...)
 
     ## this way of minimizing is only beneficial when the initial guess is completely off,
     ## then a quick couple of ConjuageGradient steps brings us easily closer to the minimum.
-    ## ```julia
     ## res = optimize(od, model.dofs, ConjugateGradient(linesearch=BackTracking()), Optim.Options(show_trace=true, show_every=1, g_tol=1e-20, iterations=10))
     ## model.dofs .= res.minimizer
-    ## ```
     ## to get the final convergence, Newton's method is more ideal since the energy landscape should be almost parabolic
     ##+
     res = optimize(od, model.dofs, Newton(linesearch=BackTracking()), Optim.Options(show_trace=true, show_every=1, g_tol=1e-20))


### PR DESCRIPTION
Fixes literate syntax for the Landau example
I'm not sure if the commented code is supposed to be run, but it wasn't before, so leaving it as it was. 