### PR TITLE
`QuadratureRule`: remove `dim` parameter and introduce `FaceQuadratureRule`

### DIFF
--- a/docs/src/literate/computational_homogenization.jl
+++ b/docs/src/literate/computational_homogenization.jl
@@ -213,7 +213,7 @@ grid = togrid("periodic-rve.msh") #src
 
 dim = 2
 ip = Lagrange{RefTriangle, 1}()^dim
-qr = QuadratureRule{dim, RefTriangle}(2)
+qr = QuadratureRule{RefTriangle}(2)
 cellvalues = CellValues(qr, ip);
 
 # We define a dof handler with a displacement field `:u`:

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -53,11 +53,11 @@ grid = generate_grid(Quadrilateral, (20, 20));
 # this we need to specify an interpolation space for the shape functions.
 # We use Lagrange functions
 # based on the two-dimensional reference quadrilateral. We also define a quadrature rule based on
-# the same reference cube. We combine the interpolation and the quadrature rule
+# the same reference element. We combine the interpolation and the quadrature rule
 # to a `CellValues` object.
 dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
-qr = QuadratureRule{dim, RefQuadrilateral}(2)
+qr = QuadratureRule{RefQuadrilateral}(2)
 cellvalues = CellValues(qr, ip);
 
 # ### Degrees of freedom

--- a/docs/src/literate/heat_equation.jl
+++ b/docs/src/literate/heat_equation.jl
@@ -55,7 +55,6 @@ grid = generate_grid(Quadrilateral, (20, 20));
 # based on the two-dimensional reference quadrilateral. We also define a quadrature rule based on
 # the same reference element. We combine the interpolation and the quadrature rule
 # to a `CellValues` object.
-dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
 qr = QuadratureRule{RefQuadrilateral}(2)
 cellvalues = CellValues(qr, ip);

--- a/docs/src/literate/helmholtz.jl
+++ b/docs/src/literate/helmholtz.jl
@@ -53,7 +53,6 @@ const Δ = Tensors.hessian;
 
 grid = generate_grid(Quadrilateral, (150, 150))
 
-dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
 qr = QuadratureRule{RefQuadrilateral}(2)
 qr_face = FaceQuadratureRule{RefQuadrilateral}(2)

--- a/docs/src/literate/helmholtz.jl
+++ b/docs/src/literate/helmholtz.jl
@@ -55,8 +55,8 @@ grid = generate_grid(Quadrilateral, (150, 150))
 
 dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
-qr = QuadratureRule{dim, RefQuadrilateral}(2)
-qr_face = QuadratureRule{dim-1, RefQuadrilateral}(2)
+qr = QuadratureRule{RefQuadrilateral}(2)
+qr_face = FaceQuadratureRule{RefQuadrilateral}(2)
 cellvalues = CellValues(qr, ip);
 facevalues = FaceValues(qr_face, ip);
 

--- a/docs/src/literate/hyperelasticity.jl
+++ b/docs/src/literate/hyperelasticity.jl
@@ -316,8 +316,8 @@ function solve()
 
     ## Finite element base
     ip = Lagrange{RefTetrahedron, 1}()^3
-    qr = QuadratureRule{3, RefTetrahedron}(1)
-    qr_face = QuadratureRule{2, RefTetrahedron}(1)
+    qr = QuadratureRule{RefTetrahedron}(1)
+    qr_face = FaceQuadratureRule{RefTetrahedron}(1)
     cv = CellValues(qr, ip)
     fv = FaceValues(qr_face, ip)
 

--- a/docs/src/literate/incompressible_elasticity.jl
+++ b/docs/src/literate/incompressible_elasticity.jl
@@ -41,8 +41,8 @@ end;
 # Next we define a function to set up our cell- and facevalues.
 function create_values(interpolation_u, interpolation_p)
     ## quadrature rules
-    qr      = QuadratureRule{2,RefTriangle}(3)
-    face_qr = QuadratureRule{1,RefTriangle}(3)
+    qr      = QuadratureRule{RefTriangle}(3)
+    face_qr = FaceQuadratureRule{RefTriangle}(3)
 
     ## cell and facevalues for u
     cellvalues_u = CellValues(qr, interpolation_u)

--- a/docs/src/literate/landau.jl
+++ b/docs/src/literate/landau.jl
@@ -86,7 +86,7 @@ function LandauModel(α, G, gridsize, left::Vec{DIM, T}, right::Vec{DIM, T}, elp
     grid = generate_grid(Tetrahedron, gridsize, left, right)
     threadindices = Ferrite.create_coloring(grid)
 
-    qr  = QuadratureRule{DIM, RefTetrahedron}(2)
+    qr  = QuadratureRule{RefTetrahedron}(2)
     ipP = Lagrange{RefTetrahedron, 1}()^3
     cvP = CellValues(qr, ipP)
 

--- a/docs/src/literate/linear_shell.jl
+++ b/docs/src/literate/linear_shell.jl
@@ -27,8 +27,8 @@ grid = generate_shell_grid(nels, size)
 # under integration for the inplane integration, to avoid shear locking. 
 #+
 ip = Lagrange{RefQuadrilateral,1}()
-qr_inplane = QuadratureRule{2,RefQuadrilateral}(1)
-qr_ooplane = QuadratureRule{1,RefLine}(2)
+qr_inplane = QuadratureRule{RefQuadrilateral}(1)
+qr_ooplane = QuadratureRule{RefLine}(2)
 cv = CellValues(qr_inplane, ip, ip^3)
 
 # Next we distribute displacement dofs,`:u = (x,y,z)` and rotational dofs, `:θ = (θ₁,  θ₂)`.

--- a/docs/src/literate/ns_vs_diffeq.jl
+++ b/docs/src/literate/ns_vs_diffeq.jl
@@ -159,7 +159,7 @@ grid = generate_grid(Quadrilateral, (x_cells, y_cells), Vec{2}((0.0, 0.0)), Vec{
 # We have to utilize the same quadrature rule for the pressure as for the velocity, because in the weak form the
 # linear pressure term is tested against a quadratic function.
 ip_v = Lagrange{RefQuadrilateral, 2}()^dim
-qr = QuadratureRule{dim, RefQuadrilateral}(4)
+qr = QuadratureRule{RefQuadrilateral}(4)
 cellvalues_v = CellValues(qr, ip_v);
 
 ip_p = Lagrange{RefQuadrilateral, 1}()

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -138,8 +138,8 @@ end
 # What follows are methods for assembling and and solving the FE-problem.
 function create_values(interpolation)
     ## setup quadrature rules
-    qr      = QuadratureRule{3,RefTetrahedron}(2)
-    face_qr = QuadratureRule{2,RefTetrahedron}(3)
+    qr      = QuadratureRule{RefTetrahedron}(2)
+    face_qr = FaceQuadratureRule{RefTetrahedron}(3)
 
     ## cell and facevalues for u
     cellvalues_u = CellValues(qr, interpolation)

--- a/docs/src/literate/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate/quasi_incompressible_hyperelasticity.jl
@@ -97,8 +97,8 @@ end;
 # follows in a similar fashion from the `incompressible_elasticity` example
 function create_values(interpolation_u, interpolation_p)
     ## quadrature rules
-    qr      = QuadratureRule{3,RefTetrahedron}(4)
-    face_qr = QuadratureRule{2,RefTetrahedron}(4)
+    qr      = QuadratureRule{RefTetrahedron}(4)
+    face_qr = FaceQuadratureRule{RefTetrahedron}(4)
 
     ## cell and facevalues for u
     cellvalues_u = CellValues(qr, interpolation_u)

--- a/docs/src/literate/stokes-flow.jl
+++ b/docs/src/literate/stokes-flow.jl
@@ -227,10 +227,10 @@ end
 # the boundary when assembling the constraint matrix ``\underline{\underline{C}}``.
 
 function setup_fevalues(ipu, ipp, ipg)
-    qr = QuadratureRule{2,RefTriangle}(2)
+    qr = QuadratureRule{RefTriangle}(2)
     cvu = CellValues(qr, ipu, ipg)
     cvp = CellValues(qr, ipp, ipg)
-    qr_face = QuadratureRule{1,RefTriangle}(2)
+    qr_face = FaceQuadratureRule{RefTriangle}(2)
     fvp = FaceValues(qr_face, ipp, ipg)
     return cvu, cvp, fvp
 end

--- a/docs/src/literate/threaded_assembly.jl
+++ b/docs/src/literate/threaded_assembly.jl
@@ -88,8 +88,8 @@ end;
 # the FaceValues)
 function create_values(interpolation_space::Interpolation{refshape}, qr_order::Int) where {dim, refshape<:Ferrite.AbstractRefShape{dim}}
     ## Interpolations and values
-    quadrature_rule = QuadratureRule{dim, refshape}(qr_order)
-    face_quadrature_rule = QuadratureRule{dim-1, refshape}(qr_order)
+    quadrature_rule = QuadratureRule{refshape}(qr_order)
+    face_quadrature_rule = FaceQuadratureRule{refshape}(qr_order)
     cellvalues = [CellValues(quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
     facevalues = [FaceValues(face_quadrature_rule, interpolation_space) for i in 1:Threads.nthreads()];
     return cellvalues, facevalues

--- a/docs/src/literate/topology_optimization.jl
+++ b/docs/src/literate/topology_optimization.jl
@@ -88,8 +88,8 @@ end
 
 function create_values()
     ## quadrature rules
-    qr      = QuadratureRule{2,RefQuadrilateral}(2)
-    face_qr = QuadratureRule{1,RefQuadrilateral}(2)
+    qr      = QuadratureRule{RefQuadrilateral}(2)
+    face_qr = FaceQuadratureRule{RefQuadrilateral}(2)
 
     ## cell and facevalues for u
     ip = Lagrange{RefQuadrilateral,1}()^2

--- a/docs/src/literate/transient_heat_equation.jl
+++ b/docs/src/literate/transient_heat_equation.jl
@@ -64,7 +64,6 @@ grid = generate_grid(Quadrilateral, (100, 100));
 
 # ### Trial and test functions
 # Again, we define the structs that are responsible for the `shape_value` and `shape_gradient` evaluation.
-dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
 qr = QuadratureRule{RefQuadrilateral}(2)
 cellvalues = CellValues(qr, ip);

--- a/docs/src/literate/transient_heat_equation.jl
+++ b/docs/src/literate/transient_heat_equation.jl
@@ -66,7 +66,7 @@ grid = generate_grid(Quadrilateral, (100, 100));
 # Again, we define the structs that are responsible for the `shape_value` and `shape_gradient` evaluation.
 dim = 2
 ip = Lagrange{RefQuadrilateral, 1}()
-qr = QuadratureRule{dim, RefQuadrilateral}(2)
+qr = QuadratureRule{RefQuadrilateral}(2)
 cellvalues = CellValues(qr, ip);
 
 # ### Degrees of freedom

--- a/docs/src/reference/fevalues.md
+++ b/docs/src/reference/fevalues.md
@@ -10,7 +10,7 @@ DocTestSetup = :(using Ferrite)
 ```@docs
 CellValues
 reinit!
-getnquadpoints
+getnquadpoints(::CellValues)
 getdetJdV
 
 shape_value
@@ -33,4 +33,5 @@ In addition, there are some methods that are unique for `FaecValues`:
 ```@docs
 FaceValues
 getcurrentface
+getnquadpoints(::FaceValues)
 ```

--- a/docs/src/reference/quadrature.md
+++ b/docs/src/reference/quadrature.md
@@ -7,7 +7,9 @@ DocTestSetup = :(using Ferrite)
 
 ```@docs
 QuadratureRule
-AbstractRefShape
+FaceQuadratureRule
+getnquadpoints(::QuadratureRule)
+getnquadpoints(::FaceQuadratureRule, ::Int)
 getpoints
 getweights
 ```

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -805,7 +805,7 @@ function _evaluate_at_grid_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol
         CT = getcelltype(dh.grid, first(fh.cellset))
         ip_geo = default_interpolation(CT)
         local_node_coords = reference_coordinates(ip_geo)
-        qr = QuadratureRule{getdim(ip), getrefshape(ip)}(zeros(length(local_node_coords)), local_node_coords)
+        qr = QuadratureRule{getrefshape(ip)}(zeros(length(local_node_coords)), local_node_coords)
         ip = getfieldinterpolation(fh, field_idx)
         if ip isa VectorizedInterpolation
             # TODO: Remove this hack when embedding works...

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -55,7 +55,7 @@ function _apply_analytical!(
     coords = getcoordinates(dh.grid, first(cellset))
     ref_points = reference_coordinates(ip_fun)
     dummy_weights = zeros(length(ref_points))
-    qr = QuadratureRule{dim, RefShape}(dummy_weights, ref_points)
+    qr = QuadratureRule{RefShape}(dummy_weights, ref_points)
     # Note: Passing ip_geo as the function interpolation here, it is just a dummy.
     cv = CellValues(qr, ip_geo, ip_geo)
     c_dofs = celldofs(dh, first(cellset))

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -39,11 +39,19 @@ The derivatives of the shape functions, and the new integration weights are comp
 reinit!
 
 """
-    getnquadpoints(fe_v::AbstractValues)
+    getnquadpoints(cv::CellValues)
 
-Return the number of quadrature points for the `Values` object.
+Return the number of quadrature points in `cv`'s quadrature rule.
 """
-getnquadpoints(fe::AbstractValues) = length(fe.qr.weights)
+getnquadpoints(fe::CellValues) = getnquadpoints(fe.qr)
+
+"""
+    getnquadpoints(fv::FaceValues)
+
+Return the number of quadrature points in `fv`s quadrature for the current
+(most recently [`reinit!`](@ref)ed) face.
+"""
+getnquadpoints(fe::FaceValues) = getnquadpoints(fe.qr, fe.current_face[])
 
 """
     getdetJdV(fe_v::AbstractValues, q_point::Int)

--- a/src/FEValues/face_integrals.jl
+++ b/src/FEValues/face_integrals.jl
@@ -5,18 +5,15 @@ end
 ##################
 # All 1D RefLine #
 ##################
-function create_face_quad_rule(quad_rule::QuadratureRule{0,RefLine,T}, ::Interpolation{RefLine}) where {T}
-    w = getweights(quad_rule)
-    face_quad_rule = QuadratureRule{1,RefLine,T}[]
-
+function create_face_quad_rule(::Type{RefLine}, w::Vector{T}, ::Vector{Vec{0, T}}) where {T}
+    face_quad_rule = QuadratureRule{RefLine, T, 1}[]
     # Face 1
     new_points = [Vec{1,T}((-one(T),))] # ξ = -1
-    push!(face_quad_rule, QuadratureRule{1,RefLine,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefLine, T}(w, new_points))
     # Face 2
     new_points = [Vec{1,T}((one(T),))] # ξ = 1
-    push!(face_quad_rule, QuadratureRule{1,RefLine,T}(w, new_points))
-
-    return face_quad_rule
+    push!(face_quad_rule, QuadratureRule{RefLine, T}(w, new_points))
+    return FaceQuadratureRule(face_quad_rule)
 end
 
 function weighted_normal(::Tensor{2,1,T}, ::Type{RefLine}, face::Int) where {T}
@@ -28,26 +25,22 @@ end
 ###########################
 # All 2D RefQuadrilateral #
 ###########################
-function create_face_quad_rule(quad_rule::QuadratureRule{1,RefQuadrilateral,T}, ::Interpolation{RefQuadrilateral}) where {T}
-    w = getweights(quad_rule)
-    p = getpoints(quad_rule)
+function create_face_quad_rule(::Type{RefQuadrilateral}, w::Vector{T}, p::Vector{Vec{1, T}}) where {T}
     n_points = length(w)
-    face_quad_rule = QuadratureRule{2,RefQuadrilateral,T}[]
-
+    face_quad_rule = QuadratureRule{RefQuadrilateral, T, 2}[]
     # Face 1
     new_points = [Vec{2,T}((p[i][1], -one(T))) for i in 1:n_points] # ξ = t, η = -1
-    push!(face_quad_rule, QuadratureRule{2,RefQuadrilateral,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefQuadrilateral, T}(w, new_points))
     # Face 2
     new_points = [Vec{2,T}((one(T), p[i][1])) for i in 1:n_points] # ξ = 1, η = t
-    push!(face_quad_rule, QuadratureRule{2,RefQuadrilateral,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefQuadrilateral, T}(w, new_points))
     # Face 3
     new_points = [Vec{2,T}((p[i][1], one(T))) for i in 1:n_points] # ξ = t, η = 1
-    push!(face_quad_rule, QuadratureRule{2,RefQuadrilateral,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefQuadrilateral, T}(w, new_points))
     # Face 4
     new_points = [Vec{2,T}((-one(T), p[i][1])) for i in 1:n_points] # ξ = -1, η = t
-    push!(face_quad_rule, QuadratureRule{2,RefQuadrilateral,T}(w, new_points))
-
-    return face_quad_rule
+    push!(face_quad_rule, QuadratureRule{RefQuadrilateral, T}(w, new_points))
+    return FaceQuadratureRule(face_quad_rule)
 end
 
 function weighted_normal(J::Tensor{2,2}, ::Type{RefQuadrilateral}, face::Int)
@@ -63,23 +56,19 @@ end
 ######################
 # All RefTriangle 2D #
 ######################
-function create_face_quad_rule(quad_rule::QuadratureRule{1,RefTriangle,T}, ::Interpolation{RefTriangle}) where {T}
-    w = getweights(quad_rule)
-    p = getpoints(quad_rule)
+function create_face_quad_rule(::Type{RefTriangle}, w::Vector{T}, p::Vector{Vec{1, T}}) where {T}
     n_points = length(w)
-    face_quad_rule = QuadratureRule{2,RefTriangle,T}[]
-
+    face_quad_rule = QuadratureRule{RefTriangle, T, 2}[]
     # Face 1
     new_points = [Vec{2,T}((p[i][1], one(T)-p[i][1])) for i in 1:n_points] # ξ = t, η = 1-t
-    push!(face_quad_rule, QuadratureRule{2,RefTriangle,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefTriangle, T}(w, new_points))
     # Face 2
     new_points = [Vec{2,T}((zero(T), p[i][1])) for i in 1:n_points] # ξ = 0, η = t
-    push!(face_quad_rule, QuadratureRule{2,RefTriangle,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefTriangle, T}(w, new_points))
     # Face 3
     new_points = [Vec{2,T}((p[i][1], zero(T))) for i in 1:n_points] # ξ = t, η = 0
-    push!(face_quad_rule, QuadratureRule{2,RefTriangle,T}(w, new_points))
-
-    return face_quad_rule
+    push!(face_quad_rule, QuadratureRule{RefTriangle, T}(w, new_points))
+    return FaceQuadratureRule(face_quad_rule)
 end
 
 function weighted_normal(J::Tensor{2,2}, ::Type{RefTriangle}, face::Int)
@@ -94,32 +83,28 @@ end
 ########################
 # All RefHexahedron 3D #
 ########################
-function create_face_quad_rule(quad_rule::QuadratureRule{2,RefHexahedron,T}, ::Interpolation{RefHexahedron}) where {T}
-    w = getweights(quad_rule)
-    p = getpoints(quad_rule)
+function create_face_quad_rule(::Type{RefHexahedron}, w::Vector{T}, p::Vector{Vec{2, T}}) where {T}
     n_points = length(w)
-    face_quad_rule = QuadratureRule{3,RefHexahedron,T}[]
-
+    face_quad_rule = QuadratureRule{RefHexahedron, T, 3}[]
     # Face 1
     new_points = [Vec{3,T}((p[i][1], p[i][2], -one(T))) for i in 1:n_points] # ξ = t, η = s, ζ = -1
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
     # Face 2
     new_points = [Vec{3,T}((p[i][1], -one(T), p[i][2])) for i in 1:n_points] # ξ = t, η = -1, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
     # Face 3
     new_points = [Vec{3,T}((one(T), p[i][1], p[i][2])) for i in 1:n_points] # ξ = 1, η = t, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
     # Face 4
     new_points = [Vec{3,T}((p[i][1], one(T), p[i][2])) for i in 1:n_points] # ξ = t, η = 1, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
     # Face 5
     new_points = [Vec{3,T}((-one(T), p[i][1], p[i][2])) for i in 1:n_points] # ξ = -1, η = t, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
     # Face 6
     new_points = [Vec{3,T}((p[i][1], p[i][2], one(T))) for i in 1:n_points] # ξ = t, η = s, ζ = 1
-    push!(face_quad_rule, QuadratureRule{3,RefHexahedron,T}(w, new_points))
-
-    return face_quad_rule
+    push!(face_quad_rule, QuadratureRule{RefHexahedron, T}(w, new_points))
+    return FaceQuadratureRule(face_quad_rule)
 end
 
 function weighted_normal(J::Tensor{2,3}, ::Type{RefHexahedron}, face::Int)
@@ -137,26 +122,22 @@ end
 #########################
 # All RefTetrahedron 3D #
 #########################
-function create_face_quad_rule(quad_rule::QuadratureRule{2,RefTetrahedron,T}, ::Interpolation{RefTetrahedron}) where {T}
-    w = getweights(quad_rule)
-    p = getpoints(quad_rule)
+function create_face_quad_rule(::Type{RefTetrahedron}, w::Vector{T}, p::Vector{Vec{2, T}}) where {T}
     n_points = length(w)
-    face_quad_rule = QuadratureRule{3,RefTetrahedron,T}[]
-
+    face_quad_rule = QuadratureRule{RefTetrahedron, T, 3}[]
     # Face 1
     new_points = [Vec{3,T}((p[i][1], p[i][2], zero(T))) for i in 1:n_points] # ξ = t, η = s, ζ = 0
-    push!(face_quad_rule, QuadratureRule{3,RefTetrahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefTetrahedron, T}(w, new_points))
     # Face 2
     new_points = [Vec{3,T}((p[i][1], zero(T), p[i][2])) for i in 1:n_points] # ξ = t, η = 0, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefTetrahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefTetrahedron, T}(w, new_points))
     # Face 3
     new_points = [Vec{3,T}((p[i][1], p[i][2], one(T)-p[i][1]-p[i][2])) for i in 1:n_points] # ξ = t, η = s, ζ = 1-t-s
-    push!(face_quad_rule, QuadratureRule{3,RefTetrahedron,T}(w, new_points))
+    push!(face_quad_rule, QuadratureRule{RefTetrahedron, T}(w, new_points))
     # Face 4
     new_points = [Vec{3,T}((zero(T), p[i][1], p[i][2])) for i in 1:n_points] # ξ = 0, η = t, ζ = s
-    push!(face_quad_rule, QuadratureRule{3,RefTetrahedron,T}(w, new_points))
-
-    return face_quad_rule
+    push!(face_quad_rule, QuadratureRule{RefTetrahedron, T}(w, new_points))
+    return FaceQuadratureRule(face_quad_rule)
 end
 
 function weighted_normal(J::Tensor{2,3}, ::Type{RefTetrahedron}, face::Int)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -63,11 +63,11 @@ function L2Projector(
 end
 
 # Quadrature sufficient for integrating a mass matrix
-function _mass_qr(::Lagrange{shape, order}) where {dim, shape <: AbstractRefShape{dim}, order}
-    return QuadratureRule{dim,shape}(order + 1)
+function _mass_qr(::Lagrange{shape, order}) where {shape <: AbstractRefShape, order}
+    return QuadratureRule{shape}(order + 1)
 end
-function _mass_qr(::Lagrange{shape, 2}) where {dim, shape <: RefSimplex{dim}}
-    return QuadratureRule{dim,shape}(4)
+function _mass_qr(::Lagrange{shape, 2}) where {shape <: RefSimplex}
+    return QuadratureRule{shape}(4)
 end
 _mass_qr(ip::VectorizedInterpolation) = _mass_qr(ip.ip)
 
@@ -255,7 +255,7 @@ function _evaluate_at_grid_nodes(
     ip, gip = proj.func_ip, proj.geom_ip
     refdim, refshape = getdim(ip), getrefshape(ip)
     local_node_coords = reference_coordinates(gip)
-    qr = QuadratureRule{refdim,refshape}(zeros(length(local_node_coords)), local_node_coords)
+    qr = QuadratureRule{refshape}(zeros(length(local_node_coords)), local_node_coords)
     cv = CellValues(qr, ip)
     # Function barrier
     return _evaluate_at_grid_nodes!(data, cv, dh, proj.set, vals)

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -33,7 +33,7 @@ function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolati
     IP  <:       Interpolation{shape},
     GIP <: ScalarInterpolation{shape}
 }
-    qr = QuadratureRule{dim, shape, T}([one(T)], [zero(Vec{dim, T})])
+    qr = QuadratureRule{shape, T}([one(T)], [zero(Vec{dim, T})])
     cv = CellValues(T, qr, ip, ipg)
     return PointValues{typeof(cv)}(cv)
 end

--- a/src/Quadrature/quadrature.jl
+++ b/src/Quadrature/quadrature.jl
@@ -5,11 +5,16 @@ include("generate_quadrature.jl")
 
 import Base.Cartesian: @nloops, @nref, @ntuple, @nexprs
 
-"""
-    QuadratureRule{dim,shape}([quad_rule_type::Symbol], order::Int)
+##################
+# QuadratureRule #
+##################
 
-Create a `QuadratureRule` used for integration. `dim` is the space dimension,
-`shape` an [`AbstractRefShape`](@ref) and `order` the order of the quadrature rule.
+"""
+    QuadratureRule{shape}([quad_rule_type::Symbol], order::Int)
+    QuadratureRule{shape, T}([quad_rule_type::Symbol], order::Int)
+
+Create a `QuadratureRule` used for integration on the refshape `shape` (of type [`AbstractRefShape`](@ref)).
+`order` is the order of the quadrature rule.
 `quad_rule_type` is an optional argument determining the type of quadrature rule,
 currently the `:legendre` and `:lobatto` rules are implemented.
 
@@ -20,8 +25,7 @@ function values at specific points:
 
 The quadrature rule consists of ``n_q`` points in space ``\\mathbf{x}_q`` with corresponding weights ``w_q``.
 
-In `Ferrite`, the `QuadratureRule` type is mostly used as one of the components to create a [`CellValues`](@ref)
-or [`FaceValues`](@ref) object.
+In `Ferrite`, the `QuadratureRule` type is mostly used as one of the components to create [`CellValues`](@ref).
 
 **Common methods:**
 * [`getpoints`](@ref) : the points of the quadrature rule
@@ -29,40 +33,207 @@ or [`FaceValues`](@ref) object.
 
 **Example:**
 ```jldoctest
-julia> QuadratureRule{2, RefTetrahedron}(1)
-Ferrite.QuadratureRule{2,Ferrite.RefTetrahedron,Float64}([0.5], Tensors.Tensor{1,2,Float64,2}[[0.333333, 0.333333]])
+julia> qr = QuadratureRule{RefTriangle}(1)
+QuadratureRule{RefTriangle, Float64, 2}([0.5], Vec{2, Float64}[[0.33333333333333, 0.33333333333333]])
 
-julia> QuadratureRule{1, RefLine}(:lobatto, 2)
-Ferrite.QuadratureRule{1,Ferrite.RefLine,Float64}([1.0, 1.0], Tensors.Tensor{1,1,Float64,1}[[-1.0], [1.0]])
+julia> getpoints(qr)
+1-element Vector{Vec{2, Float64}}:
+ [0.33333333333333, 0.33333333333333]
 ```
 """
-struct QuadratureRule{dim,shape,T}
+struct QuadratureRule{shape,T,dim}
     weights::Vector{T}
     points::Vector{Vec{dim,T}}
+    function QuadratureRule{shape, T}(weights::Vector{T}, points::Vector{Vec{dim, T}}) where {dim, shape <: AbstractRefShape{dim}, T}
+        if length(weights) != length(points)
+            throw(ArgumentError("number of weights and number of points do not match"))
+        end
+        new{shape, T, dim}(weights, points)
+    end
 end
 
-function QuadratureRule{dim, shape}(weights::AbstractVector{Tw}, points::AbstractVector{Vec{dim,Tp}}) where {dim, shape, Tw, Tp}
-    T = promote_type(Tw, Tp)
-    QuadratureRule{dim,shape,T}(weights, points)
+function QuadratureRule{shape}(weights::Vector{T}, points::Vector{Vec{dim, T}}) where {dim, shape <: AbstractRefShape{dim}, T}
+    QuadratureRule{shape, T}(weights, points)
 end
 
-# Default dim to refdim (i.e. for cell quadrature)
-function QuadratureRule{shape}(args...) where {dim, shape <: AbstractRefShape{dim}}
-    return QuadratureRule{dim, shape}(args...)
+
+# Fill in defaults (Float64, :legendre)
+function QuadratureRule{shape}(order::Int) where {shape <: AbstractRefShape}
+    return QuadratureRule{shape, Float64}(order)
+end
+function QuadratureRule{shape, T}(order::Int) where {shape <: AbstractRefShape, T}
+    quad_type = shape === RefPrism ? (:polyquad) : (:legendre)
+    return QuadratureRule{shape, T}(quad_type, order)
+end
+function QuadratureRule{shape}(quad_type::Symbol, order::Int) where {shape <: AbstractRefShape}
+    return QuadratureRule{shape, Float64}(quad_type, order)
 end
 
-Base.copy(qr::QuadratureRule) = qr # TODO: Is it ever useful to get an actual copy?
+# Generate Gauss quadrature rules on hypercubes by doing an outer product
+# over all dimensions
+for dim in 1:3
+    @eval begin
+        function QuadratureRule{RefHypercube{$dim}, T}(quad_type::Symbol, order::Int) where T
+            if quad_type === :legendre
+                p, w = GaussQuadrature.legendre(T, order)
+            elseif quad_type === :lobatto
+                p, w = GaussQuadrature.legendre(T, order, GaussQuadrature.both)
+            else
+                throw(ArgumentError("unsupported quadrature rule"))
+            end
+            weights = Vector{T}(undef, order^($dim))
+            points = Vector{Vec{$dim,T}}(undef, order^($dim))
+            count = 1
+            @nloops $dim i j->(1:order) begin
+                t = @ntuple $dim q-> p[$(Symbol("i"*"_q"))]
+                points[count] = Vec{$dim,T}(t)
+                weight = 1.0
+                @nexprs $dim j->(weight *= w[i_{j}])
+                weights[count] = weight
+                count += 1
+            end
+            return QuadratureRule{RefHypercube{$dim}, T}(weights, points)
+        end
+    end
+end
 
-getdim(::QuadratureRule{dim}) where {dim} = dim
+for dim in 2:3
+    @eval begin
+        function QuadratureRule{RefSimplex{$dim}, T}(quad_type::Symbol, order::Int) where T
+            if $dim == 2 && quad_type === :legendre
+                data = _get_gauss_tridata(order)
+            elseif $dim == 3 && quad_type === :legendre
+                data = _get_gauss_tetdata(order)
+            else
+                throw(ArgumentError("unsupported quadrature rule"))
+            end
+            n_points = size(data,1)
+            points = Vector{Vec{$dim,T}}(undef, n_points)
+
+            for p in 1:size(data, 1)
+                points[p] = Vec{$dim,T}(@ntuple $dim i -> data[p, i])
+            end
+            weights = data[:, $dim + 1]
+            QuadratureRule{RefSimplex{$dim}, T}(weights, points)
+        end
+    end
+end
+
+# Grab prism quadrature rule from table
+function QuadratureRule{RefPrism, T}(quad_type::Symbol, order::Int) where T
+    if quad_type == :polyquad
+        data = _get_gauss_prismdata_polyquad(order)
+    else
+        throw(ArgumentError("unsupported quadrature rule"))
+    end
+    n_points = size(data,1)
+    points = Vector{Vec{3,T}}(undef, n_points)
+
+    for p in 1:size(data, 1)
+        points[p] = Vec{3,T}(@ntuple 3 i -> data[p, i])
+    end
+    weights = data[:, 4]
+    QuadratureRule{RefPrism,T}(weights, points)
+end
+
+######################
+# FaceQuadratureRule #
+######################
+
+"""
+    FaceQuadratureRule{shape}([quad_rule_type::Symbol], order::Int)
+    FaceQuadratureRule{shape, T}([quad_rule_type::Symbol], order::Int)
+
+Create a `FaceQuadratureRule` used for integration of the faces of the refshape `shape` (of
+type [`AbstractRefShape`](@ref)). `order` is the order of the quadrature rule.
+`quad_rule_type` is an optional argument determining the type of quadrature rule, currently
+the `:legendre` and `:lobatto` rules are implemented.
+
+`FaceQuadratureRule` is used as one of the components to create [`FaceValues`](@ref).
+"""
+struct FaceQuadratureRule{shape, T, dim}
+    face_rules::Vector{QuadratureRule{shape, T, dim}}
+    function FaceQuadratureRule{shape, T, dim}(face_rules::Vector{QuadratureRule{shape, T, dim}}) where {shape, T, dim}
+        # TODO: Verify length(face_rules) == nfaces(shape)
+        return new{shape, T, dim}(face_rules)
+    end
+end
+
+function FaceQuadratureRule(face_rules::Vector{QuadratureRule{shape, T, dim}}) where {shape, T, dim}
+    return FaceQuadratureRule{shape, T, dim}(face_rules)
+end
+
+# Fill in defaults (Float64, :legendre)
+function FaceQuadratureRule{shape}(order::Int) where {shape <: AbstractRefShape}
+    return FaceQuadratureRule{shape, Float64}(order)
+end
+function FaceQuadratureRule{shape, T}(order::Int) where {shape <: AbstractRefShape, T}
+    return FaceQuadratureRule{shape, T}(:legendre, order)
+end
+function FaceQuadratureRule{shape}(quad_type::Symbol, order::Int) where {shape <: AbstractRefShape}
+    return FaceQuadratureRule{shape, Float64}(quad_type, order)
+end
+
+# For RefShapes with equal face-shapes: generate quad rule for the face shape
+# and expand to each face
+function FaceQuadratureRule{RefLine, T}(::Symbol, ::Int) where T
+    w, p = T[1], Vec{0, T}[]
+    return create_face_quad_rule(RefLine, w, p)
+end
+function FaceQuadratureRule{RefQuadrilateral, T}(quad_type::Symbol, order::Int) where T
+    qr = QuadratureRule{RefLine, T}(quad_type, order)
+    return create_face_quad_rule(RefQuadrilateral, qr.weights, qr.points)
+end
+function FaceQuadratureRule{RefHexahedron, T}(quad_type::Symbol, order::Int) where T
+    qr = QuadratureRule{RefQuadrilateral, T}(quad_type, order)
+    return create_face_quad_rule(RefHexahedron, qr.weights, qr.points)
+end
+function FaceQuadratureRule{RefTriangle, T}(quad_type::Symbol, order::Int) where T
+    qr = QuadratureRule{RefLine, T}(quad_type, order)
+    # Shift interval from (-1,1) to (0,1)
+    for i in eachindex(qr.weights, qr.points)
+        qr.weights[i] /= 2
+        qr.points[i] = (qr.points[i] + Vec{1,T}((1,))) / 2
+    end
+    return create_face_quad_rule(RefTriangle, qr.weights, qr.points)
+end
+function FaceQuadratureRule{RefTetrahedron, T}(quad_type::Symbol, order::Int) where T
+    qr = QuadratureRule{RefTriangle, T}(quad_type, order)
+    return create_face_quad_rule(RefTetrahedron, qr.weights, qr.points)
+end
+function FaceQuadratureRule{RefPrism, T}(quad_type::Symbol, order::Int) where T
+    # TODO: Generate 2 RefTriangle, 3 RefQuadrilateral and transform them
+    error("FaceQuadratureRule for RefPrism not implemented")
+end
+
+
+##################
+# Common methods #
+##################
+
+"""
+    getnquadpoints(qr::QuadratureRule)
+
+Return the number of quadrature points in `qr`.
+"""
+getnquadpoints(qr::QuadratureRule) = length(getweights(qr))
+
+"""
+    getnquadpoints(qr::FaceQuadratureRule, face::Int)
+
+Return the number of quadrature points in `qr` for local face index `face`.
+"""
+getnquadpoints(qr::FaceQuadratureRule, face::Int) = getnquadpoints(qr.face_rules[face])
 
 """
     getweights(qr::QuadratureRule)
+    getweights(qr::FaceQuadratureRule, face::Int)
 
 Return the weights of the quadrature rule.
 
 # Examples
 ```jldoctest
-julia> qr = QuadratureRule{2, RefTetrahedron}(:legendre, 2);
+julia> qr = QuadratureRule{RefTriangle}(:legendre, 2);
 
 julia> getweights(qr)
 3-element Array{Float64,1}:
@@ -72,119 +243,28 @@ julia> getweights(qr)
 ```
 """
 getweights(qr::QuadratureRule) = qr.weights
+getweights(qr::FaceQuadratureRule, face::Int) = getweights(qr.face_rules[face])
 
 
 """
     getpoints(qr::QuadratureRule)
+    getpoints(qr::FaceQuadratureRule, face::Int)
 
 Return the points of the quadrature rule.
 
 # Examples
 ```jldoctest
-julia> qr = QuadratureRule{2, RefTetrahedron}(:legendre, 2);
+julia> qr = QuadratureRule{RefTriangle}(:legendre, 2);
 
 julia> getpoints(qr)
-3-element Array{Tensors.Tensor{1,2,Float64,2},1}:
- [0.166667, 0.166667]
- [0.166667, 0.666667]
- [0.666667, 0.166667]
+3-element Vector{Vec{2, Float64}}:
+ [0.16666666666667, 0.16666666666667]
+ [0.16666666666667, 0.66666666666667]
+ [0.66666666666667, 0.16666666666667]
 ```
 """
 getpoints(qr::QuadratureRule) = qr.points
+getpoints(qr::FaceQuadratureRule, face::Int) = getpoints(qr.face_rules[face])
 
-QuadratureRule{dim,shape}(order::Int) where {dim,shape} = QuadratureRule{dim,shape}(:legendre, order)
-QuadratureRule{3,RefPrism}(order::Int) = QuadratureRule{3,RefPrism}(:polyquad, order) # No legendre rule available yet for prism...
-
-# Special case for face integration of 1D problems
-function (::Type{QuadratureRule{0, RefLine}})(quad_type::Symbol, order::Int)
-    w = Float64[1.0]
-    p = Vec{0,Float64}[]
-    return QuadratureRule{0,RefLine,Float64}(w,p)
-end
-
-# Generate Gauss quadrature rules on cubes by doing an outer product
-# over all dimensions
-for (dim, shape) in ((1, RefLine), (2, RefQuadrilateral), (3, RefHexahedron), (1, RefQuadrilateral), (2, RefHexahedron))
-    @eval begin
-        function (::Type{QuadratureRule{$dim,$shape}})(quad_type::Symbol, order::Int)
-            if quad_type == :legendre
-                p, w = GaussQuadrature.legendre(Float64, order)
-            elseif quad_type == :lobatto
-                p, w = GaussQuadrature.legendre(Float64, order, GaussQuadrature.both)
-            else
-                throw(ArgumentError("unsupported quadrature rule"))
-            end
-            weights = Vector{Float64}(undef, order^($dim))
-            points = Vector{Vec{$dim,Float64}}(undef, order^($dim))
-            count = 1
-            @nloops $dim i j->(1:order) begin
-                t = @ntuple $dim q-> p[$(Symbol("i"*"_q"))]
-                points[count] = Vec{$dim,Float64}(t)
-                weight = 1.0
-                @nexprs $dim j->(weight *= w[i_{j}])
-                weights[count] = weight
-                count += 1
-            end
-            return QuadratureRule{$dim,$shape,Float64}(weights, points)
-        end
-    end
-end
-
-for (dim, shape) in ((2, RefTriangle), (3, RefTetrahedron), (2, RefTetrahedron))
-    @eval begin
-        function (::Type{QuadratureRule{$dim, $shape}})(quad_type::Symbol, order::Int)
-            if $dim == 2 && quad_type == :legendre
-                data = _get_gauss_tridata(order)
-            elseif $dim == 3 && quad_type == :legendre
-                data = _get_gauss_tetdata(order)
-            else
-                throw(ArgumentError("unsupported quadrature rule"))
-            end
-            n_points = size(data,1)
-            points = Vector{Vec{$dim,Float64}}(undef, n_points)
-
-            for p in 1:size(data, 1)
-                points[p] = Vec{$dim,Float64}(@ntuple $dim i -> data[p, i])
-            end
-            weights = data[:, $dim + 1]
-            QuadratureRule{$dim,$shape,Float64}(weights, points)
-        end
-    end
-end
-
-# Special version for face integration of triangles
-function (::Type{QuadratureRule{1,RefTriangle}})(quad_type::Symbol, order::Int)
-    if quad_type == :legendre
-        p, weights = GaussQuadrature.legendre(Float64,order)
-    elseif quad_type == :lobatto
-        p, weights = GaussQuadrature.legendre(Float64, order, GaussQuadrature.both)
-    else
-        throw(ArgumentError("unsupported quadrature rule"))
-    end
-    points = Vector{Vec{1,Float64}}(undef, order)
-    # Shift interval from (-1,1) to (0,1)
-    weights *= 0.5
-    p .+= 1.0; p /= 2.0
-
-    for i in 1:length(weights)
-        points[i] = Vec{1,Float64}((p[i],))
-    end
-    return QuadratureRule{1,RefTriangle,Float64}(weights, points)
-end
-
-# Grab prism quadrature rule from table
-function (::Type{QuadratureRule{3, RefPrism}})(quad_type::Symbol, order::Int)
-    if quad_type == :polyquad
-        data = _get_gauss_prismdata_polyquad(order)
-    else
-        throw(ArgumentError("unsupported quadrature rule"))
-    end
-    n_points = size(data,1)
-    points = Vector{Vec{3,Float64}}(undef, n_points)
-
-    for p in 1:size(data, 1)
-        points[p] = Vec{3,Float64}(@ntuple 3 i -> data[p, i])
-    end
-    weights = data[:, 4]
-    QuadratureRule{3,RefPrism,Float64}(weights, points)
-end
+# TODO: This is used in copy(::(Cell|Face)Values), but it it useful to get an actual copy?
+Base.copy(qr::Union{QuadratureRule,FaceQuadratureRule}) = qr

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -196,71 +196,81 @@ function CrouzeixRaviart{2, 1}()
     return CrouzeixRaviart{RefTriangle, 1}()
 end
 
-# For the quadrature: This will be wrong for face integration, so then we warn
+# For the quadrature: Some will be wrong for face integration, so then we warn
 # in the FaceValue constructor...
+
+# QuadratureRule{1, RefCube}(...) -> QuadratureRule{RefLine}(...)
+# QuadratureRule{2, RefCube}(...) -> QuadratureRule{RefQuadrilateral}(...)
+# QuadratureRule{3, RefCube}(...) -> QuadratureRule{RefHexahedron}(...)
+# QuadratureRule{1, RefCube}(...) -> FaceQuadratureRule{RefQuadrilateral}(...)
+# QuadratureRule{2, RefCube}(...) -> FaceQuadratureRule{RefHexahedron}(...)
 function QuadratureRule{D, RefCube}(order::Int) where D
     shapes = (RefLine, RefQuadrilateral, RefHexahedron)
-    msg = "`QuadratureRule{$D, RefCube}(order::Int)` is deprecated, use `QuadratureRule{$D, $(shapes[D])}(order)` instead"
+    msg = "`QuadratureRule{$D, RefCube}(order::Int)` is deprecated, use `QuadratureRule{$(shapes[D])}(order)` instead"
     if D == 1 || D == 2
-        msg *= " (or `QuadratureRule{$D, $(shapes[D+1])}(order)` if this is a face quadrature rule)"
+        msg *= " (or `FaceQuadratureRule{$(shapes[D+1])}(order)` if this is a face quadrature rule)"
     end
     msg *= "."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{D, shapes[D]}(order)
+    return QuadratureRule{shapes[D]}(order)
 end
 function QuadratureRule{D, RefCube}(quad_type::Symbol, order::Int) where D
     shapes = (RefLine, RefQuadrilateral, RefHexahedron)
-    msg = "`QuadratureRule{$D, RefCube}(quad_type::Symbol, order::Int)` is deprecated, use `QuadratureRule{$D, $(shapes[D])}(quad_type, order)` instead"
+    msg = "`QuadratureRule{$D, RefCube}(quad_type::Symbol, order::Int)` is deprecated, use `QuadratureRule{$(shapes[D])}(quad_type, order)` instead"
     if D == 1 || D == 2
-        msg *= " (or `QuadratureRule{$D, $(shapes[D+1])}(order)` if this is a face quadrature rule)"
+        msg *= " (or `FaceQuadratureRule{$(shapes[D+1])}(quad_type, order)` if this is a face quadrature rule)"
     end
     msg *= "."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{D, shapes[D]}(quad_type, order)
+    return QuadratureRule{shapes[D]}(quad_type, order)
 end
 
-function QuadratureRule{D, RefCube}(weights::AbstractVector{Tw}, points::AbstractVector{Vec{D,Tp}}) where {D, Tw, Tp}
-    shapes = (RefLine, RefQuadrilateral, RefHexahedron)
-    msg = "`QuadratureRule{$D, RefCube}(weights, points)` is deprecated, use `QuadratureRule{$D, $(shapes[D])}(weights, points)` instead"
-    if D == 1 || D == 2
-        msg *= " (or `QuadratureRule{$D, $(shapes[D+1])}(weights, points)` if this is a face quadrature rule)"
+# QuadratureRule{2, RefTetrahedron}(...) -> QuadratureRule{RefTriangle}(...)
+# QuadratureRule{3, RefTetrahedron}(...) -> QuadratureRule{RefTetrahedron}(...)
+# QuadratureRule{2, RefTetrahedron}(...) -> FaceQuadratureRule{RefTetrahedron}(...)
+function QuadratureRule{D, RefTetrahedron}(order::Int) where D
+    shapes = (nothing, RefTriangle, RefTetrahedron)
+    msg = "`QuadratureRule{$D, RefTetrahedron}(order::Int)` is deprecated, use `QuadratureRule{$(shapes[D])}(order)` instead"
+    if D == 2
+        msg *= " (or `FaceQuadratureRule{RefTetrahedron)}(order)` if this is a face quadrature rule)"
     end
     msg *= "."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{D, shapes[D]}(weights, points)
+    return QuadratureRule{shapes[D]}(order)
 end
-
-function QuadratureRule{D, RefCube, T}(weights::AbstractVector, points::AbstractVector{<:Vec}) where {D, T}
-    shapes = (RefLine, RefQuadrilateral, RefHexahedron)
-    msg = "`QuadratureRule{$D, RefCube, T}(weights, points)` is deprecated, use `QuadratureRule{$D, $(shapes[D]), T}(weights, points)` instead"
-    if D == 1 || D == 2
-        msg *= " (or `QuadratureRule{$D, $(shapes[D+1]), T}(weights, points)` if this is a face quadrature rule)"
+function QuadratureRule{D, RefTetrahedron}(quad_type::Symbol, order::Int) where D
+    shapes = (nothing, RefTriangle, RefTetrahedron)
+    msg = "`QuadratureRule{$D, RefTetrahedron}(quad_type::Symbol, order::Int)` is deprecated, use `QuadratureRule{$(shapes[D])}(quad_type, order)` instead"
+    if D == 2
+        msg *= " (or `FaceQuadratureRule{RefTetrahedron)}(order)` if this is a face quadrature rule)"
     end
     msg *= "."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{D, shapes[D], T}(weights, points)
+    return QuadratureRule{shapes[D]}(quad_type, order)
 end
 
-# These must be for a face, warn only here.
+# QuadratureRule{0, RefCube}(...) -> FaceQuadratureRule{RefLine}
 function QuadratureRule{0, RefCube}(order::Int)
-    msg = "`QuadratureRule{0, RefCube}(order::Int)` is deprecated, use `QuadratureRule{0, RefLine}(order)` instead."
+    msg = "`QuadratureRule{0, RefCube}(order::Int)` is deprecated, use `FaceQuadratureRule{RefLine}(order)` instead."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{0, RefLine}(order)
+    return FaceQuadratureRule{RefLine}(order)
 end
 function QuadratureRule{0, RefCube}(quad_type::Symbol, order::Int)
-    msg = "`QuadratureRule{0, RefCube}(quad_type::Symbol, order::Int)` is deprecated, use `QuadratureRule{0, RefLine}(quad_type, order)` instead."
+    msg = "`QuadratureRule{0, RefCube}(quad_type::Symbol, order::Int)` is deprecated, use `FaceQuadratureRule{RefLine}(quad_type, order)` instead."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{0, RefLine}(quad_type, order)
+    return FaceQuadratureRule{RefLine}(quad_type, order)
 end
+
+# QuadratureRule{1, RefTetrahedron}(...) -> FaceQuadratureRule{RefTriangle}
 function QuadratureRule{1, RefTetrahedron}(order::Int)
-    msg = "`QuadratureRule{1, RefTetrahedron}(order::Int)` is deprecated, use `QuadratureRule{1, RefTriangle}(order)` instead."
+    msg = "`QuadratureRule{1, RefTetrahedron}(order::Int)` is deprecated, use `FaceQuadratureRule{RefTriangle}(order)` instead."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{1, RefTriangle}(order)
+    return FaceQuadratureRule{RefTriangle}(order)
 end
 function QuadratureRule{1, RefTetrahedron}(quad_type::Symbol, order::Int)
-    msg = "`QuadratureRule{1, RefTetrahedron}(quad_type::Symbol, order::Int)` is deprecated, use `QuadratureRule{0, RefTriangle}(quad_type, order)` instead."
+    msg = "`QuadratureRule{1, RefTetrahedron}(quad_type::Symbol, order::Int)` is deprecated, use `FaceQuadratureRule{RefTriangle}(quad_type, order)` instead."
     Base.depwarn(msg, :QuadratureRule)
-    return QuadratureRule{1, RefTriangle}(quad_type, order)
+    return FaceQuadratureRule{RefTriangle}(quad_type, order)
 end
 
 # Catch remaining cases in (Cell|Face)Value constructors
@@ -269,23 +279,36 @@ function CellValues(
     gip::Interpolation{RefTriangle} = default_geometric_interpolation(ip),
 ) where {T, TQ}
     qr′ = QuadratureRule{2, RefTriangle, T}(qr.weights, qr.points)
-    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{2, RefTetrahedron}(...)` which have been deprecated in favor of `QuadratureRule{2, RefTriangle}(...)`.", :CellValues)
+    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{2, RefTetrahedron}(...)` which have been deprecated in favor of `QuadratureRule{RefTriangle}(...)`.", :CellValues)
     CellValues(T, qr′, ip, gip)
 end
+function FaceValues(qr::QuadratureRule, ip::Interpolation,
+                    gip::Interpolation = default_geometric_interpolation(ip))
+    return FaceValues(Float64, qr, ip, gip)
+end
 function FaceValues(
-    ::Type{T}, qr::QuadratureRule{1, RefLine, TQ}, ip::Interpolation{RefQuadrilateral},
+    ::Type{T}, qr::QuadratureRule{RefLine, TQ}, ip::Interpolation{RefQuadrilateral},
     gip::Interpolation{RefQuadrilateral} = default_geometric_interpolation(ip),
 ) where {T, TQ}
-    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{1, RefCube}(...)` which have been deprecated in favor of `QuadratureRule{1, RefQuadrilateral}(...)`.", :FaceValues)
-    qr′ = QuadratureRule{1, RefQuadrilateral, T}(qr.weights, qr.points)
+    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{1, RefCube}(...)` which have been deprecated in favor of `FaceQuadratureRule{RefQuadrilateral}(...)`.", :FaceValues)
+    qr′ = create_face_quad_rule(RefQuadrilateral, qr.weights, qr.points)
     FaceValues(T, qr′, ip, gip)
 end
 function FaceValues(
-    ::Type{T}, qr::QuadratureRule{2, RefQuadrilateral, TQ}, ip::Interpolation{RefHexahedron},
+    ::Type{T}, qr::QuadratureRule{RefQuadrilateral, TQ}, ip::Interpolation{RefHexahedron},
     gip::Interpolation{RefHexahedron} = default_geometric_interpolation(ip),
 ) where {T, TQ}
-    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{2, RefCube}(...)` which have been deprecated in favor of `QuadratureRule{2, RefHexahedron}(...)`.", :FaceValues)
-    qr′ = QuadratureRule{2, RefHexahedron, T}(qr.weights, qr.points)
+    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{2, RefCube}(...)` which have been deprecated in favor of `FaceQuadratureRule{RefHexahedron}(...)`.", :FaceValues)
+    qr′ = create_face_quad_rule(RefHexahedron, qr.weights, qr.points)
+    FaceValues(T, qr′, ip, gip)
+end
+function FaceValues(
+    ::Type{T}, qr::QuadratureRule{RefTriangle, TQ}, ip::Interpolation{RefTetrahedron},
+    gip::Interpolation{RefTetrahedron} = default_geometric_interpolation(ip),
+) where {T, TQ}
+@info "fdjsfdsf"
+    Base.depwarn("The input quadrature rule have the wrong reference shape, likely this comes from a constructor like `QuadratureRule{2, RefTetrahedron}(...)` which have been deprecated in favor of `FaceQuadratureRule{RefTetrahedron}(...)`.", :FaceValues)
+    qr′ = create_face_quad_rule(RefTetrahedron, qr.weights, qr.points)
     FaceValues(T, qr′, ip, gip)
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -19,6 +19,8 @@ export
 
 # Quadrature
     QuadratureRule,
+    FaceQuadratureRule,
+    getnquadpoints,
     getweights,
     getpoints,
 
@@ -41,7 +43,6 @@ export
     spatial_coordinate,
     getnormal,
     getdetJdV,
-    getnquadpoints,
 
 # Grid
     Grid,

--- a/test/test_abstractgrid.jl
+++ b/test/test_abstractgrid.jl
@@ -25,7 +25,7 @@
     reference_grid = generate_grid(Quadrilateral, (2,2))
 
     ip = Lagrange{RefQuadrilateral, 1}()
-    qr = QuadratureRule{2, RefQuadrilateral}(2)
+    qr = QuadratureRule{RefQuadrilateral}(2)
     cellvalues = CellValues(qr, ip);
     
     dhs = [DofHandler(grid) for grid in (subtype_grid, reference_grid)]

--- a/test/test_apply_rhs.jl
+++ b/test/test_apply_rhs.jl
@@ -1,6 +1,5 @@
 function test_apply_rhs()
     grid = generate_grid(Quadrilateral, (20, 20))
-    dim = 2
     ip = Lagrange{RefQuadrilateral,1}()
     qr = QuadratureRule{RefQuadrilateral}(2)
     cellvalues = CellValues(qr, ip)

--- a/test/test_apply_rhs.jl
+++ b/test/test_apply_rhs.jl
@@ -2,7 +2,7 @@ function test_apply_rhs()
     grid = generate_grid(Quadrilateral, (20, 20))
     dim = 2
     ip = Lagrange{RefQuadrilateral,1}()
-    qr = QuadratureRule{dim,RefQuadrilateral}(2)
+    qr = QuadratureRule{RefQuadrilateral}(2)
     cellvalues = CellValues(qr, ip)
     
     dh = DofHandler(grid)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -110,7 +110,7 @@ end
     close!(dh);
     cell = first(CellIterator(dh))
     ip_geo = Lagrange{RefLine, 2}()
-    qr = QuadratureRule{dim, RefLine}(deg+1)
+    qr = QuadratureRule{RefLine}(deg+1)
     cv = CellValues(qr, ip_fe, ip_geo)
     res = @test_throws ArgumentError reinit!(cv, cell)
     @test occursin("265", res.value.msg)
@@ -124,7 +124,7 @@ end
     qp = 1
     ip = Lagrange{RefTriangle,1}()
     qr = QuadratureRule{RefTriangle}(1)
-    qr_f = QuadratureRule{dim-1, RefTriangle}(1)
+    qr_f = FaceQuadratureRule{RefTriangle}(1)
     csv = CellValues(qr, ip)
     cvv = CellValues(qr, VectorizedInterpolation(ip))
     fsv = FaceValues(qr_f, ip)
@@ -169,7 +169,7 @@ end
         ip_base = Lagrange{RefLine,1}()
         ip = vdim > 0 ? ip_base^vdim : ip_base
         ue = 2 * rand(getnbasefunctions(ip))
-        qr = QuadratureRule{1,RefLine}(1)
+        qr = QuadratureRule{RefLine}(1)
         # Reference values
         csv1 = CellValues(qr, ip)
         reinit!(csv1, [Vec((0.0,)), Vec((1.0,))])
@@ -255,7 +255,7 @@ end
         ip_base = Lagrange{RefQuadrilateral,1}()
         ip = vdim > 0 ? ip_base^vdim : ip_base
         ue = rand(getnbasefunctions(ip))
-        qr = QuadratureRule{2,RefQuadrilateral}(1)
+        qr = QuadratureRule{RefQuadrilateral}(1)
         csv2 = CellValues(qr, ip)
         csv3 = CellValues(qr, ip, ip_base^3)
         reinit!(csv2, [Vec((-1.0,-1.0)), Vec((1.0,-1.0)), Vec((1.0,1.0)), Vec((-1.0,1.0))])

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1393,7 +1393,7 @@ end # testset
 
         ke = zeros(ndofs_per_cell(dh), ndofs_per_cell(dh))
         fe = zeros(ndofs_per_cell(dh))
-        cv = CellValues(QuadratureRule{2,RefQuadrilateral}(2), Lagrange{RefQuadrilateral,1}())
+        cv = CellValues(QuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,1}())
 
         for cell in CellIterator(dh)
             reinit!(cv, cell)

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -21,7 +21,7 @@ end
 
 @testset "Deprecation of (Cell|Face)(Scalar|Vector)Values" begin
     ip = Lagrange{RefQuadrilateral, 1}()
-    qr = QuadratureRule{2, RefQuadrilateral}(2)
+    qr = QuadratureRule{RefQuadrilateral}(2)
     for CVType in (
             CellScalarValues, CellVectorValues,
             FaceScalarValues, FaceVectorValues,
@@ -76,8 +76,6 @@ end
     @test (@test_deprecated r"likely this comes" test_combo(FaceValues, 2, RefCube, (1,), Lagrange{RefHexahedron, 1}())) isa FaceValues
     @test (@test_deprecated r"RefQuadrilateral.*RefHexahedron" test_combo(FaceValues, 2, RefCube, (:legendre, 1), Lagrange{RefHexahedron, 1}())) isa FaceValues
     @test (@test_deprecated r"likely this comes" test_combo(FaceValues, 2, RefCube, (:legendre, 1), Lagrange{RefHexahedron, 1}())) isa FaceValues
-    @test (@test_deprecated r"likely this comes" test_combo(CellValues, 2, RefTetrahedron, (1,), Lagrange{RefTriangle, 1}())) isa CellValues
-    @test (@test_deprecated r"likely this comes" test_combo(CellValues, 2, RefTetrahedron, (:legendre, 1), Lagrange{RefTriangle, 1}())) isa CellValues
     @test (@test_deprecated r"RefTriangle" test_combo(FaceValues, 1, RefTetrahedron, (1,), Lagrange{RefTriangle, 1}())) isa FaceValues
     @test (@test_deprecated r"RefTriangle" test_combo(FaceValues, 1, RefTetrahedron, (:legendre, 1), Lagrange{RefTriangle, 1}())) isa FaceValues
 end

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -1,15 +1,15 @@
 @testset "FaceValues" begin
 for (scalar_interpol, quad_rule) in (
-                                    (Lagrange{RefLine, 1}(), QuadratureRule{0, RefLine}(2)),
-                                    (Lagrange{RefLine, 2}(), QuadratureRule{0, RefLine}(2)),
-                                    (Lagrange{RefQuadrilateral, 1}(), QuadratureRule{1, RefQuadrilateral}(2)),
-                                    (Lagrange{RefQuadrilateral, 2}(), QuadratureRule{1, RefQuadrilateral}(2)),
-                                    (Lagrange{RefTriangle, 1}(), QuadratureRule{1, RefTriangle}(2)),
-                                    (Lagrange{RefTriangle, 2}(), QuadratureRule{1, RefTriangle}(2)),
-                                    (Lagrange{RefHexahedron, 1}(), QuadratureRule{2, RefHexahedron}(2)),
-                                    (Serendipity{RefQuadrilateral, 2}(), QuadratureRule{1, RefQuadrilateral}(2)),
-                                    (Lagrange{RefTetrahedron, 1}(), QuadratureRule{2, RefTetrahedron}(2)),
-                                    (Lagrange{RefTetrahedron, 2}(), QuadratureRule{2, RefTetrahedron}(2)),
+                                    (Lagrange{RefLine, 1}(), FaceQuadratureRule{RefLine}(2)),
+                                    (Lagrange{RefLine, 2}(), FaceQuadratureRule{RefLine}(2)),
+                                    (Lagrange{RefQuadrilateral, 1}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                    (Lagrange{RefQuadrilateral, 2}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                    (Lagrange{RefTriangle, 1}(), FaceQuadratureRule{RefTriangle}(2)),
+                                    (Lagrange{RefTriangle, 2}(), FaceQuadratureRule{RefTriangle}(2)),
+                                    (Lagrange{RefHexahedron, 1}(), FaceQuadratureRule{RefHexahedron}(2)),
+                                    (Serendipity{RefQuadrilateral, 2}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                    (Lagrange{RefTetrahedron, 1}(), FaceQuadratureRule{RefTetrahedron}(2)),
+                                    (Lagrange{RefTetrahedron, 2}(), FaceQuadratureRule{RefTetrahedron}(2)),
                                    )
 
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -396,7 +396,7 @@ end
     reinit!(fv::FaceValues, faceid::FaceIndex, grid) = reinit!(fv,faceid[1],faceid[2],grid) # wrapper for reinit!(fv,cellid,faceid,grid)
     face_neighbors_ele5 = nonzeros(topology.face_neighbor[5,:])
     ip = Lagrange{RefQuadrilateral, 1}()^2
-    qr_face = QuadratureRule{1, RefQuadrilateral}(2)
+    qr_face = FaceQuadratureRule{RefQuadrilateral}(2)
     fv_ele = FaceValues(qr_face, ip)
     fv_neighbor = FaceValues(qr_face, ip)
     u_ele5 = [3.0 for _ in 1:8]

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -5,7 +5,6 @@ function test_projection(order, refshape)
     element = refshape == RefQuadrilateral ? Quadrilateral : Triangle
     grid = generate_grid(element, (1, 1), Vec((0.,0.)), Vec((1.,1.)))
 
-    dim = 2
     ip = Lagrange{refshape, order}()
     ip_geom = Lagrange{refshape, 1}()
     qr = Ferrite._mass_qr(ip)

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -100,7 +100,7 @@ function test_projection(order, refshape)
     else
         bad_order = 1
     end
-    @test_throws LinearAlgebra.PosDefException L2Projector(ip, grid; qr_lhs=QuadratureRule{dim,refshape}(bad_order), geom_ip=ip_geom)
+    @test_throws LinearAlgebra.PosDefException L2Projector(ip, grid; qr_lhs=QuadratureRule{refshape}(bad_order), geom_ip=ip_geom)
 end
 
 # Test a mixed grid, where only a subset of the cells contains a field
@@ -127,7 +127,7 @@ function test_projection_mixedgrid()
     order = 2
     ip = Lagrange{RefQuadrilateral, order}()
     ip_geom = Lagrange{RefQuadrilateral, 1}()
-    qr = QuadratureRule{dim, RefQuadrilateral}(order+1)
+    qr = QuadratureRule{RefQuadrilateral}(order+1)
     cv = CellValues(qr, ip, ip_geom)
 
     # Create node values for the 1st cell
@@ -157,7 +157,7 @@ function test_projection_mixedgrid()
     order = 2
     ip = Lagrange{RefTriangle, order}()
     ip_geom = Lagrange{RefTriangle, 1}()
-    qr = QuadratureRule{dim, RefTriangle}(4)
+    qr = QuadratureRule{RefTriangle}(4)
     cv = CellValues(qr, ip, ip_geom)
     nqp = getnquadpoints(cv)
 
@@ -185,7 +185,7 @@ end
 
 function test_export(;subset::Bool)
     grid = generate_grid(Quadrilateral, (2, 1))
-    qr = QuadratureRule{2,RefQuadrilateral}(2)
+    qr = QuadratureRule{RefQuadrilateral}(2)
     ip = Lagrange{RefQuadrilateral,1}()
     cv = CellValues(qr, ip)
     nqp = getnquadpoints(cv)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -353,7 +353,7 @@ function test_2_element_heat_eq()
     assembler = start_assemble(K, f);
     # Use the same assemble function since it is the same weak form for both cell-types
     for fh in dh.fieldhandlers
-        qr = QuadratureRule{2, RefQuadrilateral}(2)
+        qr = QuadratureRule{RefQuadrilateral}(2)
         interp = fh.field_interpolations[1]
         cellvalues = CellValues(qr, interp)
         doassemble(fh.cellset, cellvalues, assembler, dh)

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -7,7 +7,7 @@ function scalar_field()
     ip_g = Lagrange{RefQuadrilateral,2}() # geometry interpolation
 
     # compute values in quadrature points
-    qr = QuadratureRule{2, RefQuadrilateral}(3) # exactly approximate quadratic field
+    qr = QuadratureRule{RefQuadrilateral}(3) # exactly approximate quadratic field
     cv = CellValues(qr, ip_f, ip_g)
     qp_vals = [Vector{Float64}(undef, getnquadpoints(cv)) for _ in 1:getncells(mesh)]
     for cellid in eachindex(mesh.cells)
@@ -46,7 +46,7 @@ function vector_field()
     ip_g = Lagrange{RefQuadrilateral,2}() # geometry interpolation
 
     # compute values in quadrature points
-    qr = QuadratureRule{2, RefQuadrilateral}(3) # exactly approximate quadratic field
+    qr = QuadratureRule{RefQuadrilateral}(3) # exactly approximate quadratic field
     cv = CellValues(qr, ip_f, ip_g)
     qp_vals = [Vector{Vec{2,Float64}}(undef, getnquadpoints(cv)) for i=1:getncells(mesh)]
     for cellid in eachindex(mesh.cells)
@@ -82,7 +82,7 @@ function superparametric()
     ip_f = Lagrange{RefQuadrilateral,2}() # function interpolation
 
     # compute values in quadrature points
-    qr = QuadratureRule{2, RefQuadrilateral}(3) # exactly approximate quadratic field
+    qr = QuadratureRule{RefQuadrilateral}(3) # exactly approximate quadratic field
     cv = CellValues(qr, ip_f)
     qp_vals = [Vector{Vec{2,Float64}}(undef, getnquadpoints(cv)) for i=1:getncells(mesh)]
     for cellid in eachindex(mesh.cells)
@@ -132,7 +132,7 @@ function dofhandler2()
     mesh = generate_grid(Quadrilateral, (20, 20))
     ip_f = Lagrange{RefQuadrilateral,2}()
     ip_f_v = ip_f^2
-    qr = QuadratureRule{2,RefQuadrilateral}(3)
+    qr = QuadratureRule{RefQuadrilateral}(3)
     csv = CellValues(qr, ip_f)
     cvv = CellValues(qr, ip_f_v)
     dh = DofHandler(mesh);
@@ -238,7 +238,7 @@ function mixed_grid()
     f(x) = x[1]
 
     # compute values in quadrature points for quad
-    qr = QuadratureRule{2, RefQuadrilateral}(2)
+    qr = QuadratureRule{RefQuadrilateral}(2)
     cv = CellValues(qr, ip_quad)
     qp_vals_quads = [Vector{Float64}(undef, getnquadpoints(cv)) for cell in getcellset(mesh, "quads")]
     for (local_cellid, global_cellid) in enumerate(getcellset(mesh, "quads"))
@@ -287,7 +287,7 @@ function oneD()
     ip_f = Lagrange{RefLine,1}() # function interpolation
 
     # compute values in quadrature points
-    qr = QuadratureRule{1, RefLine}(2)
+    qr = QuadratureRule{RefLine}(2)
     cv = CellValues(qr, ip_f)
     qp_vals = [Vector{Float64}(undef, getnquadpoints(cv)) for i=1:getncells(mesh)]
     for cellid in eachindex(mesh.cells)
@@ -341,7 +341,7 @@ end
     x = Vec{2,Float64}.([(0.0, 0.0), (2.0, 0.5), (2.5, 2.5), (0.5, 2.0)])
     ξ₁ = Vec{2,Float64}((0.12, -0.34))
     ξ₂ = Vec{2,Float64}((0.56, -0.78))
-    qr = QuadratureRule{2,RefQuadrilateral,Float64}([2.0, 2.0], [ξ₁, ξ₂])
+    qr = QuadratureRule{RefQuadrilateral,Float64}([2.0, 2.0], [ξ₁, ξ₂])
 
     # PointScalarValues
     csv = CellValues(qr, ip_f)

--- a/test/test_quadrules.jl
+++ b/test/test_quadrules.jl
@@ -15,42 +15,42 @@
         for order in (1,2,3,4)
             f = (x, p) -> sum([x[i]^p for i in 1:length(x)])
             # Legendre
-            qr = QuadratureRule{dim, shape}(:legendre, order)
+            qr = QuadratureRule{shape}(:legendre, order)
             @test integrate(qr, (x) -> f(x, 2*order-1)) < 1e-14
             @test sum(qr.weights) ≈ ref_square_vol(dim)
             @test sum(getweights(qr)) ≈ ref_square_vol(dim)
             # Lobatto
             if order > 1
-                qr = QuadratureRule{dim, shape}(:lobatto, order)
+                qr = QuadratureRule{shape}(:lobatto, order)
                 @test integrate(qr, (x) -> f(x, 2*order-1)) < 1e-14
                 @test sum(qr.weights) ≈ ref_square_vol(dim)
                 @test sum(getweights(qr)) ≈ ref_square_vol(dim)
             end
         end
     end
-    @test_throws ArgumentError QuadratureRule{1, RefLine}(:einstein, 2)
+    @test_throws ArgumentError QuadratureRule{RefLine}(:einstein, 2)
 
     # Tetrahedron
     g = (x) -> sqrt(sum(x))
     dim = 2
     for order in 1:15
-        qr = QuadratureRule{dim, RefTriangle}(:legendre, order)
+        qr = QuadratureRule{RefTriangle}(:legendre, order)
         # http://www.wolframalpha.com/input/?i=integrate+sqrt(x%2By)+from+x+%3D+0+to+1,+y+%3D+0+to+1-x
         @test integrate(qr, g) - 0.4 < 0.01
         @test sum(qr.weights) ≈ ref_tet_vol(dim)
     end
-    @test_throws ArgumentError QuadratureRule{dim, RefTriangle}(:einstein, 2)
-    @test_throws ArgumentError QuadratureRule{dim, RefTriangle}(0)
+    @test_throws ArgumentError QuadratureRule{RefTriangle}(:einstein, 2)
+    @test_throws ArgumentError QuadratureRule{RefTriangle}(0)
 
     dim = 3
     for order in (1, 2, 3, 4)
-        qr = QuadratureRule{dim, RefTetrahedron}(:legendre, order)
+        qr = QuadratureRule{RefTetrahedron}(:legendre, order)
         # Table 1:
         # http://www.m-hikari.com/ijma/ijma-2011/ijma-1-4-2011/venkateshIJMA1-4-2011.pdf
         @test integrate(qr, g) - 0.14 < 0.01
         @test sum(qr.weights) ≈ ref_tet_vol(dim)
     end
-    @test_throws ArgumentError QuadratureRule{dim, RefTetrahedron}(:einstein, 2)
-    @test_throws ArgumentError QuadratureRule{dim, RefTetrahedron}(0)
+    @test_throws ArgumentError QuadratureRule{RefTetrahedron}(:einstein, 2)
+    @test_throws ArgumentError QuadratureRule{RefTetrahedron}(0)
 
 end


### PR DESCRIPTION
This patch removes the `dim` parameter from `QuadratureRule` constructors, since it is now implicit from the reference shape.

Unlike for interpolations (#711) the `dim` parameter for `QuadratureRule` was not completely redundant since it was used to construct quadrature rules for face integration. This patch therefore introduces `FaceQuadratureRule` as a replacement:
`FaceQuadratureRule{refshape}` instead of `QuadratureRule{dim - 1, refshape}`. The new syntax generalizes better to elements such as wedge or pyramid which doesn't have a unique `dim - 1` reference shape.

With the new syntax it is also possible to materialize the rule for each face already in the `FaceQuadratureRule` constructor, instead of doing it in the `FaceValues` constructor.