### PR TITLE
replaced str with str_scalar/str_vector for CellValues warning

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -119,11 +119,11 @@ for VT in (
 
     Upgrade as follows:
      - Scalar fields: Replace usage of
-           $(str)(quad_rule, interpolation)
+           $(str_scalar)(quad_rule, interpolation)
        with
            $(str_new)(quad_rule, interpolation)
      - Vector fields: Replace usage of
-           $(str)(quad_rule, interpolation)
+           $(str_vector)(quad_rule, interpolation)
        with
            $(str_new)(quad_rule, interpolation^dim)
        where `dim` is the dimension to vectorize to.


### PR DESCRIPTION
I think the warning that appears when one tries to use `CellScalarValues` has a mistake in it. For my understanding the marked CellScalarValues needs to be replaced by a CellVectorValues to make sense.

![grafik](https://github.com/Ferrite-FEM/Ferrite.jl/assets/93594564/62cea3a8-bb5b-4d39-bd5b-601ede81806b)

