### PR TITLE
Replace deprecated functions in tests/examples

### DIFF
--- a/docs/src/literate/computational_homogenization.jl
+++ b/docs/src/literate/computational_homogenization.jl
@@ -196,17 +196,17 @@ using FerriteGmsh
 #src notebook: use coarse mesh to decrease build time
 #src   script: use the fine mesh
 #src markdown: use the coarse mesh to decrease build time, but make it look like the fine
-#nb ## grid = saved_file_to_grid("periodic-rve.msh")
-#nb grid = saved_file_to_grid("periodic-rve-coarse.msh")
-#jl ## grid = saved_file_to_grid("periodic-rve-coarse.msh")
-#jl grid = saved_file_to_grid("periodic-rve.msh")
-#md grid = saved_file_to_grid("periodic-rve.msh")
+#nb ## grid = togrid("periodic-rve.msh")
+#nb grid = togrid("periodic-rve-coarse.msh")
+#jl ## grid = togrid("periodic-rve-coarse.msh")
+#jl grid = togrid("periodic-rve.msh")
+#md grid = togrid("periodic-rve.msh")
 #-
 #md grid = redirect_stdout(devnull) do                #hide
-#md     saved_file_to_grid("periodic-rve-coarse.msh") #hide
+#md     togrid("periodic-rve-coarse.msh") #hide
 #md end                                               #hide
 
-grid = saved_file_to_grid("periodic-rve.msh") #src
+grid = togrid("periodic-rve.msh") #src
 
 # Next we construct the interpolation and quadrature rule, and combining them into
 # cellvalues as usual:

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -598,8 +598,8 @@ function test_show()
     field1 = create_field(name=:u, spatial_dim=2, field_dim=2, order=1, cellshape=RefCube)
     field2 = create_field(name=:u, spatial_dim=2, field_dim=2, order=1, cellshape=RefTetrahedron)
     dh = DofHandler(grid);
-    push!(dh, FieldHandler([field1], Set(1)));
-    push!(dh, FieldHandler([field2], Set(2)));
+    add!(dh, FieldHandler([field1], Set(1)));
+    add!(dh, FieldHandler([field2], Set(2)));
     close!(dh)
     @test repr("text/plain", dh) == repr(typeof(dh)) * "\n  Fields:\n    :u, dim: 2\n  Total dofs: 10"
 end


### PR DESCRIPTION
Fixes two simple cases where deprecated functions are used. 