### PR TITLE
Use `BitSet` in `apply_analytical!` and `reshape_to_nodes`

### DIFF
--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -667,7 +667,7 @@ function reshape_to_nodes(dh::MixedDofHandler, u::Vector{T}, fieldname::Symbol) 
         field_idx === nothing && continue
         offset = field_offset(fh, field_idx)
 
-        reshape_field_data!(data, dh, u, offset, field_dim, fh.cellset)
+        reshape_field_data!(data, dh, u, offset, field_dim, BitSet(fh.cellset))
     end
     return data
 end

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -56,7 +56,12 @@ function apply_analytical!(
         ip_fun = getfieldinterpolation(fh, field_idx)
         field_dim = getfielddim(fh, field_idx)
         celldofinds = dof_range(fh, fieldname)
-        _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, intersect(fh.cellset, cellset))
+        set_intersection = if length(cellset) == length(fh.cellset) == getncells(dh.grid)
+            BitSet(1:getncells(dh.grid))
+        else
+            intersect(BitSet(fh.cellset), BitSet(cellset))
+        end
+        _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)
     end
     return a
 end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -120,7 +120,7 @@ onboundary(cc::CellCache, face::Int) = cc.grid.boundary_matrix[face, cc.cellid[]
 ## CellIterator ##
 ##################
 
-const IntegerCollection = Union{Set{<:Integer}, AbstractVector{<:Integer}}
+const IntegerCollection = Union{AbstractSet{<:Integer}, AbstractVector{<:Integer}}
 
 """
     CellIterator(grid::Grid, cellset=1:getncells(grid))


### PR DESCRIPTION
This patch uses `BitSet` in `apply_analytical!` and `reshape_to_nodes` for `MixedDofHandler`. The benefit here is twofold: computing the intersection is much faster (basically just bitwise `&`) and the subsequent looping over the cells are done in ascending cell order.

This closes the performance gap between `MixedDofHandler` and `DofHandler` in benchmarks from #629 of `apply_analytical!`, `reshape_to_nodes`, and `vtk_point_data`. For example, here is the benchmark results for `apply_analytical!`:
```
387.853 ms (72 allocations: 34.50 MiB)  # MixedDofHandler master
 55.262 ms (38 allocations: 553.45 KiB) # MixedDofHandler patch
 41.861 ms (14 allocations: 2.27 KiB)   # DofHandler master/patch
```