### PR TITLE
RFC: Relax FieldHandler

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -306,6 +306,11 @@ function add_prescribed_dof!(ch::ConstraintHandler, constrained_dof::Int, inhomo
     return ch
 end
 
+# Lookup into an array is rather slow, so we construct a Set to speedup the lookup operation.
+function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcentities::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::AbstractVector{Int}) where {Index<:BoundaryIndex}
+    return _add!(ch, dbc, bcentities, interpolation, field_dim, offset, bcvalue, Set(cellset))
+end
+    
 function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset=1:getncells(ch.dh.grid)) where {Index<:BoundaryIndex}
     local_face_dofs, local_face_dofs_offset =
         _local_face_dofs_for_bc(interpolation, field_dim, dbc.components, offset, boundarydof_indices(eltype(bcfaces)))

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -311,7 +311,7 @@ function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcentities::Set{Index}, in
     return _add!(ch, dbc, bcentities, interpolation, field_dim, offset, bcvalue, Set(cellset))
 end
     
-function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset=1:getncells(ch.dh.grid)) where {Index<:BoundaryIndex}
+function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::Union{UnitRange{Int},Set{Int},Vector{Int}}=1:getncells(ch.dh.grid)) where {Index<:BoundaryIndex}
     local_face_dofs, local_face_dofs_offset =
         _local_face_dofs_for_bc(interpolation, field_dim, dbc.components, offset, boundarydof_indices(eltype(bcfaces)))
     copy!(dbc.local_face_dofs, local_face_dofs)
@@ -357,7 +357,7 @@ function _local_face_dofs_for_bc(interpolation, field_dim, components, offset, b
     return local_face_dofs, local_face_dofs_offset
 end
 
-function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset=1:getncells(ch.dh.grid))
+function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::Union{UnitRange{Int},Set{Int},Vector{Int}}=1:getncells(ch.dh.grid))
     if interpolation !== default_interpolation(typeof(ch.dh.grid.cells[first(cellset)]))
         @warn("adding constraint to nodeset is not recommended for sub/super-parametric approximations.")
     end
@@ -934,7 +934,7 @@ function add!(ch::ConstraintHandler{<:MixedDofHandler}, dbc::Dirichlet)
     return ch
 end
 
-function add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet; warn_not_in_cellset=true)
+function add!(ch::ConstraintHandler, fh::FieldHandler{T}, dbc::Dirichlet; warn_not_in_cellset=true) where {T}
     if warn_not_in_cellset && !(_in_cellset(ch.dh.grid, fh.cellset, dbc.faces; all=true))
         @warn("You are trying to add a constraint a face/edge/node that is not in the cellset of the fieldhandler. This location will be skipped")
     end
@@ -959,7 +959,7 @@ function add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet; warn_not_
         bcvalue = BCValues(interpolation, default_interpolation(celltype), eltype(dbc.faces))
     end
 
-    Ferrite._add!(ch, dbc, dbc.faces, interpolation, field_dim, field_offset(fh, dbc.field_name), bcvalue, fh.cellset)
+    _add!(ch, dbc, dbc.faces, interpolation, field_dim, field_offset(fh, dbc.field_name), bcvalue, fh.cellset)
     return ch
 end
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -306,7 +306,7 @@ function add_prescribed_dof!(ch::ConstraintHandler, constrained_dof::Int, inhomo
     return ch
 end
 
-function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::Set{Int}=Set{Int}(1:getncells(ch.dh.grid))) where {Index<:BoundaryIndex}
+function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfaces::Set{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset=1:getncells(ch.dh.grid)) where {Index<:BoundaryIndex}
     local_face_dofs, local_face_dofs_offset =
         _local_face_dofs_for_bc(interpolation, field_dim, dbc.components, offset, boundarydof_indices(eltype(bcfaces)))
     copy!(dbc.local_face_dofs, local_face_dofs)
@@ -352,7 +352,7 @@ function _local_face_dofs_for_bc(interpolation, field_dim, components, offset, b
     return local_face_dofs, local_face_dofs_offset
 end
 
-function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::Set{Int}=Set{Int}(1:getncells(ch.dh.grid)))
+function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::Set{Int}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset=1:getncells(ch.dh.grid))
     if interpolation !== default_interpolation(typeof(ch.dh.grid.cells[first(cellset)]))
         @warn("adding constraint to nodeset is not recommended for sub/super-parametric approximations.")
     end
@@ -960,7 +960,7 @@ end
 
 # If all==true, return true only if all items in faceset/nodeset are in the cellset
 # If all==false, return true if some items in faceset/nodeset are in the cellset
-function _in_cellset(::AbstractGrid, cellset::Set{Int}, faceset::Set{<:BoundaryIndex}; all=true)
+function _in_cellset(::AbstractGrid, cellset, faceset::Set{<:BoundaryIndex}; all=true)
     for (cellid,faceid) in faceset
         if cellid in cellset
             all || return true
@@ -971,7 +971,7 @@ function _in_cellset(::AbstractGrid, cellset::Set{Int}, faceset::Set{<:BoundaryI
     return all # if not returned by now and all==false, then no `cellid`s where in cellset
 end
 
-function _in_cellset(grid::AbstractGrid, cellset::Set{Int}, nodeset::Set{Int}; all=true)
+function _in_cellset(grid::AbstractGrid, cellset, nodeset; all=true)
     nodes = Set{Int}()
     for cellid in cellset
         for nodeid in grid.cells[cellid].nodes

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -23,9 +23,9 @@ A `FieldHandler` must fullfill the following requirements:
 
 Notice that a `FieldHandler` can hold several fields.
 """
-mutable struct FieldHandler
+struct FieldHandler{TCS}
     fields::Vector{Field}
-    cellset::Set{Int}
+    cellset::TCS
 end
 
 struct CellVector{T}
@@ -157,7 +157,7 @@ Add all fields of the [`FieldHandler`](@ref) `fh` to `dh`.
 function add!(dh::MixedDofHandler, fh::FieldHandler)
     # TODO: perhaps check that a field with the same name is the same field?
     @assert !isclosed(dh)
-    _check_same_celltype(dh.grid, collect(fh.cellset))
+    _check_same_celltype(dh.grid, fh.cellset)
     _check_cellset_intersections(dh, fh)
     # the field interpolations should have the same refshape as the cells they are applied to
     refshapes_fh = getrefshape.(getfieldinterpolations(fh))
@@ -240,10 +240,10 @@ function __close!(dh::MixedDofHandler{dim}) where {dim}
     @debug "\n\nCreating dofs\n"
     for fh in dh.fieldhandlers
         # sort the cellset since we want to loop through the cells in a fixed order
-        cellnumbers = sort(collect(fh.cellset))
+        # cellnumbers = issorted(fh.cellset) ? sort(collect(fh.cellset)) : fh.cellset
         nextdof = _close!(
             dh,
-            cellnumbers,
+            fh.cellset,
             field_names,
             getfieldnames(fh),
             getfielddims(fh),

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -23,7 +23,7 @@ function L2Projector(fe_values::Ferrite.Values, interp::Interpolation,
     # Create an internal scalar valued field. This is enough since the projection is done on a component basis, hence a scalar field.
     dh = MixedDofHandler(grid)
     field = Field(:_, interp, 1)
-    fh = FieldHandler([field], Set(set))
+    fh = FieldHandler([field], set)
     add!(dh, fh)
     _, vertex_dict, _, _ = __close!(dh)
 
@@ -80,7 +80,7 @@ function L2Projector(
     # Create an internal scalar valued field. This is enough since the projection is done on a component basis, hence a scalar field.
     dh = MixedDofHandler(grid)
     field = Field(:_, func_ip, 1) # we need to create the field, but the interpolation is not used here
-    fh = FieldHandler([field], Set(set))
+    fh = FieldHandler([field], set)
     add!(dh, fh)
     _, vertex_dict, _, _ = __close!(dh)
 

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -258,7 +258,7 @@ function _get_point_values!(
     ph::PointEvalHandler,
     dh::AbstractDofHandler,
     ip::Interpolation,
-    cellset::Union{Nothing, Set{Int}},
+    cellset,
     fdim::Val{fielddim},
     dofrange::AbstractRange{Int},
     ) where {T2,T,fielddim}

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -37,7 +37,7 @@ function test_1d_bar_beam()
 
     dh = MixedDofHandler(grid);
     add!(dh, FieldHandler([field2, field3], Set(3)));
-    add!(dh, FieldHandler([field1], Set((1, 2))));
+    add!(dh, FieldHandler([field1], 1:2));
     close!(dh)
     @test ndofs(dh) == 8
     @test celldofs(dh, 3) == collect(1:6)
@@ -146,7 +146,7 @@ function test_face_dofs_2_tri()
     grid = Grid(cells, nodes);
     field1 = create_field(name = :u, spatial_dim = 2, field_dim = 2, order = 2, cellshape = RefTetrahedron)
     dh = MixedDofHandler(grid);
-    add!(dh, FieldHandler([field1], Set((1, 2))));
+    add!(dh, FieldHandler([field1], 1:2));
     #add!(dh, FieldHandler([field2], Set(2)));
     close!(dh)
 
@@ -169,7 +169,7 @@ function test_3d_tetrahedrons()
     grid = Grid(cells, nodes)
     field = create_field(name = :u, spatial_dim=3,  field_dim = 3, order = 2, cellshape = RefTetrahedron)
     dh = MixedDofHandler(grid);
-    add!(dh, FieldHandler([field], Set((1, 2, 3, 4, 5, 6))));
+    add!(dh, FieldHandler([field], 1:6));
     close!(dh)
 
     # reference using the regular DofHandler
@@ -229,7 +229,7 @@ function test_2d_mixed_field_triangles()
     field1 = create_field(name=:u, spatial_dim=2, field_dim=2, order=2, cellshape=RefTetrahedron)
     field2 = create_field(name=:p, spatial_dim=2, field_dim=1, order=1, cellshape=RefTetrahedron)
     dh = MixedDofHandler(grid);
-    add!(dh, FieldHandler([field1, field2], Set((1, 2))));
+    add!(dh, FieldHandler([field1, field2], 1:2));
     close!(dh)
     @test ndofs(dh) == 22
     @test celldofs(dh, 1) == collect(1:15)
@@ -394,7 +394,7 @@ function test_element_order()
 
     dh = MixedDofHandler(grid);
     # Note the jump in cell numbers
-    add!(dh, FieldHandler([field1_tri], Set((1, 3))));
+    add!(dh, FieldHandler([field1_tri], [1,3]));
     add!(dh, FieldHandler([field1_quad], Set(2)));
     # Dofs are first created for cell 1 and 3, thereafter cell 2
     close!(dh)
@@ -519,7 +519,7 @@ function test_subparametric_triangle()
     ip = Lagrange{2,RefTetrahedron,2}()
     
     field = Field(:u, ip, 2)
-    fh = FieldHandler([field], Set(1:getncells(grid)))
+    fh = FieldHandler([field], 1:getncells(grid))
     
     dh = MixedDofHandler(grid)
     add!(dh, fh)


### PR DESCRIPTION
This change should eliminate the internal collect calls. If a user strongly depends on the ordering while only having a `cellset::Set{Int}`, then the collect should be done manually during construction once (instead of several times internally).

I also noticed that the FieldHandler was marked mutable. Is this legacy or is there some deeper reason downstream in some framework utilizing Ferrite as backend?

## TODOs
* [ ] OrderedSet for grid cellset
* [ ] Test coverage
* [ ] Docs
* [ ] Devdocs