### PR TITLE
Deprecate `function_*(::VectorValues, ::Int, ::VectorDofs)`

### DIFF
--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -153,11 +153,6 @@ function function_value(::FieldTrait, fe_v::Values{dim}, q_point::Int, u::Abstra
     return val
 end
 
-# TODO: Deprecate this, nobody is using this in practice...
-function function_value(vv::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T}
-    return function_value(vv, fe_v, q_point, reinterpret(T, u))
-end
-
 _valuetype(t::T, v) where T = _valuetype(FieldTrait(T), t, v)
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{T}) where {dim,T} = T
 _valuetype(::ScalarValued, ::Values{dim}, ::AbstractVector{Vec{dim,T}}) where {dim,T} = Vec{dim,T}
@@ -210,12 +205,6 @@ function function_gradient(::ScalarValued, fe_v::Values{dim}, q_point::Int, u::A
     return grad
 end
 
-# TODO: Deprecate this, nobody is using this in practice...
-function function_gradient(vv::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T}
-    return function_gradient(vv, fe_v, q_point, reinterpret(T, u))
-end
-
-
 const function_derivative = function_gradient
 
 """
@@ -264,13 +253,11 @@ end
 function_divergence(::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{T}, dof_range = eachindex(u)) where {dim,T} =
     tr(function_gradient(fe_v, q_point, u, dof_range))
 
-function_divergence(::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} =
-    tr(function_gradient(fe_v, q_point, u))
-
 function_curl(fe_v::Values, q_point::Int, u::AbstractVector, dof_range = eachindex(u)) =
     curl_from_gradient(function_gradient(fe_v, q_point, u, dof_range))
 
-function_curl(fe_v::Values, q_point::Int, u::AbstractVector{Vec{3, T}}) where T =
+# TODO: Deprecate this, nobody is using this in practice...
+function_curl(fe_v::Union{CellScalarValues,FaceScalarValues}, q_point::Int, u::AbstractVector{Vec{3, T}}) where T =
     curl_from_gradient(function_gradient(fe_v, q_point, u))
 
 """

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -96,7 +96,6 @@ function CellVectorValues(::Type{T}, quad_rule::QuadratureRule, func_interpol::S
         "See CHANGELOG for more details.",
         :CellVectorValues
     )
-    Base.depwarn("", :CellVectorValues)
     return CellVectorValues(T, quad_rule, VectorizedInterpolation(func_interpol), geom_interpol)
 end
 function FaceVectorValues(quad_rule::QuadratureRule, func_interpol::ScalarInterpolation,
@@ -113,3 +112,12 @@ function FaceVectorValues(::Type{T}, quad_rule::QuadratureRule, func_interpol::S
     )
     return FaceVectorValues(T, quad_rule, VectorizedInterpolation(func_interpol), geom_interpol)
 end
+
+# (Cell|Face)VectorValues with vector dofs
+@deprecate function_value(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_value(fe_v, q_point, reinterpret(T, u))
+@deprecate function_value(vv::VectorValued, fe_v::Values, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_value(vv, fe_v, q_point, reinterpret(T, u))
+@deprecate function_gradient(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_gradient(fe_v, q_point, reinterpret(T, u))
+@deprecate function_gradient(vv::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_gradient(vv, fe_v, q_point, reinterpret(T, u))
+@deprecate function_divergence(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_divergence(fe_v, q_point, reinterpret(T, u))
+@deprecate function_divergence(::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_divergence(vv, fe_v, q_point, reinterpret(T, u))
+@deprecate function_curl(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{3, T}}) where T function_curl(fe_v::Values, q_point::Int, reinterpret(T, u))

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -44,19 +44,26 @@ for (func_interpol, quad_rule) in  (
         u_vector = reinterpret(Float64, u)
 
         for i in 1:length(getpoints(quad_rule))
-            @test function_gradient(cv, i, u) ≈ H
-            @test function_symmetric_gradient(cv, i, u) ≈ 0.5(H + H')
-            @test function_divergence(cv, i, u) ≈ tr(H)
-            ndim == 3 && @test function_curl(cv, i, u) ≈ Ferrite.curl_from_gradient(H)
-            function_value(cv, i, u)
             if isa(cv, CellScalarValues)
+                @test function_gradient(cv, i, u) ≈ H
+                @test function_symmetric_gradient(cv, i, u) ≈ 0.5(H + H')
+                @test function_divergence(cv, i, u) ≈ tr(H)
                 @test function_gradient(cv, i, u_scal) ≈ V
+                ndim == 3 && @test function_curl(cv, i, u) ≈ Ferrite.curl_from_gradient(H)
+                function_value(cv, i, u)
                 function_value(cv, i, u_scal)
             elseif isa(cv, CellVectorValues)
-                @test function_gradient(cv, i, u_vector) ≈ function_gradient(cv, i, u) ≈ H
-                @test function_value(cv, i, u_vector) ≈ function_value(cv, i, u)
-                @test function_divergence(cv, i, u_vector) ≈ function_divergence(cv, i, u) ≈ tr(H)
-                ndim == 3 && @test function_curl(cv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
+                @test function_gradient(cv, i, u_vector)  ≈ H
+                @test (@test_deprecated function_gradient(cv, i, u)) ≈ H
+                @test function_symmetric_gradient(cv, i, u_vector) ≈ 0.5(H + H')
+                @test (@test_deprecated function_symmetric_gradient(cv, i, u)) ≈ 0.5(H + H')
+                @test function_divergence(cv, i, u_vector) ≈ tr(H)
+                @test (@test_deprecated function_divergence(cv, i, u)) ≈ tr(H)
+                if ndim == 3
+                    @test function_curl(cv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
+                    @test (@test_deprecated function_curl(cv, i, u)) ≈ Ferrite.curl_from_gradient(H)
+                end
+                function_value(cv, i, u_vector) ≈ (@test_deprecated function_value(cv, i, u))
             end
         end
 
@@ -157,11 +164,6 @@ end
     @test_throws ArgumentError function_value(csv, qp, ue)
     @test_throws ArgumentError function_gradient(csv, qp, ue)
     @test_throws ArgumentError function_divergence(csv, qp, ue)
-    # Vector values, vector dofs
-    ue = [rand(Vec{dim}) for _ in 1:(getnbasefunctions(cvv) ÷ dim + 1)]
-    @test_throws ArgumentError function_value(cvv, qp, ue)
-    @test_throws ArgumentError function_gradient(cvv, qp, ue)
-    @test_throws ArgumentError function_divergence(cvv, qp, ue)
 end
 
 end # of testset

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -44,19 +44,26 @@ for (func_interpol, quad_rule) in  (
 
             for i in 1:length(getnquadpoints(fv))
                 @test getnormal(fv, i) ≈ n[face]
-                @test function_gradient(fv, i, u) ≈ H
-                @test function_symmetric_gradient(fv, i, u) ≈ 0.5(H + H')
-                @test function_divergence(fv, i, u) ≈ tr(H)
-                ndim == 3 && @test function_curl(fv, i, u) ≈ Ferrite.curl_from_gradient(H)
-                function_value(fv, i, u)
                 if isa(fv, FaceScalarValues)
+                    @test function_gradient(fv, i, u) ≈ H
+                    @test function_symmetric_gradient(fv, i, u) ≈ 0.5(H + H')
+                    @test function_divergence(fv, i, u) ≈ tr(H)
                     @test function_gradient(fv, i, u_scal) ≈ V
+                    ndim == 3 && @test function_curl(fv, i, u) ≈ Ferrite.curl_from_gradient(H)
+                    function_value(fv, i, u)
                     function_value(fv, i, u_scal)
                 elseif isa(fv, FaceVectorValues)
-                    @test function_gradient(fv, i, u_vector) ≈ function_gradient(fv, i, u) ≈ H
-                    @test function_value(fv, i, u_vector) ≈ function_value(fv, i, u)
-                    @test function_divergence(fv, i, u_vector) ≈ function_divergence(fv, i, u) ≈ tr(H)
-                    ndim == 3 && @test function_curl(fv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
+                    @test function_gradient(fv, i, u_vector) ≈ H
+                    @test (@test_deprecated function_gradient(fv, i, u)) ≈ H
+                    @test function_symmetric_gradient(fv, i, u_vector) ≈ 0.5(H + H')
+                    @test (@test_deprecated function_symmetric_gradient(fv, i, u)) ≈ 0.5(H + H')
+                    @test function_divergence(fv, i, u_vector) ≈ tr(H)
+                    @test (@test_deprecated function_divergence(fv, i, u)) ≈ tr(H)
+                    if ndim == 3
+                        @test function_curl(fv, i, u_vector) ≈ Ferrite.curl_from_gradient(H)
+                        @test (@test_deprecated function_curl(fv, i, u)) ≈ Ferrite.curl_from_gradient(H)
+                    end
+                    @test function_value(fv, i, u_vector) ≈ (@test_deprecated function_value(fv, i, u))
                 end
             end
 


### PR DESCRIPTION
`function_value`, `function_gradient`, `function_divergence`, and `function_curl` together with `CellVectorValues` supports specifying the local dof vector using `Vec` entries. This patch deprecates this. There is no point in casting `T` to `Vec`, just to then recast to `T` for the evaluation. Deprecations are added, but in practice I estimate that zero people use this functionality.