### PR TITLE
Move shared dofhandler functionality out of DofHandler.jl

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -306,13 +306,6 @@ function WriteVTK.vtk_grid(filename::AbstractString, dh::AbstractDofHandler; com
     vtk_grid(filename, dh.grid; compress=compress)
 end
 
-"""
-    reshape_to_nodes(dh::AbstractDofHandler, u::Vector{T}, fieldname::Symbol) where T
-
-Reshape the entries of the dof-vector `u` which correspond to the field `fieldname` in nodal order.
-Return a matrix with a column for every node and a row for every dimension of the field.
-For superparametric fields only the entries corresponding to nodes of the grid will be returned. Do not use this function for subparametric approximations.
-"""
 function reshape_to_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol) where T
     # make sure the field exists
     fieldname ∈ Ferrite.getfieldnames(dh) || error("Field $fieldname not found.")

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -321,23 +321,3 @@ function reshape_to_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol) where
 
     return data
 end
-
-function reshape_field_data!(data::Matrix{T}, dh::AbstractDofHandler, u::Vector{T}, field_offset::Int, field_dim::Int, cellset=1:getncells(dh.grid)) where T
-
-    for cell in CellIterator(dh, cellset, UpdateFlags(; nodes=true, coords=false, dofs=true))
-        _celldofs = celldofs(cell)
-        counter = 1
-        for node in getnodes(cell)
-            for d in 1:field_dim
-                data[d, node] = u[_celldofs[counter + field_offset]]
-                @debug println("  exporting $(u[_celldofs[counter + field_offset]]) for dof#$(_celldofs[counter + field_offset])")
-                counter += 1
-            end
-            if field_dim == 2
-                # paraview requires 3D-data so pad with zero
-                data[3, node] = 0
-            end
-        end
-    end
-    return data
-end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -40,7 +40,6 @@ function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
 end
 
 ndofs_per_cell(dh::AbstractDofHandler, cell::Int=1) = dh.cell_dofs_offset[cell+1] - dh.cell_dofs_offset[cell]
-isclosed(dh::AbstractDofHandler) = dh.closed[]
 nfields(dh::AbstractDofHandler) = length(dh.field_names)
 getfieldnames(dh::AbstractDofHandler) = dh.field_names
 ndim(dh::AbstractDofHandler, field_name::Symbol) = dh.field_dims[find_field(dh, field_name)]

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -293,10 +293,6 @@ end
 
 cellcoords!(global_coords::Vector{<:Vec}, dh::DofHandler, i::Int) = cellcoords!(global_coords, dh.grid, i)
 
-function WriteVTK.vtk_grid(filename::AbstractString, dh::AbstractDofHandler; compress::Bool=true)
-    vtk_grid(filename, dh.grid; compress=compress)
-end
-
 function reshape_to_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol) where T
     # make sure the field exists
     fieldname ∈ Ferrite.getfieldnames(dh) || error("Field $fieldname not found.")

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -1,5 +1,3 @@
-abstract type AbstractDofHandler end
-
 """
     DofHandler(grid::Grid)
 

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -124,48 +124,6 @@ function add!(dh::DofHandler, name::Symbol, ip::Interpolation=default_interpolat
     return add!(dh, name, 1, ip)
 end
 
-"""
-    sortedge(edge::Tuple{Int,Int})
-
-Returns the unique representation of an edge and its orientation.
-Here the unique representation is the sorted node index tuple. The
-orientation is `true` if the edge is not flipped, where it is `false`
-if the edge is flipped.
-"""
-function sortedge(edge::Tuple{Int,Int})
-    a, b = edge
-    a < b ? (return (edge, true)) : (return ((b, a), false))
-end
-
-"""
-    sortface(face::Tuple{Int,Int}) 
-    sortface(face::Tuple{Int,Int,Int})
-    sortface(face::Tuple{Int,Int,Int,Int})
-
-Returns the unique representation of a face.
-Here the unique representation is the sorted node index tuple.
-Note that in 3D we only need indices to uniquely identify a face,
-so the unique representation is always a tuple length 3.
-"""
-sortface(face::Tuple{Int,Int}) = minmax(face[1], face[2])
-function sortface(face::Tuple{Int,Int,Int})
-    a, b, c = face
-    b, c = minmax(b, c)
-    a, c = minmax(a, c)
-    a, b = minmax(a, b)
-    return (a, b, c)
-end
-function sortface(face::Tuple{Int,Int,Int,Int})
-    a, b, c, d = face
-    c, d = minmax(c, d)
-    b, d = minmax(b, d)
-    a, d = minmax(a, d)
-    b, c = minmax(b, c)
-    a, c = minmax(a, c)
-    a, b = minmax(a, b)
-    return (a, b, c)
-end
-
 function close!(dh::DofHandler)
     dh, _, _, _ = __close!(dh)
     return dh

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -39,12 +39,6 @@ function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
     end
 end
 
-"""
-    ndofs(dh::AbstractDofHandler)
-
-Return the number of degrees of freedom in `dh`
-"""
-ndofs(dh::AbstractDofHandler) = dh.ndofs[]
 ndofs_per_cell(dh::AbstractDofHandler, cell::Int=1) = dh.cell_dofs_offset[cell+1] - dh.cell_dofs_offset[cell]
 isclosed(dh::AbstractDofHandler) = dh.closed[]
 nfields(dh::AbstractDofHandler) = length(dh.field_names)

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -1,3 +1,5 @@
+abstract type AbstractDofHandler end
+
 """
     Field(name::Symbol, interpolation::Interpolation, dim::Int)
 

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -633,3 +633,23 @@ function reshape_to_nodes(dh::MixedDofHandler, u::Vector{T}, fieldname::Symbol) 
     end
     return data
 end
+
+function reshape_field_data!(data::Matrix{T}, dh::AbstractDofHandler, u::Vector{T}, field_offset::Int, field_dim::Int, cellset=1:getncells(dh.grid)) where T
+
+    for cell in CellIterator(dh, cellset, UpdateFlags(; nodes=true, coords=false, dofs=true))
+        _celldofs = celldofs(cell)
+        counter = 1
+        for node in getnodes(cell)
+            for d in 1:field_dim
+                data[d, node] = u[_celldofs[counter + field_offset]]
+                @debug println("  exporting $(u[_celldofs[counter + field_offset]]) for dof#$(_celldofs[counter + field_offset])")
+                counter += 1
+            end
+            if field_dim == 2
+                # paraview requires 3D-data so pad with zero
+                data[3, node] = 0
+            end
+        end
+    end
+    return data
+end

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -73,6 +73,13 @@ function Base.show(io::IO, ::MIME"text/plain", dh::MixedDofHandler)
 end
 
 """
+    ndofs(dh::AbstractDofHandler)
+
+Return the number of degrees of freedom in `dh`
+"""
+ndofs(dh::AbstractDofHandler) = dh.ndofs[]
+
+"""
     ndofs_per_cell(dh::AbstractDofHandler[, cell::Int=1])
 
 Return the number of degrees of freedom for the cell with index `cell`.

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -608,6 +608,13 @@ end
 getfieldinterpolation(fh::FieldHandler, field_idx::Int) = fh.fields[field_idx].interpolation
 getfieldinterpolation(fh::FieldHandler, field_name::Symbol) = getfieldinterpolation(fh, find_field(fh, field_name))
 
+"""
+    reshape_to_nodes(dh::AbstractDofHandler, u::Vector{T}, fieldname::Symbol) where T
+
+Reshape the entries of the dof-vector `u` which correspond to the field `fieldname` in nodal order.
+Return a matrix with a column for every node and a row for every dimension of the field.
+For superparametric fields only the entries corresponding to nodes of the grid will be returned. Do not use this function for subparametric approximations.
+"""
 function reshape_to_nodes(dh::MixedDofHandler, u::Vector{T}, fieldname::Symbol) where T
     # make sure the field exists
     fieldname ∈ getfieldnames(dh) || error("Field $fieldname not found.")

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -72,6 +72,8 @@ function Base.show(io::IO, ::MIME"text/plain", dh::MixedDofHandler)
     end
 end
 
+isclosed(dh::AbstractDofHandler) = dh.closed[]
+
 """
     ndofs(dh::AbstractDofHandler)
 

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -424,6 +424,49 @@ function add_cell_dofs(cell_dofs, field_dim, ncelldofs, nextdof)
 end
 
 """
+    sortedge(edge::Tuple{Int,Int})
+
+Returns the unique representation of an edge and its orientation.
+Here the unique representation is the sorted node index tuple. The
+orientation is `true` if the edge is not flipped, where it is `false`
+if the edge is flipped.
+"""
+function sortedge(edge::Tuple{Int,Int})
+    a, b = edge
+    a < b ? (return (edge, true)) : (return ((b, a), false))
+end
+
+"""
+    sortface(face::Tuple{Int,Int}) 
+    sortface(face::Tuple{Int,Int,Int})
+    sortface(face::Tuple{Int,Int,Int,Int})
+
+Returns the unique representation of a face.
+Here the unique representation is the sorted node index tuple.
+Note that in 3D we only need indices to uniquely identify a face,
+so the unique representation is always a tuple length 3.
+"""
+sortface(face::Tuple{Int,Int}) = minmax(face[1], face[2])
+function sortface(face::Tuple{Int,Int,Int})
+    a, b, c = face
+    b, c = minmax(b, c)
+    a, c = minmax(a, c)
+    a, b = minmax(a, b)
+    return (a, b, c)
+end
+function sortface(face::Tuple{Int,Int,Int,Int})
+    a, b, c, d = face
+    c, d = minmax(c, d)
+    b, d = minmax(b, d)
+    a, d = minmax(a, d)
+    b, c = minmax(b, c)
+    a, c = minmax(a, c)
+    a, b = minmax(a, b)
+    return (a, b, c)
+end
+
+
+"""
     find_field(dh::MixedDofHandler, field_name::Symbol)::NTuple{2,Int}
 
 Return the index of the field with name `field_name` in a `MixedDofHandler`. The index is a

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -108,6 +108,10 @@ the cell is in the set and 0 otherwise.
 vtk_cellset(vtk::WriteVTK.DatasetFile, grid::AbstractGrid, cellset::String) =
     vtk_cellset(vtk, grid, [cellset])
 
+function WriteVTK.vtk_grid(filename::AbstractString, dh::AbstractDofHandler; compress::Bool=true)
+    vtk_grid(filename, dh.grid; compress=compress)
+end
+
 function WriteVTK.vtk_point_data(vtkfile, dh::AbstractDofHandler, u::Vector, suffix="")
 
     fieldnames = Ferrite.getfieldnames(dh)  # all primary fields

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -86,8 +86,8 @@ include("Grid/grid_generators.jl")
 include("Grid/coloring.jl")
 
 # Dofs
-include("Dofs/DofHandler.jl")
 include("Dofs/MixedDofHandler.jl")
+include("Dofs/DofHandler.jl")
 include("Dofs/ConstraintHandler.jl")
 include("Dofs/apply_analytical.jl")
 include("Dofs/sparsity_pattern.jl")


### PR DESCRIPTION
No functional change. This PR moves all functionality that is shared between the dofhandlers out of `Dofs/DofHandler.jl` in order to prepare for removing that file in the future.