### PR TITLE
Use vectors instead of dicts for keeping track of vertex dofs

### DIFF
--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -7,7 +7,7 @@ struct L2Projector <: AbstractProjector
     M_cholesky #::SuiteSparse.CHOLMOD.Factor{Float64}
     dh::MixedDofHandler
     set::Vector{Int}
-    node2dof_map::Dict{Int,Int}
+    node2dof_map::Vector{Int}
     fe_values::Union{CellValues,Nothing} # only used for deprecated constructor
     qr_rhs::Union{QuadratureRule,Nothing}    # only used for deprecated constructor
 end
@@ -216,7 +216,7 @@ function project(proj::L2Projector,
         nnodes = getnnodes(proj.dh.grid)
         reordered_vals = fill(convert(T, NaN * zero(T)), nnodes)
         for node = 1:nnodes
-            if (k = get(proj.node2dof_map, node, nothing); k !== nothing)
+            if (k = proj.node2dof_map[node]; k != 0)
                 reordered_vals[node] = projected_vals[k]
             end
         end


### PR DESCRIPTION
This patch changes the storage for vertex dof tracking from dictionaries to vectors. This is possible since we know already from the start the number of vertices and their global numbers. Since dof distribution is almost 100% dict hashing this give a pretty big performance boost.

Running the benchmark code from #637:

```
1.267 s (234 allocations: 405.12 MiB)    # DofHandler master
812.388 ms (130 allocations: 290.07 MiB) # DofHandler patch
1.220 s (249 allocations: 456.05 MiB)    # MixedDofHandler master
838.601 ms (145 allocations: 341.00 MiB) # MixedDofHandler patch
```

Note that the same optimization can be done for edges/faces too if those were globally enumerated. Fortunately vertex dofs are the most common case so implementing this is not a high priority.