### PR TITLE
Fix constraint condensation for `Symmetric` matrices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ - Fix an issue in constraint application of `Symmetric`-wrapped sparse matrices (i.e.
+   obtained from `create_symmatric_sparsity_pattern`). In particular, `apply!(K::Symmetric,
+   f, ch)` would incorrectly modify `f` if any of the constraints were inhomogeneous.
+   ([#592][github-592])
 
 ## [0.3.11] - 2023-01-17
 ### Added
@@ -299,6 +304,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-575]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/575
 [github-578]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/578
 [github-583]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/583
+[github-592]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/592
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.11...HEAD
 [0.3.11]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.10...v0.3.11


### PR DESCRIPTION
This patch fixes an issue where `f` would be incorrectly modified in `apply!(K, f, ch)` when `K::Symmetric` and when using inhomogeneous constraints. Specifically this patch make sure that entries below the diagonal of the matrix backing the `Symmetric` aren't used, and that the corresponding entries from above the diagonal are used in their place.