### PR TITLE
remove Ferrite.ndim(dh, fieldname)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    sparsity pattern. ([#650][github-650])
  - Support Metis dof reordering with coupling information for `MixedDofHandler`.
    ([#650][github-650])
+### Internal changes
+- `Ferrite.ndim(dh, fieldname)` has been removed, use `Ferrite.getfielddim(dh,
+  fieldname)` instead.
 
 ## [0.3.13] - 2023-03-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    ([#650][github-650])
 ### Internal changes
 - `Ferrite.ndim(dh, fieldname)` has been removed, use `Ferrite.getfielddim(dh,
-  fieldname)` instead.
+  fieldname)` instead. ([#658][github-658])
 
 ## [0.3.13] - 2023-03-23
 ### Added
@@ -384,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-633]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/633
 [github-645]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/645
 [github-650]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/650
+[github-658]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/658
 
 [Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.13...HEAD
 [0.3.13]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.12...v0.3.13

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -512,7 +512,7 @@ function WriteVTK.vtk_point_data(vtkfile, ch::ConstraintHandler)
     unique!(unique_fields)
 
     for field in unique_fields
-        nd = ndim(ch.dh, field)
+        nd = getfielddim(ch.dh, field)
         data = zeros(Float64, nd, getnnodes(ch.dh.grid))
         for dbc in ch.dbcs
             dbc.field_name != field && continue

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -42,7 +42,7 @@ end
 ndofs_per_cell(dh::AbstractDofHandler, cell::Int=1) = dh.cell_dofs_offset[cell+1] - dh.cell_dofs_offset[cell]
 nfields(dh::AbstractDofHandler) = length(dh.field_names)
 getfieldnames(dh::AbstractDofHandler) = dh.field_names
-ndim(dh::AbstractDofHandler, field_name::Symbol) = dh.field_dims[find_field(dh, field_name)]
+
 function find_field(dh::DofHandler, field_name::Symbol)
     j = findfirst(i->i == field_name, dh.field_names)
     j === nothing && error("could not find field :$field_name in DofHandler (existing fields: $(getfieldnames(dh)))")


### PR DESCRIPTION
As the diff shows this was almost unused and also duplicate functionality of `getfielddim`.