### PR TITLE
Deprecate `Ferrite.value` and `Ferrite.derivative`

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -325,3 +325,6 @@ end
 function Base.show(io::IO, ::CrouzeixRaviart{shape, order}) where {shape, order}
     print(io, "CrouzeixRaviart{$(shape), $(order)}()")
 end
+
+@deprecate value(ip::Interpolation, ξ::Vec) [Ferrite.value(ip, i, ξ) for i in 1:getnbasefunctions(ip)] false
+@deprecate derivative(ip::Interpolation, ξ::Vec) [Tensors.gradient(x -> Ferrite.value(ip, i, x), ξ) for i in 1:getnbasefunctions(ip)] false

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -176,27 +176,6 @@ Return order of the interpolation.
 """
 @inline getorder(::Interpolation{shape,order}) where {shape,order} = order
 
-"""
-    Ferrite.value(ip::Interpolation, ξ::Vec)
-
-Return a vector, of length [`getnbasefunctions(ip::Interpolation)`](@ref), with the value of each shape functions
-of `ip`, evaluated in the reference coordinate `ξ`. This calls [`Ferrite.value(ip::Interpolation, i::Int, ξ::Vec)`](@ref), where `i`
-is the shape function number, which each concrete interpolation should implement.
-"""
-function value(ip::InterpolationByDim{dim}, ξ::Vec{dim,T}) where {dim,T}
-    [value(ip, i, ξ) for i in 1:getnbasefunctions(ip)]
-end
-
-"""
-    Ferrite.derivative(ip::Interpolation, ξ::Vec)
-
-Return a vector, of length [`getnbasefunctions(ip::Interpolation)`](@ref), with the derivative (w.r.t. the
-reference coordinate) of each shape functions of `ip`, evaluated in the reference coordinate
-`ξ`. This uses automatic differentiation and uses `ip`s implementation of [`Ferrite.value(ip::Interpolation, i::Int, ξ::Vec)`](@ref).
-"""
-function derivative(ip::InterpolationByDim{dim}, ξ::Vec{dim,T}) where {dim,T}
-    [gradient(ξ -> value(ip, i, ξ), ξ) for i in 1:getnbasefunctions(ip)]
-end
 
 function gradient_and_value(ip::Interpolation, i::Int, x::Vec)
     return gradient(ξ -> value(ip, i, ξ), x, :all)

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -80,4 +80,11 @@ end
     @test (@test_deprecated r"RefTriangle" test_combo(FaceValues, 1, RefTetrahedron, (:legendre, 1), Lagrange{RefTriangle, 1}())) isa FaceValues
 end
 
+@testset "Ferrite.value and Ferrite.derivative" begin
+    ip = Lagrange{RefQuadrilateral, 1}()
+    ξ = zero(Vec{2})
+    @test (@test_deprecated Ferrite.value(ip, ξ)) == [Ferrite.value(ip, i, ξ) for i in 1:getnbasefunctions(ip)]
+    @test (@test_deprecated Ferrite.derivative(ip, ξ)) == [Tensors.gradient(x -> Ferrite.value(ip, i, x), ξ) for i in 1:getnbasefunctions(ip)]
+end
+
 end # testset deprecations


### PR DESCRIPTION
This patch deprecates the (internal) functions
`Ferrite.value(::Interpolation, ::Vec)` and
`Ferrite.derivative(::Interpolation, ::Vec)`. After #719 they are not used internally. It is usually best to not allocate this vector at all and instead request the value/gradient for each specific shape function.