### PR TITLE
Making Lagrange2Tri345 interpolation values exact

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -554,7 +554,7 @@ function value(ip::Lagrange2Tri345, i::Int, ξ::Vec{2})
     ξ_y = ξ[2]
     i1, i2, i3 = _numlin_basis2D(i, order)
     val = one(ξ_y)
-    i1 ≥ 1 && (val *= prod((order*1-order*( ξ_x +  ξ_y )-j) / (j + 1) for j = 0:(i1 - 1)))
+    i1 ≥ 1 && (val *= prod((order - order * (ξ_x + ξ_y ) - j) / (j + 1) for j = 0:(i1 - 1)))
     i2 ≥ 1 && (val *= prod((order * ξ_x - j) / (j + 1) for j = 0:(i2 - 1)))
     i3 ≥ 1 && (val *= prod((order * ξ_y - j) / (j + 1) for j = 0:(i3 - 1)))
     return val

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -552,10 +552,9 @@ function value(ip::Lagrange2Tri345, i::Int, ξ::Vec{2})
     i = permdof2DLagrange2Tri345[order][i]
     ξ_x = ξ[1]
     ξ_y = ξ[2]
-    γ = 1. - ξ_x - ξ_y
     i1, i2, i3 = _numlin_basis2D(i, order)
-    val = one(γ)
-    i1 ≥ 1 && (val *= prod((order * γ - j) / (j + 1) for j = 0:(i1 - 1)))
+    val = one(ξ_y)
+    i1 ≥ 1 && (val *= prod((order*1-order*( ξ_x +  ξ_y )-j) / (j + 1) for j = 0:(i1 - 1)))
     i2 ≥ 1 && (val *= prod((order * ξ_x - j) / (j + 1) for j = 0:(i2 - 1)))
     i3 ≥ 1 && (val *= prod((order * ξ_y - j) / (j + 1) for j = 0:(i3 - 1)))
     return val

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -9,7 +9,7 @@
                       Lagrange{2, RefTetrahedron, 2}(),
                       Lagrange{2, RefTetrahedron, 3}(),
                       Lagrange{2, RefTetrahedron, 4}(),
-                      #Lagrange{2, RefTetrahedron, 5}(),
+                      Lagrange{2, RefTetrahedron, 5}(),
                       Lagrange{3, RefCube, 1}(),
                       Lagrange{3, RefCube, 2}(),
                       Serendipity{2, RefCube, 2}(),


### PR DESCRIPTION
Fixes #582, turns out the issue was with `γ` and Float64 precision. using `γ` directly (multiplying `1` and `-( ξ_x +  ξ_y )` by `order` individually) seems to solve the issue.
Interpolation tests passed:
```Julia
Test Summary:  | Pass  Total   Time
interpolations | 3466   3466  47.5s
```