### PR TITLE
CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 1
+    timeout-minutes: 40
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 1
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
@@ -36,6 +37,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
The output when canceled due to timeout is unfortunately not very informative:
```
    Installed ChangesOfVariables ─── v0.1.7
   Installed CodecZlib ──────────── v0.7.1
   Installed Tensors ────────────── v1.13.1
   Installed DocStringExtensions ── v0.9.3
Error: The operation was canceled.
```
Normally CI seems to finish in max 20 min, so I suggest putting it at 40 min to be on the safe side. 