### PR TITLE
More development docs related to interpolations

### DIFF
--- a/docs/src/devdocs/elements.md
+++ b/docs/src/devdocs/elements.md
@@ -1,0 +1,29 @@
+# [Elements](@id devdocs-elements)
+
+## Type definitions
+
+Elements are subtypes of `AbstractCell{dim,N,M}`. They are parametrized by
+the dimension of their nodes via `dim`, the number of nodes `N` and the number
+of faces `M`.
+
+### Required methods to implement for all subtypes of `AbstractCell` to define a new element
+
+```@docs
+Ferrite.vertices(::Ferrite.AbstractCell)
+Ferrite.edges(::Ferrite.AbstractCell)
+Ferrite.faces(::Ferrite.AbstractCell)
+Ferrite.default_interpolation(::Ferrite.AbstractCell)
+```
+
+### Common utilities and definitions when working with grids internally.
+
+```@docs
+Ferrite.BoundaryIndex
+Ferrite.boundaryfunction(::Type{<:Ferrite.BoundaryIndex})
+Ferrite.get_coordinate_eltype(::Ferrite.AbstractGrid)
+Ferrite.get_coordinate_eltype(::Node)
+Ferrite.toglobal
+Ferrite.sortface
+Ferrite.sortedge
+```
+

--- a/docs/src/devdocs/elements.md
+++ b/docs/src/devdocs/elements.md
@@ -1,8 +1,8 @@
-# [Elements](@id devdocs-elements)
+# [Elements and cells](@id devdocs-elements)
 
 ## Type definitions
 
-Elements are subtypes of `AbstractCell{dim,N,M}`. They are parametrized by
+Elements or cells are subtypes of `AbstractCell{dim,N,M}`. They are parametrized by
 the dimension of their nodes via `dim`, the number of nodes `N` and the number
 of faces `M`.
 

--- a/docs/src/devdocs/index.md
+++ b/docs/src/devdocs/index.md
@@ -5,5 +5,5 @@ developing the library.
 
 ```@contents
 Depth = 1
-Pages = ["interpolations.md"]
+Pages = ["interpolations.md", "elements.md"]
 ```

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -3,7 +3,7 @@
 ## Type definitions
 
 Interpolations are subtypes of `Interpolation{dim, shape, order}`, i.e. they are
-parametrized by the (spatial) dimension, reference shape and order.
+parametrized by the (reference element) dimension, reference shape and order.
 
 ### Fallback methods applicable for all subtypes of `Interpolation`
 
@@ -11,12 +11,21 @@ parametrized by the (spatial) dimension, reference shape and order.
 Ferrite.getdim(::Interpolation)
 Ferrite.getrefshape(::Interpolation)
 Ferrite.getorder(::Interpolation)
-Ferrite.value(::Interpolation{dim}, ::Vec{dim}) where {dim}
+Ferrite.value(::Interpolation{dim}, ::Vec{dim,T}) where {dim,T}
 Ferrite.derivative(::Interpolation{dim}, ::Vec{dim}) where {dim}
 ```
 
-### Required methods to implement for all subtypes of `Interpolation`
+### Required methods to implement for all subtypes of `Interpolation` to define a new finite element
 
 ```@docs
+Ferrite.value(::Interpolation, ::Int, ::Vec)
+Ferrite.vertices(::Interpolation)
+Ferrite.nvertexdofs(::Interpolation)
+Ferrite.faces(::Interpolation)
+Ferrite.nfacedofs(::Interpolation)
+Ferrite.edges(::Interpolation)
+Ferrite.nedgedofs(::Interpolation)
+Ferrite.ncelldofs(::Interpolation)
 Ferrite.getnbasefunctions(::Interpolation)
+Ferrite.reference_coordinates(::Interpolation)
 ```

--- a/docs/src/reference/grid.md
+++ b/docs/src/reference/grid.md
@@ -39,10 +39,14 @@ compute_vertex_values
 transform!
 getcoordinates
 getcoordinates!
+```
+
+### Topology
+
+```@docs
 Ferrite.ExclusiveTopology
 Ferrite.getneighborhood
 Ferrite.faceskeleton
-Ferrite.toglobal
 ```
 
 ### Grid Sets Utility

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -304,11 +304,10 @@ function __close!(dh::DofHandler{dim}) where {dim}
         # push! the first index of the next cell to the offset vector
         push!(dh.cell_dofs_offset, length(dh.cell_dofs)+1)
     end # cell loop
-    dh.ndofs[] = maximum(dh.cell_dofs)
+    dh.ndofs[] = maximum(dh.cell_dofs, init=0)
     dh.closed[] = true
 
     return dh, vertexdicts, edgedicts, facedicts
-
 end
 
 function celldofs!(global_dofs::Vector{Int}, dh::DofHandler, i::Int)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -122,12 +122,29 @@ function add!(dh::DofHandler, name::Symbol, dim::Int, ip::Interpolation=default_
     return dh
 end
 
-# sort and return true (was already sorted) or false (if we had to sort)
+"""
+    sortedge(edge::Tuple{Int,Int})
+
+Returns the unique representation of an edge and its orientation.
+Here the unique representation is the sorted node index tuple. The
+orientation is `true` if the edge is not flipped, where it is `false`
+if the edge is flipped.
+"""
 function sortedge(edge::Tuple{Int,Int})
     a, b = edge
     a < b ? (return (edge, true)) : (return ((b, a), false))
 end
 
+"""
+    sortface(face::Tuple{Int,Int}) 
+    sortface(face::Tuple{Int,Int,Int})
+    sortface(face::Tuple{Int,Int,Int,Int})
+
+Returns the unique representation of a face.
+Here the unique representation is the sorted node index tuple.
+Note that in 3D we only need indices to uniquely identify a face,
+so the unique representation is always a tuple length 3.
+"""
 sortface(face::Tuple{Int,Int}) = minmax(face[1], face[2])
 function sortface(face::Tuple{Int,Int,Int})
     a, b, c = face
@@ -136,7 +153,6 @@ function sortface(face::Tuple{Int,Int,Int})
     a, b = minmax(a, b)
     return (a, b, c)
 end
-
 function sortface(face::Tuple{Int,Int,Int,Int})
     a, b, c, d = face
     c, d = minmax(c, d)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -18,13 +18,14 @@ getcoordinates(n::Node) = n.x
 """
     Ferrite.get_coordinate_eltype(::Node)
 
-Get the data type of 
+Get the data type of the components of the nodes coordinate.
 """
 get_coordinate_eltype(::Node{dim,T}) where {dim,T} = T
 
 abstract type AbstractCell{dim,N,M} end
 """
     Cell{dim,N,M} <: AbstractCell{dim,N,M}
+
 A `Cell` is a subdomain defined by a collection of `Node`s.
 The parameter `dim` refers here to the geometrical/ambient dimension, i.e. the dimension of the `nodes` in the grid and **not** the topological dimension of the cell (i.e. the dimension of the reference element obtained by default_interpolation).
 A `Cell` has `N` nodes and `M` faces.
@@ -51,6 +52,7 @@ This function induces the [`VertexIndex`](@ref), where the second index
 corresponds to the local index into this tuple.
 """
 vertices(::Ferrite.AbstractCell)
+
 """
     Ferrite.edges(::AbstractCell)
 
@@ -61,6 +63,7 @@ the vertices that define an *oriented edge*. This function induces the
 Note that the vertices are sufficient to define an edge uniquely.
 """
 edges(::Ferrite.AbstractCell)
+
 """
     Ferrite.faces(::AbstractCell)
 
@@ -71,6 +74,7 @@ the vertices that define an *oriented face*. This function induces the
 Note that the vertices are sufficient to define a face uniquely.
 """
 faces(::Ferrite.AbstractCell)
+
 """
     Ferrite.default_interpolation(::AbstractCell)::Interpolation
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -124,13 +124,13 @@ nvertexdofs(::Interpolation) = 0
 """
     Ferrite.nedgedofs(::Interpolation)
 
-Number of dofs on the *interior* of a single edge.
+Number of dofs on the interior of a single edge.
 """
 nedgedofs(::Interpolation)   = 0
 """
     Ferrite.nfacedofs(::Interpolation)
 
-Number of dofs on the *interior* of a single face.
+Number of dofs on the interior of a single face.
 """
 nfacedofs(::Interpolation)   = 0
 """
@@ -170,18 +170,18 @@ reference_coordinates(ip::Interpolation)
     vertices(::Interpolation)
 
 A tuple containing tuples of local dof indices for the respective 
-vertex in local enumeration on a cell. The vertex enumeration must 
+vertex in local enumeration on a cell defined by [`vertices(::Cell)`](@ref). The vertex enumeration must 
 match the vertex enumeration of the corresponding geometrical cell.
-Also, the length of each tuple must be exactly [`nvertexdofs(::Interpolation)`](@ref).
+The length of each tuple must be exactly [`nvertexdofs(::Interpolation)`](@ref).
 """
 vertices(::Interpolation)
 """
     edges(::Interpolation)
 
 A tuple containing tuples of local dof indices for the respective 
-edge in local enumeration on a cell. The edge enumeration must 
+edge in local enumeration on a cell defined by [`edges(::Cell)`](@ref). The edge enumeration must 
 match the edge enumeration of the corresponding geometrical cell.
-Note that the vertex dofs are included here. Also, the length of 
+Note that the vertex dofs are included here. The length of 
 each tuple must be exactly [`nvertexdofs(::Interpolation)`](@ref)+[`nedgedofs(::Interpolation)`](@ref).
 """
 edges(::Interpolation)
@@ -189,9 +189,9 @@ edges(::Interpolation)
     faces(::Interpolation)
 
 A tuple containing tuples of all local dof indices for the respective 
-face in local enumeration on a cell. The face enumeration must 
+face in local enumeration on a cell defined by [`faces(::Cell)`](@ref). The face enumeration must 
 match the face enumeration of the corresponding geometrical cell.
-Note that the vertex and edge dofs are included here. Also, the
+Note that the vertex and edge dofs are included here. The
 length of each tuple must be exactly [`nvertexdofs(::Interpolation)`](@ref)+[`nedgedofs(::Interpolation)`](@ref)+[`nfacedofs(::Interpolation)`](@ref).
 """
 faces(::Interpolation)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -259,6 +259,7 @@ vertices(::Lagrange{2,RefCube,order}) where {order} = ((1,),(2,),(3,),(4,))
 vertices(::Lagrange{3,RefCube,order}) where {order} = ((1,),(2,),(3,),(4,),(5,),(6,),(7,),(8,))
 vertices(::Lagrange{2,RefTetrahedron,order}) where {order} = ((1,),(2,),(3,))
 vertices(::Lagrange{3,RefTetrahedron,order}) where {order} = ((1,),(2,),(3,),(4,))
+nvertexdofs(::Lagrange{dim,shape,order}) where {dim,shape,order} = 1
 
 getlowerdim(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{dim-1,shape,order}()
 getlowerorder(::Lagrange{dim,shape,order}) where {dim,shape,order} = Lagrange{dim,shape,order-1}()


### PR DESCRIPTION
I added more information about the interpolations that I could reconstruct over the last months + some initial grid docs related to dof management and interpolations. Note that the `AbstractCell` interface is not really well-specified at this point, so I just used the assumptions taken on `Cell` to document it for now.