### PR TITLE
Deprecate start_assemble(f, K)

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -142,7 +142,6 @@ out, but instead keep their current values.
 """
 start_assemble(K::Union{SparseMatrixCSC, Symmetric{<:Any,SparseMatrixCSC}}, f::Vector; fillzero::Bool)
 
-start_assemble(f::Vector, K::Union{SparseMatrixCSC, Symmetric}; fillzero::Bool=true) = start_assemble(K, f; fillzero=fillzero)
 function start_assemble(K::SparseMatrixCSC{T}, f::Vector=T[]; fillzero::Bool=true) where {T}
     fillzero && (fillzero!(K); fillzero!(f))
     return AssemblerSparsityPattern(K, f, Int[], Int[])

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -138,3 +138,5 @@ end
 @deprecate compute_vertex_values(grid::AbstractGrid, set::String, f::Function) map(n -> f(n.x), getnodes(grid, set))
 
 @deprecate reshape_to_nodes evaluate_at_grid_nodes
+
+@deprecate start_assemble(f::Vector, K::Union{SparseMatrixCSC, Symmetric}; kwargs...) = start_assemble(K, f; kwargs...)


### PR DESCRIPTION
Seems unnecessary to allow both options for starting to assemble, of which only one is documented. 