### PR TITLE
Speed up transform!(grid, f)

### DIFF
--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -620,13 +620,9 @@ end
 
 Transform all nodes of the `grid` based on some transformation function `f`.
 """
-function transform!(g::AbstractGrid, f::Function)
-    c = similar(g.nodes)
-    for i in 1:length(c)
-        c[i] = Node(f(g.nodes[i].x))
-    end
-    copyto!(g.nodes, c)
-    g
+function transform!(g::Grid, f::Function)
+    map!(n -> Node(f(getcoordinates(n))), g.nodes, g.nodes)
+    return g
 end
 
 # Sets


### PR DESCRIPTION
Speeds up transform! and removes allocations
```julia
using Ferrite, BenchmarkTools
grid = generate_grid(Quadrilateral, (200,200));
f(x::Vec{2}) = x*1.01;
gtmp = deepcopy(grid); @btime transform!($gtmp, $f); # PR:  30.600 μs (0 allocations: 0 bytes)
gtmp = deepcopy(grid); @btime transform!($gtmp, $f); # master: 86.100 μs (2 allocations: 631.36 KiB)
```
Note: It disallows `AbstractGrid` as it assumes the grid's nodes are stored as `Node` and that the grid has the field `grid.nodes`. 