### PR TITLE
Fix slow show(grid)

### DIFF
--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -726,7 +726,11 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", grid::Grid)
     print(io, "$(typeof(grid)) with $(getncells(grid)) ")
-    typestrs = sort!(collect(Set(repr(typeof(x)) for x in grid.cells)))
+    if isconcretetype(eltype(grid.cells))
+        typestrs = [repr(eltype(grid.cells))]
+    else
+        typestrs = sort!(repr.(Set(typeof(x) for x in grid.cells)))
+    end
     join(io, typestrs, '/')
     print(io, " cells and $(getnnodes(grid)) nodes")
 end


### PR DESCRIPTION
The use of `repr` on every cell in #570 was very slow.
With this PR, there is still performance regression for mixed grids (factor 3), but still ok (in my opinion).

@fredrikekre: Is there a better way to get each type in the union? In that case the suggestion below might make sense, even though I don't think it matters that much... 