### PR TITLE
Create a `BitSet` of `FieldHandler.cellset` in loops

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -265,8 +265,8 @@ function __close!(dh::MixedDofHandler{dim}) where {dim}
 
     @debug "\n\nCreating dofs\n"
     for fh in dh.fieldhandlers
-        # sort the cellset since we want to loop through the cells in a fixed order
-        cellnumbers = sort(collect(fh.cellset))
+        # TODO: Remove BitSet construction when SubDofHandler ensures sorted collections
+        cellnumbers = BitSet(fh.cellset)
         nextdof = _close!(
             dh,
             cellnumbers,

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -130,7 +130,8 @@ function _create_sparsity_pattern(dh::AbstractDofHandler, ch#=::Union{Constraint
 
     for (fhi, fh) in pairs(dh isa DofHandler ? (dh, ) : dh.fieldhandlers)
         coupling === nothing || (coupling_fh = couplings[fhi])
-        set = fh isa DofHandler ? (1:getncells(dh.grid)) : fh.cellset
+        # TODO: Remove BitSet construction when SubDofHandler ensures sorted collections
+        set = fh isa DofHandler ? (1:getncells(dh.grid)) : BitSet(fh.cellset)
         n = ndofs_per_cell(dh, first(set)) # TODO: ndofs_per_cell(fh)
         resize!(global_dofs, n)
         @inbounds for element_id in set


### PR DESCRIPTION
This patch creates a `BitSet` of `FieldHandler.cellset` in loops, in particular in `close!(::DofHandler)` and
`create_sparsity_pattern(::DofHandler)`. Since `BitSet`s are sorted this ensures that these loops are done in ascending cell order, which gives a performance boost due to better memory locality.

This is an even smaller change than #654 (and #625) which should be completely non-breaking since the type of `FieldHandler.cellset` is not changed. Larger refactoring, such as using `BitSet` or `OrderedSet` will be done in the `FieldHandler/`SubDofHandler` rework.