### PR TITLE
Improve boundschecks during assemble

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -81,8 +81,9 @@ Assembles the element residual `ge` into the global residual vector `g`.
 """
 @propagate_inbounds function assemble!(g::AbstractVector{T}, dofs::AbstractVector{Int}, ge::AbstractVector{T}) where {T}
     @boundscheck checkbounds(g, dofs)
-    @inbounds for i in 1:length(dofs)
-        addindex!(g, ge[i], dofs[i])
+    @boundscheck checkbounds(ge, keys(dofs))
+    @inbounds for (i, dof) in pairs(dofs)
+        addindex!(g, ge[i], dof)
     end
 end
 
@@ -179,10 +180,9 @@ end
 
 @propagate_inbounds function _assemble!(A::AbstractSparseAssembler, dofs::AbstractVector{Int}, Ke::AbstractMatrix, fe::AbstractVector, sym::Bool)
     ld = length(dofs)
-    @assert size(Ke, 1) == ld
-    @assert size(Ke, 2) == ld
+    @boundscheck checkbounds(Ke, keys(dofs), keys(dofs))
     if length(fe) != 0
-        @assert length(fe) == ld
+        @boundscheck checkbounds(fe, keys(dofs))
         @boundscheck checkbounds(A.f, dofs)
         @inbounds assemble!(A.f, dofs, fe)
     end

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -72,8 +72,8 @@
     assembler = start_assemble(Kc, fc)
     @test_throws BoundsError assemble!(assembler, [11, 1, 2, 3], rand(4, 4))
     @test_throws BoundsError assemble!(assembler, [11, 1, 2, 3], rand(4, 4), rand(4))
-    @test_throws AssertionError assemble!(assembler, [11, 1, 2], rand(4, 4))
-    @test_throws AssertionError assemble!(assembler, [11, 1, 2, 3], rand(4, 4), rand(3))
+    @test_throws BoundsError assemble!(assembler, [11, 1, 2], rand(4, 4))
+    @test_throws BoundsError assemble!(assembler, [11, 1, 2, 3], rand(4, 4), rand(3))
 end
 
 @testset "Base.show for assemblers" begin


### PR DESCRIPTION
I think this should be safer, but I haven't benchmarked if there is a performance regression.