### PR TITLE
Deprecate `compute_vertex_values`

### DIFF
--- a/docs/src/reference/grid.md
+++ b/docs/src/reference/grid.md
@@ -35,7 +35,6 @@ getedgeset
 getedgesets
 getvertexset
 getvertexsets
-compute_vertex_values
 transform!
 getcoordinates
 getcoordinates!

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -725,38 +725,6 @@ Returns all vertex sets of the grid.
 
 n_faces_per_cell(grid::Grid) = nfaces(eltype(grid.cells))
 
-"""
-    function compute_vertex_values(grid::AbstractGrid, f::Function)
-    function compute_vertex_values(grid::AbstractGrid, v::Vector{Int}, f::Function)    
-    function compute_vertex_values(grid::AbstractGrid, set::String, f::Function)
-
-Given a `grid` and some function `f`, `compute_vertex_values` computes all nodal values,
- i.e. values at the nodes,  of the function `f`. 
-The function implements two dispatches, where only a subset of the grid's node is used.
-
-```julia
-    compute_vertex_values(grid, x -> sin(x[1]) + cos([2]))
-    compute_vertex_values(grid, [9, 6, 3], x -> sin(x[1]) + cos([2])) #compute function values at nodes with id 9,6,3
-    compute_vertex_values(grid, "right", x -> sin(x[1]) + cos([2])) #compute function values at nodes belonging to nodeset right
-```
-
-"""
-@inline function compute_vertex_values(nodes::Vector{Node{dim,T}}, f::Function) where{dim,T}
-    map(n -> f(getcoordinates(n)), nodes)
-end
-
-@inline function compute_vertex_values(grid::AbstractGrid, f::Function)
-    compute_vertex_values(getnodes(grid), f::Function)
-end
-
-@inline function compute_vertex_values(grid::AbstractGrid, v::Vector{Int}, f::Function)
-    compute_vertex_values(getnodes(grid, v), f::Function)
-end
-
-@inline function compute_vertex_values(grid::AbstractGrid, set::String, f::Function)
-    compute_vertex_values(getnodes(grid, set), f::Function)
-end
-
 # Transformations
 """
     transform!(grid::Abstractgrid, f::Function)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -121,3 +121,9 @@ end
 @deprecate function_divergence(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_divergence(fe_v, q_point, reinterpret(T, u))
 @deprecate function_divergence(::VectorValued, fe_v::Values{dim}, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_divergence(vv, fe_v, q_point, reinterpret(T, u))
 @deprecate function_curl(fe_v::Union{CellVectorValues,FaceVectorValues}, q_point::Int, u::AbstractVector{Vec{3, T}}) where T function_curl(fe_v::Values, q_point::Int, reinterpret(T, u))
+
+# Deprecation of compute_vertex_values
+@deprecate compute_vertex_values(nodes::Vector{<:Node}, f::Function) map(n -> f(n.x), nodes)
+@deprecate compute_vertex_values(grid::AbstractGrid, f::Function) map(n -> f(n.x), getnodes(grid))
+@deprecate compute_vertex_values(grid::AbstractGrid, v::Vector{Int}, f::Function) map(n -> f(n.x), getnodes(grid, v))
+@deprecate compute_vertex_values(grid::AbstractGrid, set::String, f::Function) map(n -> f(n.x), getnodes(grid, set))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -92,7 +92,6 @@ export
     addcellset!,
     transform!,
     generate_grid,
-    compute_vertex_values,
 
 # Grid coloring
     create_coloring,

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -167,18 +167,6 @@ end
 
     @test getcells(grid, "cell_set") == [getcells(grid, 1)]
 
-    f(x) = Tensor{1,1,Float64}((1 + x[1]^2 + 2x[2]^2, ))
-
-    values = compute_vertex_values(grid, f)
-    @test f([0.0, 0.0]) == values[1]
-    @test f([0.5, 0.5]) == values[5]
-    @test f([1.0, 1.0]) == values[9]
-
-    @test compute_vertex_values(grid, collect(1:9), f) == values
-
-    # Can we test this in a better way? The set makes the order random.
-    @test length(compute_vertex_values(grid, "node_set", f)) == 9
-
     # CellIterator on a grid without DofHandler
     grid = generate_grid(Triangle, (4,4))
     n = 0

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -146,7 +146,6 @@ function test_projection_mixedgrid()
     point_vars = project(proj, qp_values, qr)
     point_vars_2 = project(proj, qp_values_matrix, qr)
 
-    # ae = compute_vertex_values(mesh, f)
     ae = zeros(3, length(point_vars))
     for i in 1:3
         apply_analytical!(@view(ae[i, :]), proj.dh, :_, x -> f(x).data[i], quadset)


### PR DESCRIPTION
This function was mostly used in tests, and is just a simple `map` over the nodes. Doesn't seem worthwhile to keep.