### PR TITLE
Remove deprecated L2Projector methods

### DIFF
--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -8,37 +8,6 @@ struct L2Projector <: AbstractProjector
     dh::DofHandler
     set::Vector{Int}
     node2dof_map::Vector{Int}
-    fe_values::Union{CellValues,Nothing} # only used for deprecated constructor
-    qr_rhs::Union{QuadratureRule,Nothing}    # only used for deprecated constructor
-end
-
-function L2Projector(fe_values::Ferrite.Values, interp::Interpolation,
-    grid::Ferrite.AbstractGrid, set=1:getncells(grid), fe_values_mass::Ferrite.Values=fe_values)
-
-    Base.depwarn("L2Projector(fe_values, interp, grid) is deprecated, " *
-                 "use L2Projector(qr, interp, grid) instead.", :L2Projector)
-
-    dim, T, shape = typeof(fe_values).parameters
-
-    # Create an internal scalar valued field. This is enough since the projection is done on a component basis, hence a scalar field.
-    dh = DofHandler(grid)
-    field = Field(:_, interp)
-    fh = FieldHandler([field], Set(set))
-    add!(dh, fh)
-    _, vertex_dict, _, _ = __close!(dh)
-
-    M = _assemble_L2_matrix(fe_values_mass, set, dh)  # the "mass" matrix
-    M_cholesky = cholesky(M)  # TODO maybe have a lazy eval instead of precomputing? / JB
-    dummy = Lagrange{1,RefCube,1}()
-    return L2Projector(dummy, dummy, M_cholesky, dh, collect(set), vertex_dict[1], fe_values, nothing)
-end
-
-function L2Projector(qr::QuadratureRule, func_ip::Interpolation,
-    grid::Ferrite.AbstractGrid, set=1:getncells(grid), qr_mass::QuadratureRule=_mass_qr(func_ip),
-    geom_ip::Interpolation = default_interpolation(typeof(grid.cells[first(set)])))
-    Base.depwarn("L2Projector(qr, func_ip, grid) is deprecated, " *
-                 "use L2Projector(func_ip, grid) instead.", :L2Projector)
-    return L2Projector(func_ip, grid; qr_lhs=qr_mass, set=set, geom_ip=geom_ip, qr_rhs=qr)
 end
 
 """
@@ -70,7 +39,6 @@ function L2Projector(
         qr_lhs::QuadratureRule = _mass_qr(func_ip),
         set = 1:getncells(grid),
         geom_ip::Interpolation = default_interpolation(typeof(grid.cells[first(set)])),
-        qr_rhs::Union{QuadratureRule,Nothing}=nothing, # deprecated
     )
 
     # TODO: Maybe this should not be allowed? We always assume to project scalar entries.
@@ -78,7 +46,7 @@ function L2Projector(
         func_ip = func_ip.ip
     end
 
-    _check_same_celltype(grid, collect(set)) # TODO this does the right thing, but gives the wrong error message if it fails
+    _check_same_celltype(grid, set)
 
     fe_values_mass = CellScalarValues(qr_lhs, func_ip, geom_ip)
 
@@ -92,11 +60,7 @@ function L2Projector(
     M = _assemble_L2_matrix(fe_values_mass, set, dh)  # the "mass" matrix
     M_cholesky = cholesky(M)
 
-    # For deprecated API
-    fe_values = qr_rhs === nothing ? nothing :
-                CellScalarValues(qr_rhs, func_ip, geom_ip)
-
-    return L2Projector(func_ip, geom_ip, M_cholesky, dh, collect(set), vertex_dict[1], fe_values, qr_rhs)
+    return L2Projector(func_ip, geom_ip, M_cholesky, dh, collect(set), vertex_dict[1])
 end
 
 # Quadrature sufficient for integrating a mass matrix
@@ -117,7 +81,7 @@ end
 
 function _assemble_L2_matrix(fe_values, set, dh)
 
-    n = Ferrite.getn_scalarbasefunctions(fe_values)
+    n = Ferrite.getnbasefunctions(fe_values)
     M = create_symmetric_sparsity_pattern(dh)
     assembler = start_assemble(M)
 
@@ -155,13 +119,6 @@ function _assemble_L2_matrix(fe_values, set, dh)
         assemble!(assembler, cell_dofs, Me)
     end
     return M
-end
-
-function project(vars::Vector{Vector{T}}, proj::L2Projector;
-                 project_to_nodes=true) where T <: Union{Number, AbstractTensor}
-    Base.depwarn("project(vars, proj::L2Projector) is deprecated, " *
-                 "use project(proj, vars, qr) instead.", :project)
-    return project(proj, vars; project_to_nodes=project_to_nodes)
 end
 
 
@@ -206,13 +163,11 @@ field over the domain, which is useful if one wants to interpolate the projected
 """
 function project(proj::L2Projector,
                  vars::AbstractVector{<:AbstractVector{T}},
-                 qr_rhs::Union{QuadratureRule,Nothing}=nothing;
+                 qr_rhs::QuadratureRule;
                  project_to_nodes::Bool=true) where T <: Union{Number, AbstractTensor}
 
     # For using the deprecated API
-    fe_values = qr_rhs === nothing ?
-        proj.fe_values :
-        CellScalarValues(qr_rhs, proj.func_ip, proj.geom_ip)
+    fe_values = CellScalarValues(qr_rhs, proj.func_ip, proj.geom_ip)
 
     M = T <: AbstractTensor ? length(vars[1][1].data) : 1
 

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -41,14 +41,7 @@ function test_projection(order, refshape)
     point_vars = project(proj, qp_values, qr)
     qp_values_matrix = reduce(hcat, qp_values)
     point_vars_2 = project(proj, qp_values_matrix, qr)
-    ## Old API with fe values as first arg
-    proj2 = @test_deprecated L2Projector(cv, ip, grid)
-    point_vars_3 = @test_deprecated project(qp_values, proj2)
-    ## Old API with qr as first arg
-    proj3 = @test_deprecated L2Projector(qr, ip, grid)
-    point_vars_4 = @test_deprecated project(qp_values, proj3)
-
-    @test point_vars ≈ point_vars_2 ≈ point_vars_3 ≈ point_vars_4
+    @test point_vars ≈ point_vars_2
 
     if order == 1
         # A linear approximation can not recover a quadratic solution,
@@ -155,17 +148,10 @@ function test_projection_mixedgrid()
     proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=1:1)
     point_vars = project(proj, qp_values, qr)
     point_vars_2 = project(proj, qp_values_matrix, qr)
-    ## Old API with fe values as first arg
-    proj = @test_deprecated L2Projector(cv, ip, mesh, 1:1)
-    point_vars_3 = @test_deprecated project(qp_values, proj)
-    ## Old API with qr as first arg
-    proj = @test_deprecated L2Projector(qr, ip, mesh, 1:1)
-    point_vars_4 = @test_deprecated project(qp_values, proj)
 
     # In the nodes of the 1st cell we should recover the field
     for node in mesh.cells[1].nodes
-        @test ae[node] ≈ point_vars[node] ≈ point_vars_2[node] ≈ point_vars_3[node] ≈
-                         point_vars_4[node]
+        @test ae[node] ≈ point_vars[node] ≈ point_vars_2[node]
     end
 
     # in all other nodes we should have NaNs
@@ -173,8 +159,6 @@ function test_projection_mixedgrid()
         for d1 = 1:dim, d2 = 1:dim
              @test isnan(point_vars[node][d1, d2])
              @test isnan(point_vars_2[node][d1, d2])
-             @test isnan(point_vars_3[node][d1, d2])
-             @test isnan(point_vars_4[node][d1, d2])
          end
     end
 


### PR DESCRIPTION
This old L2 projection API have been deprecated for quite some releasese now and it is time to clean up.