### PR TITLE
Rename MetisExt extension module to FerriteMetis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  - [Metis.jl](https://github.com/JuliaSparse/Metis.jl) extension for fill-reducing DoF
-   permutation. This uses Julias new package extension mechanism (requires Julia 1.9) to
+   permutation. This uses Julias new package extension mechanism (requires Julia 1.10) to
    support a new DoF renumbering order `DofOrder.Ext{Metis}()` that can be passed to
    `renumber!` to renumber DoFs using the Metis.jl library. ([#393][github-393],
    [#549][github-549])

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 
 [extensions]
 FerriteBlockArrays = "BlockArrays"
-MetisExt = "Metis"
+FerriteMetis = "Metis"
 
 [compat]
 EnumX = "1"

--- a/ext/FerriteMetis.jl
+++ b/ext/FerriteMetis.jl
@@ -1,4 +1,4 @@
-module MetisExt
+module FerriteMetis
 
 using Ferrite
 using Ferrite: AbstractDofHandler
@@ -80,4 +80,4 @@ function Ferrite.compute_renumber_permutation(
     return perm
 end
 
-end # module MetisExt
+end # module FerriteMetis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,11 @@ using LinearAlgebra
 using SparseArrays
 
 const HAS_EXTENSIONS = isdefined(Base, :get_extension)
-if HAS_EXTENSIONS
+
+# https://github.com/JuliaLang/julia/pull/47749
+const MODULE_CAN_BE_TYPE_PARAMETER = VERSION >= v"1.10.0-DEV.90"
+
+if HAS_EXTENSIONS && MODULE_CAN_BE_TYPE_PARAMETER
     import Metis
 end
 

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -256,7 +256,7 @@ end
     end
 
     # Metis ordering
-    if HAS_EXTENSIONS
+    if HAS_EXTENSIONS && MODULE_CAN_BE_TYPE_PARAMETER
         # TODO: Should probably test that the new order result in less fill-in
         dh, ch = testdhch()
         renumber!(dh, DofOrder.Ext{Metis}())


### PR DESCRIPTION
This module name should largely be invisible for users, but it might show up in e.g. stacktraces so FerriteMetis is more explanatory. This patch also fixes tests on Julia 1.9 (which does not support modules as type parameters).