### PR TITLE
Add `ndofs_per_cell(::FieldHandler)`

### DIFF
--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -134,7 +134,9 @@ function test_2d_mixed_2_el()
     # THEN: we expect 15 dofs
     @test ndofs(dh) == 15
     @test ndofs_per_cell(dh, 1) == 12
+    @test ndofs_per_cell(dh.fieldhandlers[1]) == 12
     @test ndofs_per_cell(dh, 2) == 9
+    @test ndofs_per_cell(dh.fieldhandlers[2]) == 9
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     @test celldofs(dh, 2) == [5, 6, 3, 4, 13, 14, 11, 10, 15]
 end


### PR DESCRIPTION
Since #657 the number of dofs per cell is stored in the `FieldHandler` struct. This patch adds the method `ndofs_per_cell(::FieldHandler)` to extract this information, which avoids the extra indirection of first looking up the correct field handler for the cell of interest.

Typically this method is used for initializing cell buffers such as the local matrix and vector. In the non-mixed case it is natural to do it just once by calling `ndofs_per_cell(::DofHandler)`. In the mixed case it must generally be called once per field handler, which you can now do directly using the method added in this patch. Previously, it was necessary to resort to the ugly workaround of first looking up a cell id in the set, i.e. `first((fh::FieldHandler).cellset)`, and then looking up the number of dofs by calling the method
`ndofs_per_cell(::DofHandler, ::Int)`.