### PR TITLE
Update dof storage in MixedDofHandler

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -344,14 +344,6 @@ end
 
 cellcoords!(global_coords::Vector{<:Vec}, dh::DofHandler, i::Int) = cellcoords!(global_coords, dh.grid, i)
 
-function celldofs(dh::DofHandler, i::Int)
-    @assert isclosed(dh)
-    n = ndofs_per_cell(dh, i)
-    global_dofs = zeros(Int, n)
-    unsafe_copyto!(global_dofs, 1, dh.cell_dofs, dh.cell_dofs_offset[i], n)
-    return global_dofs
-end
-
 # Compute a coupling matrix of size (ndofs_per_cell × ndofs_per_cell) based on the input
 # coupling which can be of size i) (nfields × nfields) specifying coupling between fields,
 # ii) (ncomponents × ncomponents) specifying coupling between components, or iii)

--- a/src/Dofs/DofRenumbering.jl
+++ b/src/Dofs/DofRenumbering.jl
@@ -81,10 +81,8 @@ end
 
 function _renumber!(dh::Union{DofHandler, MixedDofHandler}, perm::AbstractVector{<:Integer})
     @assert isclosed(dh)
-    cell_dofs = dh isa DofHandler ? dh.cell_dofs :
-                #= dh isa MixedDofHandler ? =# dh.cell_dofs.values
-    for i in eachindex(cell_dofs)
-        cell_dofs[i] = perm[cell_dofs[i]]
+    for i in eachindex(dh.cell_dofs)
+        dh.cell_dofs[i] = perm[dh.cell_dofs[i]]
     end
     return dh
 end

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -129,10 +129,10 @@ end
     renumber!(dh, perm)
     renumber!(dh, iperm)
     @test original_dofs == dh.cell_dofs
-    original_dofs_mdh = copy(mdh.cell_dofs.values)
+    original_dofs_mdh = copy(mdh.cell_dofs)
     renumber!(mdh, perm)
     renumber!(mdh, iperm)
-    @test original_dofs_mdh == mdh.cell_dofs.values
+    @test original_dofs_mdh == mdh.cell_dofs
     original_prescribed = copy(ch.prescribed_dofs)
     original_inhomogeneities = copy(ch.inhomogeneities)
     original_affine_inhomogeneities = copy(ch.affine_inhomogeneities)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -64,7 +64,7 @@ function test_2d_scalar()
 
     # THEN: we expect 5 dofs and dof 2 and 3 being shared
     @test ndofs(dh) == 5
-    @test dh.cell_dofs.values == [1, 2, 3, 4, 3, 2, 5]
+    @test dh.cell_dofs == [1, 2, 3, 4, 3, 2, 5]
     @test celldofs(dh, 1) == [1, 2, 3, 4]
     @test celldofs(dh, 2) == [3, 2, 5]
 end


### PR DESCRIPTION
Since #577 the CellVector struct does not seem necessary anymore since it is only used in one place for dof storage. This patch removes the struct and inlines the fields directly in the MixedDofHandler struct instead, similar to the DofHandler struct. Also removes some duplicate code for celldofs(...).