### PR TITLE
Reduce memory footprint in dof distribution for MixedDofHandler

### DIFF
--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -7,7 +7,7 @@ struct L2Projector <: AbstractProjector
     M_cholesky #::SuiteSparse.CHOLMOD.Factor{Float64}
     dh::MixedDofHandler
     set::Vector{Int}
-    node2dof_map::Dict{Int64, Array{Int64,N} where N}
+    node2dof_map::Dict{Int,Int}
     fe_values::Union{CellValues,Nothing} # only used for deprecated constructor
     qr_rhs::Union{QuadratureRule,Nothing}    # only used for deprecated constructor
 end
@@ -217,8 +217,7 @@ function project(proj::L2Projector,
         reordered_vals = fill(convert(T, NaN * zero(T)), nnodes)
         for node = 1:nnodes
             if (k = get(proj.node2dof_map, node, nothing); k !== nothing)
-                @assert length(k) == 1
-                reordered_vals[node] = projected_vals[k[1]]
+                reordered_vals[node] = projected_vals[k]
             end
         end
         return reordered_vals


### PR DESCRIPTION
This reduces memory used in dof distribution for MixedDofHandler by only storing the first dof that are added for every entity, instead of the range of dofs. This simply copies the logic from DofHandler, which also means that MixedDofHandler now also support multiple dofs per face in 2D, but not in 3D, just like DofHandler.

This closes the performance gap between the DofHandlers (benchmark code from #637):

```
1.397 s (257 allocations: 543.50 MiB) # MixedDofHandler master
1.220 s (249 allocations: 456.05 MiB) # MixedDofHandler patch
1.267 s (234 allocations: 405.12 MiB) # DofHandler master/patch
```