### PR TITLE
Add basic `Base.show` method for assemblers

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -109,6 +109,15 @@ struct AssemblerSymmetricSparsityPattern{Tv,Ti} <: AbstractSparseAssembler
     sorteddofs::Vector{Int}
 end
 
+function Base.show(io::IO, ::MIME"text/plain", a::Union{AssemblerSparsityPattern,AssemblerSymmetricSparsityPattern})
+    print(io, typeof(a), " for assembling into:\n - ")
+    summary(io, a.K)
+    if !isempty(a.f)
+        print(io, "\n - ")
+        summary(io, a.f)
+    end
+end
+
 matrix_handle(a::AssemblerSparsityPattern) = a.K
 matrix_handle(a::AssemblerSymmetricSparsityPattern) = a.K.data
 vector_handle(a::Union{AssemblerSparsityPattern, AssemblerSymmetricSparsityPattern}) = a.f

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -76,6 +76,28 @@
     @test_throws AssertionError assemble!(assembler, [11, 1, 2, 3], rand(4, 4), rand(3))
 end
 
+@testset "Base.show for assemblers" begin
+    A = sparse(rand(10, 10))
+    S = Symmetric(A)
+    b = rand(10)
+    @test occursin(
+        r"for assembling into:\n - 10×10 SparseMatrix",
+        sprint(show, MIME"text/plain"(), start_assemble(A)),
+    )
+    @test occursin(
+        r"for assembling into:\n - 10×10 SparseMatrix.*\n - 10-element Vector",
+        sprint(show, MIME"text/plain"(), start_assemble(A, b)),
+    )
+    @test occursin(
+        r"for assembling into:\n - 10×10 Symmetric.*SparseMatrix",
+        sprint(show, MIME"text/plain"(), start_assemble(S)),
+    )
+    @test occursin(
+        r"for assembling into:\n - 10×10 Symmetric.*SparseMatrix.*\n - 10-element Vector",
+        sprint(show, MIME"text/plain"(), start_assemble(S, b)),
+    )
+end
+
 struct IgnoreMeIfZero
     x::Float64
 end


### PR DESCRIPTION
This patch adds basic `Base.show` methods for assemblers. Without this the full matrix/vector is displayed in the REPL, which is pretty annoying. Example output:

```
julia> start_assemble(A, b)
Ferrite.AssemblerSparsityPattern{Float64, Int64} for assembling into:
 - 882×882 SparseArrays.SparseMatrixCSC{Float64, Int64} with 14884 stored entries
 - 882-element Vector{Float64}
```