### PR TITLE
Remove `getfielddims`/`getfieldinterpolations`/`getfieldnames` for `FieldHandler`

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -914,7 +914,7 @@ end
 function add!(ch::ConstraintHandler{<:MixedDofHandler}, dbc::Dirichlet)
     dbc_added = false
     for fh in ch.dh.fieldhandlers
-        if dbc.field_name in getfieldnames(fh) && _in_cellset(ch.dh.grid, fh.cellset, dbc.faces; all=false)
+        if !isnothing(_find_field(fh, dbc.field_name)) && _in_cellset(ch.dh.grid, fh.cellset, dbc.faces; all=false)
             # Dofs in `dbc` not in `fh` will be removed, hence `dbc.faces` must be copied.
             # Recreating the `dbc` will create a copy of `dbc.faces`.
             # In this case, add! will warn, unless `warn_not_in_cellset=false`
@@ -938,8 +938,8 @@ function add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet; warn_not_
 
     # Extract stuff for the field
     field_idx = find_field(fh, dbc.field_name)
-    interpolation = getfieldinterpolations(fh)[field_idx]
-    field_dim = getfielddims(fh)[field_idx]
+    interpolation = getfieldinterpolation(fh, field_idx)
+    field_dim = getfielddim(fh, field_idx)
 
     if !all(c -> 0 < c <= field_dim, dbc.components)
         error("components $(dbc.components) not within range of field :$(dbc.field_name) ($(field_dim) dimension(s))")

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -70,10 +70,6 @@ function Base.show(io::IO, ::MIME"text/plain", dh::MixedDofHandler)
     end
 end
 
-getfieldnames(fh::FieldHandler) = [field.name for field in fh.fields]
-getfielddims(fh::FieldHandler) = [field.dim for field in fh.fields]
-getfieldinterpolations(fh::FieldHandler) = [field.interpolation for field in fh.fields]
-
 """
     ndofs_per_cell(dh::AbstractDofHandler[, cell::Int=1])
 
@@ -120,7 +116,6 @@ end
 
 """
     getfieldnames(dh::MixedDofHandler)
-    getfieldnames(fh::FieldHandler)
 
 Return a vector with the names of all fields. Can be used as an iterable over all the fields
 in the problem.

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -51,7 +51,7 @@ function apply_analytical!(
     ip_geos = _default_interpolations(dh)
 
     for (fh, ip_geo) in zip(dh.fieldhandlers, ip_geos)
-        fieldname ∈ getfieldnames(fh) || continue
+        isnothing(_find_field(fh, fieldname)) && continue
         field_idx = find_field(fh, fieldname)
         ip_fun = getfieldinterpolation(fh, field_idx)
         field_dim = getfielddim(fh, field_idx)

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -296,7 +296,7 @@ get_func_interpolations(dh::DH, fieldname) where DH<:DofHandler = [getfieldinter
 function get_func_interpolations(dh::DH, fieldname) where DH<:MixedDofHandler
     func_interpolations = Union{Interpolation,Nothing}[]
     for fh in dh.fieldhandlers
-        j = findfirst(i -> i === fieldname, getfieldnames(fh))
+        j = _find_field(fh, fieldname)
         if j === nothing
             push!(func_interpolations, missing)
         else

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -68,7 +68,7 @@
     function _global_dof_range(dh::MixedDofHandler, field_name::Symbol)
         dofs = Set{Int}()
         for fh in dh.fieldhandlers
-            if field_name ∈ Ferrite.getfieldnames(fh)
+            if !isnothing(Ferrite._find_field(fh, field_name))
                 _global_dof_range!(dofs, dh, fh, field_name, fh.cellset)
             end
         end


### PR DESCRIPTION
These were a bit of an anti-pattern as they needed to allocate vectors. Instead of using these, one should iterate over the fields instead.