### PR TITLE
Remove old `vertexdof_indices` method

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -502,8 +502,6 @@ const permdof2DLagrange2Tri345 = Dict{Int,Vector{Int}}(
     5 => [6, 21, 1, 11, 15, 18, 20, 19, 16, 12, 7, 2, 3, 4, 5, 8, 9, 10, 13, 14, 17],
 )
 
-vertexdof_indices(::Lagrange2Tri345) = (1, 2, 3)
-
 function facedof_indices(ip::Lagrange2Tri345)
     order = getorder(ip)
     order == 1 && return ((1,2), (2,3), (3,1))


### PR DESCRIPTION
After #581 `vertexdof_indices` should return a tuple of tuples, but since `length(::Int) == length(::Tuple{Int}) == 1` this old code worked anyway. This patch removes the method to rely on the generic `Lagrange` method instead.