### PR TITLE
Default to `Lagrange{refdim,refshape,1}()` for geometric mapping

### DIFF
--- a/docs/src/literate/incompressible_elasticity.jl
+++ b/docs/src/literate/incompressible_elasticity.jl
@@ -44,15 +44,12 @@ function create_values(interpolation_u, interpolation_p)
     qr      = QuadratureRule{2,RefTetrahedron}(3)
     face_qr = QuadratureRule{1,RefTetrahedron}(3)
 
-    ## geometric interpolation
-    interpolation_geom = Lagrange{2,RefTetrahedron,1}()
-
     ## cell and facevalues for u
-    cellvalues_u = CellVectorValues(qr, interpolation_u, interpolation_geom)
-    facevalues_u = FaceVectorValues(face_qr, interpolation_u, interpolation_geom)
+    cellvalues_u = CellVectorValues(qr, interpolation_u)
+    facevalues_u = FaceVectorValues(face_qr, interpolation_u)
 
     ## cellvalues for p
-    cellvalues_p = CellScalarValues(qr, interpolation_p, interpolation_geom)
+    cellvalues_p = CellScalarValues(qr, interpolation_p)
 
     return cellvalues_u, cellvalues_p, facevalues_u
 end;

--- a/docs/src/literate/ns_vs_diffeq.jl
+++ b/docs/src/literate/ns_vs_diffeq.jl
@@ -159,12 +159,11 @@ grid = generate_grid(Quadrilateral, (x_cells, y_cells), Vec{2}((0.0, 0.0)), Vec{
 # We have to utilize the same quadrature rule for the pressure as for the velocity, because in the weak form the
 # linear pressure term is tested against a quadratic function.
 ip_v = Lagrange{dim, RefCube, 2}()
-ip_geom = Lagrange{dim, RefCube, 1}()
 qr = QuadratureRule{dim, RefCube}(4)
-cellvalues_v = CellVectorValues(qr, ip_v, ip_geom);
+cellvalues_v = CellVectorValues(qr, ip_v);
 
 ip_p = Lagrange{dim, RefCube, 1}()
-cellvalues_p = CellScalarValues(qr, ip_p, ip_geom);
+cellvalues_p = CellScalarValues(qr, ip_p);
 
 dh = DofHandler(grid)
 add!(dh, :v, dim, ip_v)

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -141,12 +141,9 @@ function create_values(interpolation)
     qr      = QuadratureRule{3,RefTetrahedron}(2)
     face_qr = QuadratureRule{2,RefTetrahedron}(3)
 
-    ## create geometric interpolation (use the same as for u)
-    interpolation_geom = Lagrange{3,RefTetrahedron,1}()
-
     ## cell and facevalues for u
-    cellvalues_u = CellVectorValues(qr, interpolation, interpolation_geom)
-    facevalues_u = FaceVectorValues(face_qr, interpolation, interpolation_geom)
+    cellvalues_u = CellVectorValues(qr, interpolation)
+    facevalues_u = FaceVectorValues(face_qr, interpolation)
 
     return cellvalues_u, facevalues_u
 end;

--- a/docs/src/literate/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate/quasi_incompressible_hyperelasticity.jl
@@ -100,15 +100,12 @@ function create_values(interpolation_u, interpolation_p)
     qr      = QuadratureRule{3,RefTetrahedron}(4)
     face_qr = QuadratureRule{2,RefTetrahedron}(4)
 
-    ## geometric interpolation
-    interpolation_geom = Lagrange{3,RefTetrahedron,1}()
-
     ## cell and facevalues for u
-    cellvalues_u = CellVectorValues(qr, interpolation_u, interpolation_geom)
-    facevalues_u = FaceVectorValues(face_qr, interpolation_u, interpolation_geom)
+    cellvalues_u = CellVectorValues(qr, interpolation_u)
+    facevalues_u = FaceVectorValues(face_qr, interpolation_u)
 
     ## cellvalues for p
-    cellvalues_p = CellScalarValues(qr, interpolation_p, interpolation_geom)
+    cellvalues_p = CellScalarValues(qr, interpolation_p)
 
     return cellvalues_u, cellvalues_p, facevalues_u
 end;

--- a/docs/src/literate/stokes-flow.jl
+++ b/docs/src/literate/stokes-flow.jl
@@ -220,9 +220,10 @@ end
 # As mentioned in the introduction we will use a quadratic approximation for the velocity
 # field and a linear approximation for the pressure to ensure that we fulfill the LBB
 # condition. We create the corresponding FE values with interpolations `ipu` for the
-# velocity and `ipp` for the pressure. Note that we use linear geometric interpolation
-# (`ipg`) for both the velocity and pressure, this is because our grid contains linear
-# triangles. We also construct face-values for the pressure since we need to integrate along
+# velocity and `ipp` for the pressure. Note that we specify linear geometric mapping
+# (`ipg`) for both the velocity and pressure because our grid contains linear
+# triangles. However, since linear mapping is default this could have been skipped.
+# We also construct face-values for the pressure since we need to integrate along
 # the boundary when assembling the constraint matrix ``\underline{\underline{C}}``.
 
 function setup_fevalues(ipu, ipp, ipg)

--- a/docs/src/literate/topology_optimization.jl
+++ b/docs/src/literate/topology_optimization.jl
@@ -91,12 +91,9 @@ function create_values()
     qr      = QuadratureRule{2,RefCube}(2)
     face_qr = QuadratureRule{1,RefCube}(2)
 
-    ## geometric interpolation
-    interpolation_geom = Lagrange{2,RefCube,1}()
-
     ## cell and facevalues for u
-    cellvalues = CellVectorValues(qr, Lagrange{2,RefCube,1}(), Lagrange{2,RefCube,1}())
-    facevalues = FaceVectorValues(face_qr, Lagrange{2,RefCube,1}(), Lagrange{2,RefCube,1}())
+    cellvalues = CellVectorValues(qr, Lagrange{2,RefCube,1}())
+    facevalues = FaceVectorValues(face_qr, Lagrange{2,RefCube,1}())
     
     return cellvalues, facevalues
 end

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -13,7 +13,8 @@ utilizes scalar shape functions and `CellVectorValues` utilizes vectorial shape 
 * `T`: an optional argument (default to `Float64`) to determine the type the internal data is stored as.
 * `quad_rule`: an instance of a [`QuadratureRule`](@ref)
 * `func_interpol`: an instance of an [`Interpolation`](@ref) used to interpolate the approximated function
-* `geom_interpol`: an optional instance of a [`Interpolation`](@ref) which is used to interpolate the geometry
+* `geom_interpol`: an optional instance of a [`Interpolation`](@ref) which is used to interpolate the geometry.
+  By default linear Lagrange interpolation is used.
 
 **Common methods:**
 * [`reinit!`](@ref)
@@ -33,6 +34,10 @@ utilizes scalar shape functions and `CellVectorValues` utilizes vectorial shape 
 """
 CellValues, CellScalarValues, CellVectorValues
 
+function default_geometric_interpolation(::Interpolation{dim,shape}) where {dim, shape}
+    return Lagrange{dim,shape,1}()
+end
+
 # CellScalarValues
 struct CellScalarValues{dim,T<:Real,refshape<:AbstractRefShape} <: CellValues{dim,T,refshape}
     N::Matrix{T}
@@ -49,12 +54,12 @@ struct CellScalarValues{dim,T<:Real,refshape<:AbstractRefShape} <: CellValues{di
 end
 
 function CellScalarValues(quad_rule::QuadratureRule, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol)
+        geom_interpol::Interpolation=default_geometric_interpolation(func_interpol))
     CellScalarValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
 function CellScalarValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol) where {dim,T,shape<:AbstractRefShape}
+        geom_interpol::Interpolation=default_geometric_interpolation(func_interpol)) where {dim,T,shape<:AbstractRefShape}
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape
@@ -100,12 +105,12 @@ struct CellVectorValues{dim,T<:Real,refshape<:AbstractRefShape,M} <: CellValues{
     geo_interp::Interpolation{dim,refshape}
 end
 
-function CellVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=func_interpol)
+function CellVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=default_geometric_interpolation(func_interpol))
     CellVectorValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
 function CellVectorValues(::Type{T}, quad_rule::QuadratureRule{dim,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol) where {dim,T,shape<:AbstractRefShape}
+        geom_interpol::Interpolation=default_geometric_interpolation(func_interpol)) where {dim,T,shape<:AbstractRefShape}
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -18,7 +18,8 @@ For a scalar field, the `FaceScalarValues` type should be used. For vector field
 * `T`: an optional argument to determine the type the internal data is stored as.
 * `quad_rule`: an instance of a [`QuadratureRule`](@ref)
 * `func_interpol`: an instance of an [`Interpolation`](@ref) used to interpolate the approximated function
-* `geom_interpol`: an optional instance of an [`Interpolation`](@ref) which is used to interpolate the geometry
+* `geom_interpol`: an optional instance of an [`Interpolation`](@ref) which is used to interpolate the geometry.
+  By default linear Lagrange interpolation is used.
 
 **Common methods:**
 
@@ -61,12 +62,12 @@ struct FaceScalarValues{dim,T<:Real,refshape<:AbstractRefShape} <: FaceValues{di
 end
 
 function FaceScalarValues(quad_rule::QuadratureRule, func_interpol::Interpolation,
-                          geom_interpol::Interpolation=func_interpol)
+                          geom_interpol::Interpolation=default_geometric_interpolation(func_interpol))
     FaceScalarValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
 function FaceScalarValues(::Type{T}, quad_rule::QuadratureRule{dim_qr,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol) where {dim_qr,T,shape<:AbstractRefShape}
+        geom_interpol::Interpolation=default_geometric_interpolation(func_interpol)) where {dim_qr,T,shape<:AbstractRefShape}
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape
@@ -125,12 +126,12 @@ struct FaceVectorValues{dim,T<:Real,refshape<:AbstractRefShape,M} <: FaceValues{
     geo_interp::Interpolation{dim,refshape}
 end
 
-function FaceVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=func_interpol)
+function FaceVectorValues(quad_rule::QuadratureRule, func_interpol::Interpolation, geom_interpol::Interpolation=default_geometric_interpolation(func_interpol))
     FaceVectorValues(Float64, quad_rule, func_interpol, geom_interpol)
 end
 
 function FaceVectorValues(::Type{T}, quad_rule::QuadratureRule{dim_qr,shape}, func_interpol::Interpolation,
-        geom_interpol::Interpolation=func_interpol) where {dim_qr,T,shape<:AbstractRefShape}
+        geom_interpol::Interpolation=default_geometric_interpolation(func_interpol)) where {dim_qr,T,shape<:AbstractRefShape}
 
     @assert getdim(func_interpol) == getdim(geom_interpol)
     @assert getrefshape(func_interpol) == getrefshape(geom_interpol) == shape

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -16,7 +16,8 @@ for (func_interpol, quad_rule) in  (
                                    )
 
     for fe_valtype in (CellScalarValues, CellVectorValues)
-        cv = fe_valtype(quad_rule, func_interpol)
+        geom_interpol = func_interpol # Tests below assume this
+        cv = fe_valtype(quad_rule, func_interpol, geom_interpol)
         ndim = Ferrite.getdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)
 

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -13,7 +13,8 @@ for (func_interpol, quad_rule) in  (
                                    )
 
     for fe_valtype in (FaceScalarValues, FaceVectorValues)
-        fv = fe_valtype(quad_rule, func_interpol)
+        geom_interpol = func_interpol # Tests below assume this
+        fv = fe_valtype(quad_rule, func_interpol, geom_interpol)
         ndim = Ferrite.getdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)
 


### PR DESCRIPTION
This patch changes the default value for the geometric mapping in
`(Cell|Face)(Scalar|Vector)Values` to linear Lagrange interpolation
instead of (re)using the function interpolation. This decouples these
two concepts further.

Some "real world" examples where I think this new default is more sane,
and the current default is just a stumbling block:

1. Consider the following code with linear cells:
   ```julia
   grid = generate_grid(Triangle, ...)
   ip = Lagrange{2, RefTriangle, 1}()
   cv = CellVectorValues(qr, ip)
   ```
   To update this to use e.g. a quadratic approximation one currently
   have to change more than just the approximation order, i.e. one has
   to use
   ```julia
   grid = generate_grid(Triangle, ...)
   ip  = Lagrange{2, RefTriangle, 2}()
   ipg = Lagrange{2, RefTriangle, 1}()
   cv = CellVectorValues(qr, ip, ipg)
   ```
   instead of simply
   ```julia
   grid = generate_grid(Triangle, ...)
   ip = Lagrange{2, RefTriangle, 2}()
   cv = CellVectorValues(qr, ip)
   ```

2. For the Taylor-Hood element one *always* have to worry about the
   geometric mapping, regardless if it is linear or quadratic:
   ```julia
   ip_g = Lagrange{2, RefTriangle, 1}()
   ip_u = Lagrange{2, RefTriangle, 2}()
   ip_p = Lagrange{2, RefTriangle, 1}()
   cv_u = CellVectorValues(qr, ip_u, ip_g)
   cv_p = CellVectorValues(qr, ip_p, ip_g)
   ```
   instead of just
   ```julia
   ip_u = Lagrange{2, RefTriangle, 2}()
   ip_p = Lagrange{2, RefTriangle, 1}()
   cv_u = CellVectorValues(qr, ip_u)
   cv_p = CellVectorValues(qr, ip_p)
   ```

3. For more exotic elements, such as `VectorizedInterpolation` (#694),
   or `RaviartThomas` it is also a more useful default.
