### PR TITLE
fix vtk docs export

### DIFF
--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -27,8 +27,8 @@ reshape_to_nodes
 
 ```@docs
 vtk_grid(filename::AbstractString, grid::Grid{dim,C,T}; compress::Bool) where {dim,C,T} 
-vtk_point_data(vtk::WriteVTK.DatasetFile, data::Union{Vector{SymmetricTensor{2,dim,T,M}}},name::AbstractString) where {dim,T,M}
-vtk_point_data(vtk::WriteVTK.DatasetFile, data::Union{ Vector{Tensor{order,dim,T,M}}, Vector{SymmetricTensor{order,dim,T,M}}}, name::AbstractString) where {order,dim,T,M}
+vtk_point_data
+vtk_cell_data
 vtk_cellset
 vtk_cell_data_colors
 ```

--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -28,7 +28,6 @@ reshape_to_nodes
 ```@docs
 vtk_grid(filename::AbstractString, grid::Grid{dim,C,T}; compress::Bool) where {dim,C,T} 
 vtk_point_data
-vtk_cell_data
 vtk_cellset
 vtk_cell_data_colors
 ```


### PR DESCRIPTION
In the documentation for the export as VTK file the description of the method vtk_cell_data was missing and the description of the method vtk_point_data was duplicated. 
The description of the method vtk_cell_data was added and the duplication of the method vtk_point_data was removed. 