### PR TITLE
Add method hasfieldname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+ - `hasfieldname` method added for checking if a fieldname exists in an `AbstractDofHandler`/`FieldHandler`. 
+
+### Internal changes
+ - `getfielddims(::FieldHandler)`, `getfieldinterpolations(::FieldHandler)`, and `getfieldnames(::FieldHandler)` removed ([#647][github-647])
 
 ## [0.3.13] - 2023-03-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
- - `hasfieldname` method added for checking if a fieldname exists in an `AbstractDofHandler`/`FieldHandler`. 
+ - `hasfieldname` method added for checking if a fieldname exists in an `AbstractDofHandler`/`FieldHandler` ([#648][github-648])
 
 ### Internal changes
  - `getfielddims(::FieldHandler)`, `getfieldinterpolations(::FieldHandler)`, and `getfieldnames(::FieldHandler)` removed ([#647][github-647])
@@ -376,6 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-614]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/614
 [github-621]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/621
 [github-633]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/633
+[github-647]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/647
+[github-648]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/648
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.13...HEAD
 [0.3.13]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.12...v0.3.13

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -914,7 +914,7 @@ end
 function add!(ch::ConstraintHandler{<:MixedDofHandler}, dbc::Dirichlet)
     dbc_added = false
     for fh in ch.dh.fieldhandlers
-        if !isnothing(_find_field(fh, dbc.field_name)) && _in_cellset(ch.dh.grid, fh.cellset, dbc.faces; all=false)
+        if hasfieldname(fh, dbc.field_name) && _in_cellset(ch.dh.grid, fh.cellset, dbc.faces; all=false)
             # Dofs in `dbc` not in `fh` will be removed, hence `dbc.faces` must be copied.
             # Recreating the `dbc` will create a copy of `dbc.faces`.
             # In this case, add! will warn, unless `warn_not_in_cellset=false`

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -58,6 +58,13 @@ function find_field(dh::DofHandler, field_name::Symbol)
     return j
 end
 
+"""
+    hasfieldname(dh::AbstractDofHandler, field_name::Symbol)
+
+Check if `field_name` is the name of a field in `dh`
+"""
+hasfieldname(dh::AbstractDofHandler, field_name::Symbol) = field_name ∈ getfieldnames(dh)
+
 # Calculate the offset to the first local dof of a field
 function field_offset(dh::DofHandler, field_name::Symbol)
     offset = 0

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -478,6 +478,8 @@ function _find_field(fh::FieldHandler, field_name::Symbol)
     return nothing
 end
 
+hasfieldname(fh::FieldHandler, field_name::Symbol) = !isnothing(_find_field(fh, field_name))
+
 # Calculate the offset to the first local dof of a field
 function field_offset(fh::FieldHandler, field_idx::Int)
     offset = 0

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -34,7 +34,7 @@ function apply_analytical!(
     a::AbstractVector, dh::DofHandler, fieldname::Symbol, f::Function,
     cellset = 1:getncells(dh.grid))
 
-    fieldname ∉ getfieldnames(dh) && error("The fieldname $fieldname was not found in the dof handler")
+    hasfieldname(dh, fieldname) || error("The fieldname $fieldname was not found in the dof handler")
     ip_geo = _default_interpolation(dh)
     field_idx = find_field(dh, fieldname)
     ip_fun = getfieldinterpolation(dh, field_idx)
@@ -47,11 +47,11 @@ function apply_analytical!(
     a::AbstractVector, dh::MixedDofHandler, fieldname::Symbol, f::Function,
     cellset = 1:getncells(dh.grid))
 
-    fieldname ∉ getfieldnames(dh) && error("The fieldname $fieldname was not found in the dof handler")
+    hasfieldname(dh, fieldname) || error("The fieldname $fieldname was not found in the dof handler")
     ip_geos = _default_interpolations(dh)
 
     for (fh, ip_geo) in zip(dh.fieldhandlers, ip_geos)
-        isnothing(_find_field(fh, fieldname)) && continue
+        hasfieldname(fh, fieldname) || continue
         field_idx = find_field(fh, fieldname)
         ip_fun = getfieldinterpolation(fh, field_idx)
         field_dim = getfielddim(fh, field_idx)


### PR DESCRIPTION
I was using the `getfieldnames(::FieldHandler)` antipattern in dependent packages. 
With this gone, the "simple" option is to check if `_find_field(fh, name)` returns `nothing`, but this method is clearly marked as internal. Hence, I propose adding a simple way for checking if a fieldhandler/dofhandler has a given field. 

(I also added a CHANGELOG entry for the removed methods in #647 in case someone else also was using these.)