### PR TITLE
New DofHandler syntax for mixed grids / subdomains

### DIFF
--- a/docs/src/devdocs/dofhandler.md
+++ b/docs/src/devdocs/dofhandler.md
@@ -21,7 +21,6 @@ The main entry point for dof distribution is [`__close!`](@ref).
 ```@docs
 Ferrite.get_grid
 Ferrite.find_field(dh::DofHandler, field_name::Symbol)
-Ferrite._find_field(fh::FieldHandler, field_name::Symbol)
 Ferrite._close_fieldhandler!
 Ferrite._distribute_dofs_for_cell!
 Ferrite.permute_and_push!

--- a/docs/src/reference/dofhandler.md
+++ b/docs/src/reference/dofhandler.md
@@ -11,9 +11,6 @@ DofHandler
 ## Adding fields to the DofHandlers
 ```@docs
 add!(::DofHandler, ::Symbol, ::Interpolation)
-add!(::DofHandler, ::FieldHandler)
-Field
-FieldHandler
 close!(::DofHandler)
 ```
 

--- a/ext/FerriteMetis.jl
+++ b/ext/FerriteMetis.jl
@@ -45,22 +45,22 @@ function Ferrite.compute_renumber_permutation(
     # Create the CSR (CSC, but pattern is symmetric so equivalent) using
     # Metis.idx_t as the integer type
     buffer_length = 0
-    for (fhi, fh) in pairs(dh.fieldhandlers)
-        n = ndofs_per_cell(fh)
+    for (sdhi, sdh) in pairs(dh.subdofhandlers)
+        n = ndofs_per_cell(sdh)
         entries_per_cell = if coupling === nothing
             n * (n - 1)
         else
-            count(couplings[fhi][i, j] for i in 1:n, j in 1:n if i != j)
+            count(couplings[sdhi][i, j] for i in 1:n, j in 1:n if i != j)
         end
-        buffer_length += entries_per_cell * length(fh.cellset)
+        buffer_length += entries_per_cell * length(sdh.cellset)
     end
     I = Vector{idx_t}(undef, buffer_length)
     J = Vector{idx_t}(undef, buffer_length)
     idx = 0
 
-    for (fhi, fh) in pairs(dh.fieldhandlers)
-        coupling === nothing || (coupling_fh = couplings[fhi])
-        for cc in CellIterator(dh, fh.cellset)
+    for (sdhi, sdh) in pairs(dh.subdofhandlers)
+        coupling === nothing || (coupling_fh = couplings[sdhi])
+        for cc in CellIterator(dh, sdh.cellset)
             dofs = celldofs(cc)
             for (j, dofj) in pairs(dofs), (i, dofi) in pairs(dofs)
                 dofi == dofj && continue # Metis doesn't want the diagonal

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -4,7 +4,7 @@ abstract type AbstractDofHandler end
     get_grid(dh::AbstractDofHandler)
 
 Access some grid representation for the dof handler.
-    
+
 !!! note
     This API function is currently not well-defined. It acts as the interface between 
     distributed assembly and assembly on a single process, because most parts of the
@@ -12,59 +12,60 @@ Access some grid representation for the dof handler.
 """
 get_grid(dh::AbstractDofHandler)
 
-"""
-    Field(name::Symbol, interpolation::Interpolation, dim::Int)
 
-Construct `dim`-dimensional `Field` called `name` which is approximated by `interpolation`.
-
-The interpolation is used for distributing the degrees of freedom.
-"""
-struct Field
-    name::Symbol
-    interpolation::Interpolation
-end
-
-# TODO: Deprecate after DofHandler rework.
-function Field(name, interpolation::ScalarInterpolation, dim)
-    if dim == 1 # Presumably scalar and not 1D vector
-        return Field(name, interpolation)
-    else
-        return Field(name, VectorizedInterpolation{dim}(interpolation))
-    end
-end
-
-"""
-    FieldHandler(fields::Vector{Field}, cellset::Set{Int})
-
-Construct a `FieldHandler` based on an array of [`Field`](@ref)s and assigns it a set of cells.
-
-A `FieldHandler` must fulfill the following requirements:
-- All [`Cell`](@ref)s in `cellset` are of the same type.
-- Each field only uses a single interpolation on the `cellset`.
-- Each cell belongs only to a single `FieldHandler`, i.e. all fields on a cell must be added within the same `FieldHandler`.
-
-Notice that a `FieldHandler` can hold several fields.
-"""
-mutable struct FieldHandler
-    fields::Vector{Field} # Should not be used, kept for compatibility for now
-    field_names::Vector{Symbol}
-    field_dims::Vector{Int}
-    field_interpolations::Vector{Interpolation}
+struct SubDofHandler{DH} <: AbstractDofHandler
+    # From constructor
+    dh::DH
     cellset::Set{Int}
-    ndofs_per_cell::Int # set in close(::DofHandler)
-    function FieldHandler(fields, cellset)
-        fh = new(fields, Symbol[], Int[], Interpolation[], cellset, -1)
-        for f in fields
-            push!(fh.field_names, f.name)
-            push!(fh.field_dims, n_components(f.interpolation))
-            push!(fh.field_interpolations, f.interpolation)
-        end
-        return fh
+    # Populated in add!
+    field_names::Vector{Symbol}
+    field_interpolations::Vector{Interpolation}
+    field_n_components::Vector{Int} # Redundant with interpolations, remove?
+    # Computed in close!
+    ndofs_per_cell::ScalarWrapper{Int}
+    # const dof_ranges::Vector{UnitRange{Int}} # TODO: Why not?
+end
+
+# TODO: Should be an inner constructor.
+function SubDofHandler(dh::DH, cellset) where {DH <: AbstractDofHandler}
+    isclosed(dh) && error("DofHandler already closed")
+    # Compute the celltype and make sure all elements have the same one
+    CT = getcelltype(dh.grid, first(cellset))
+    if any(x -> getcelltype(dh.grid, x) !== CT, cellset)
+        error("all cells in a SubDofHandler must be of the same type")
     end
+    # Make sure this set is disjoint with all other existing
+    for sdh in dh.subdofhandlers
+        if !isdisjoint(cellset, sdh.cellset)
+            error("cellset not disjoint with sets in existing SubDofHandlers")
+        end
+    end
+    # Construct and insert into the parent dh
+    sdh = SubDofHandler{typeof(dh)}(dh, cellset, Symbol[], Interpolation[], Int[], ScalarWrapper(-1))
+    push!(dh.subdofhandlers, sdh)
+    return sdh
 end
 
 # Shortcut
-@inline getcelltype(grid::AbstractGrid, fh::FieldHandler) = getcelltype(grid, first(fh.cellset))
+@inline getcelltype(grid::AbstractGrid, sdh::SubDofHandler) = getcelltype(grid, first(sdh.cellset))
+
+function Base.show(io::IO, ::MIME"text/plain", sdh::SubDofHandler)
+    println(io, typeof(sdh))
+    println(io, "  Cell type: ", getcelltype(sdh.dh.grid, first(sdh.cellset)))
+    _print_field_information(io, sdh)
+end
+
+function _print_field_information(io::IO, sdh::SubDofHandler)
+    println(io, "  Fields:")
+    for (i, fieldname) in pairs(sdh.field_names)
+        println(io, "    ", repr(fieldname), ", ", sdh.field_interpolations[i])
+    end
+    if !isclosed(sdh.dh)
+        print(io, "  Not closed!")
+    else
+        println(io, "  Dofs per cell: ", ndofs_per_cell(sdh))
+    end
+end
 
 """
     DofHandler(grid::Grid)
@@ -74,33 +75,33 @@ Construct a `DofHandler` based on `grid`. Supports:
 - One or several fields, which can live on the whole domain or on subsets of the `Grid`.
 """
 struct DofHandler{dim,G<:AbstractGrid{dim}} <: AbstractDofHandler
-    fieldhandlers::Vector{FieldHandler}
+    subdofhandlers::Vector{SubDofHandler{DofHandler{dim, G}}}
     field_names::Vector{Symbol}
     # Dofs for cell i are stored in cell_dofs at the range:
     #     cell_dofs_offset[i]:(cell_dofs_offset[i]+ndofs_per_cell(dh, i)-1)
     cell_dofs::Vector{Int}
     cell_dofs_offset::Vector{Int}
-    cell_to_fieldhandler::Vector{Int} # maps cell id -> fieldhandler id
+    cell_to_subdofhandler::Vector{Int} # maps cell id -> SubDofHandler id
     closed::ScalarWrapper{Bool}
     grid::G
     ndofs::ScalarWrapper{Int}
 end
 
-function DofHandler(grid::AbstractGrid{dim}) where dim
+function DofHandler(grid::G) where {dim, G <: AbstractGrid{dim}}
     ncells = getncells(grid)
-    DofHandler{dim,typeof(grid)}(FieldHandler[], Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), ScalarWrapper(false), grid, ScalarWrapper(-1))
-end
-
-function MixedDofHandler(::AbstractGrid)
-    error("MixedDofHandler is the standard DofHandler in Ferrite now and has been renamed to DofHandler.
-Use DofHandler even for mixed grids and fields on subdomains.")
+    sdhs = SubDofHandler{DofHandler{dim, G}}[]
+    DofHandler{dim, G}(sdhs, Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), ScalarWrapper(false), grid, ScalarWrapper(-1))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
     println(io, typeof(dh))
-    println(io, "  Fields:")
-    for fieldname in getfieldnames(dh)
-        println(io, "    ", repr(fieldname), ", dim: ", getfielddim(dh, fieldname))
+    if length(dh.subdofhandlers) == 1
+        _print_field_information(io, dh.subdofhandlers[1])
+    else
+        println(io, "  Fields:")
+        for fieldname in getfieldnames(dh)
+            println(io, "    ", repr(fieldname), ", dim: ", getfielddim(dh, fieldname))
+        end
     end
     if !isclosed(dh)
         print(io, "  Not closed!")
@@ -128,10 +129,9 @@ See also [`ndofs`](@ref).
 """
 function ndofs_per_cell(dh::DofHandler, cell::Int=1)
     @boundscheck 1 <= cell <= getncells(get_grid(dh))
-    return @inbounds ndofs_per_cell(dh.fieldhandlers[dh.cell_to_fieldhandler[cell]])
+    return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end
-ndofs_per_cell(fh::FieldHandler) = fh.ndofs_per_cell
-nnodes_per_cell(dh::DofHandler, cell::Int=1) = nnodes_per_cell(get_grid(dh), cell) # TODO: deprecate, shouldn't belong to DofHandler any longer
+ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
 
 """
     celldofs!(global_dofs::Vector{Int}, dh::AbstractDofHandler, i::Int)
@@ -145,6 +145,10 @@ function celldofs!(global_dofs::Vector{Int}, dh::DofHandler, i::Int)
     @assert length(global_dofs) == ndofs_per_cell(dh, i)
     unsafe_copyto!(global_dofs, 1, dh.cell_dofs, dh.cell_dofs_offset[i], length(global_dofs))
     return global_dofs
+end
+function celldofs!(global_dofs::Vector{Int}, sdh::SubDofHandler, i::Int)
+    @assert i in sdh.cellset
+    return celldofs!(global_dofs, sdh.dh, i)
 end
 
 """
@@ -164,90 +168,100 @@ end
 
 """
     getfieldnames(dh::DofHandler)
-    getfieldnames(fh::FieldHandler)
+    getfieldnames(sdh::SubDofHandler)
 
-Return a vector with the names of all fields. Can be used as an iterable over all the fields
-in the problem.
+Return a vector with the unique names of all fields. The order is the sam eas the order in
+which they were originally added to the (Sub)DofHandler. Can be used as an iterable over all
+the fields.
 """
 getfieldnames(dh::DofHandler) = dh.field_names
-getfieldnames(fh::FieldHandler) = fh.field_names
+getfieldnames(sdh::SubDofHandler) = sdh.field_names
 
-getfielddim(fh::FieldHandler, field_idx::Int) = fh.field_dims[field_idx]
-getfielddim(fh::FieldHandler, field_name::Symbol) = getfielddim(fh, find_field(fh, field_name))
+getfielddim(sdh::SubDofHandler, field_idx::Int) = n_components(sdh.field_interpolations[field_idx])::Int
+getfielddim(sdh::SubDofHandler, field_name::Symbol) = getfielddim(sdh, find_field(sdh, field_name))
 
 """
     getfielddim(dh::DofHandler, field_idxs::NTuple{2,Int})
     getfielddim(dh::DofHandler, field_name::Symbol)
-    getfielddim(dh::FieldHandler, field_idx::Int)
-    getfielddim(dh::FieldHandler, field_name::Symbol)
+    getfielddim(sdh::SubDofHandler, field_idx::Int)
+    getfielddim(sdh::SubDofHandler, field_name::Symbol)
 
-Return the dimension of a given field. The field can be specified by its index (see
-[`find_field`](@ref)) or its name.
+Return the dimension (number of components) of a given field. The field can be specified by
+its index (see [`find_field`](@ref)) or its name.
 """
 function getfielddim(dh::DofHandler, field_idxs::NTuple{2, Int})
-    fh_idx, field_idx = field_idxs
-    fielddim = getfielddim(dh.fieldhandlers[fh_idx], field_idx)
+    sdh_idx, field_idx = field_idxs
+    fielddim = getfielddim(dh.subdofhandlers[sdh_idx], field_idx)
     return fielddim
 end
 getfielddim(dh::DofHandler, name::Symbol) = getfielddim(dh, find_field(dh, name))
 
 """
-    add!(dh::DofHandler, fh::FieldHandler)
+    add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
 
-Add all fields of the [`FieldHandler`](@ref) `fh` to `dh`.
+Add a field called `name` approximated by `ip` to the SubDofHandler `sdh`.
 """
-function add!(dh::DofHandler, fh::FieldHandler)
-    # TODO: perhaps check that a field with the same name is the same field?
-    @assert !isclosed(dh)
-    _check_same_celltype(get_grid(dh), collect(fh.cellset))
-    _check_cellset_intersections(dh, fh)
-    # the field interpolations should have the same refshape as the cells they are applied to
-    # extract the celltype from the first cell as the celltypes are all equal
-    cell_type = getcelltype(get_grid(dh), fh)
-    refshape_cellset = getrefshape(default_interpolation(cell_type))
-    for interpolation in fh.field_interpolations
-        refshape = getrefshape(interpolation)
-        refshape_cellset == refshape || error("The RefShapes of the fieldhandlers interpolations must correspond to the RefShape of the cells it is applied to.")
+function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
+    @assert !isclosed(sdh.dh)
+    # Verify that name doesn't exist
+    if name in sdh.field_names
+        error("field already exist")
+    end
+    # Verify that fields with the same name in other SubDofHandler have compatible
+    # interpolation
+    for _sdh in sdh.dh.subdofhandlers
+        for (_name, _ip) in zip(_sdh.field_names, _sdh.field_interpolations)
+            _name != name && continue
+            # same field name, check for same field dimension
+            if n_components(ip) != n_components(_ip)
+                error("Field :$name has a different number of components in another SubDofHandler. Use a different field name.")
+            end
+            if getorder(ip) != getorder(_ip)
+                @warn "Field :$name uses a different interpolation order in another SubDofHandler."
+            end
+            # TODO: warn if interpolation type is not the same?
+        end
+    end
+    
+    # Check that interpolation is compatible with cells it it added to
+    refshape_sdh = getrefshape(getcells(sdh.dh.grid, first(sdh.cellset)))
+    if refshape_sdh !== getrefshape(ip)
+        error("The refshape of the interpolation $(getrefshape(ip)) is incompatible with the refshape $refshape_sdh of the cells.")
     end
 
-    push!(dh.fieldhandlers, fh)
-    return dh
-end
-
-function _check_cellset_intersections(dh::DofHandler, fh::FieldHandler)
-    for _fh in dh.fieldhandlers
-        isdisjoint(_fh.cellset, fh.cellset) || error("Each cell can only belong to a single FieldHandler.")
-    end
+    # Store in the SubDofHandler, it is collected to the parent DofHandler in close!.
+    push!(sdh.field_names, name)
+    push!(sdh.field_interpolations, ip)
+    return sdh
 end
 
 """
-    add!(dh::AbstractDofHandler, name::Symbol, ip::Interpolation)
+    add!(dh::DofHandler, name::Symbol, ip::Interpolation)
 
-Add a field called `name` which is approximated by `ip` to `dh`.
-The field is added to all cells of the underlying grid. If the grid uses several
-celltypes, [`add!(dh::DofHandler, fh::FieldHandler)`](@ref) must be used instead.
+Add a field called `name` approximated by `ip` to the DofHandler `dh`.
+
+The field is added to all cells of the underlying grid, use
+[`SubDofHandler`](@ref)s if the grid contains multiple cell types, or to add
+the field to subset of all the cells.
 """
 function add!(dh::DofHandler, name::Symbol, ip::Interpolation)
     @assert !isclosed(dh)
-
     celltype = getcelltype(get_grid(dh))
     @assert isconcretetype(celltype)
-
-    if length(dh.fieldhandlers) == 0
-        cellset = Set(1:getncells(get_grid(dh)))
-        push!(dh.fieldhandlers, FieldHandler(Field[], cellset))
-    elseif length(dh.fieldhandlers) > 1
-        error("If you have more than one FieldHandler, you must specify field")
+    if isempty(dh.subdofhandlers)
+        # Create a new SubDofHandler for all cells
+        sdh = SubDofHandler(dh, Set(1:getncells(get_grid(dh))))
+    elseif length(dh.subdofhandlers) == 1
+        # Add to existing SubDofHandler (if it covers all cells)
+        sdh = dh.subdofhandlers[1]
+        if length(sdh.cellset) != getncells(get_grid(dh))
+            error("can not add field to DofHandler with a SubDofHandler for a subregion")
+        end
+    else # length(dh.subdofhandlers) > 1
+        error("can not add field to DofHandler with multiple SubDofHandlers")
     end
-    fh = first(dh.fieldhandlers)
-
-    push!(fh.field_names, name)
-    push!(fh.field_dims, n_components(ip))
-    push!(fh.field_interpolations, ip)
-
-    field = Field(name, ip)
-    push!(fh.fields, field)
-
+    # Add to SubDofHandler
+    add!(sdh, name, ip)
     return dh
 end
 
@@ -267,8 +281,8 @@ end
 Internal entry point for dof distribution.
 
 Dofs are distributed as follows:
-For the `DofHandler` each `FieldHandler` is visited in the order they were added.
-For each field in the `FieldHandler` create dofs for the cell.
+For the `DofHandler` each `SubDofHandler` is visited in the order they were added.
+For each field in the `SubDofHandler` create dofs for the cell.
 This means that dofs on a particular cell will be numbered in groups for each field,
 so first the dofs for field 1 are distributed, then field 2, etc.
 For each cell dofs are first distributed on its vertices, then on the interior of edges (if applicable), then on the 
@@ -280,7 +294,7 @@ function __close!(dh::DofHandler{dim}) where {dim}
 
     # Collect the global field names
     empty!(dh.field_names)
-    for fh in dh.fieldhandlers, name in fh.field_names
+    for sdh in dh.subdofhandlers, name in sdh.field_names
         name in dh.field_names || push!(dh.field_names, name)
     end
     numfields = length(dh.field_names)
@@ -307,11 +321,11 @@ function __close!(dh::DofHandler{dim}) where {dim}
     nextdof = 1  # next free dof to distribute
 
     @debug println("\n\nCreating dofs\n")
-    for (fhi, fh) in pairs(dh.fieldhandlers)
-        nextdof = _close_fieldhandler!(
+    for (sdhi, sdh) in pairs(dh.subdofhandlers)
+        nextdof = _close_subdofhandler!(
             dh,
-            fh,
-            fhi, # TODO: Store in the FieldHandler?
+            sdh,
+            sdhi, # TODO: Store in the SubDofHandler?
             nextdof,
             vertexdicts,
             edgedicts,
@@ -326,13 +340,13 @@ function __close!(dh::DofHandler{dim}) where {dim}
 end
 
 """
-    _close_fieldhandler!(dh::DofHandler{sdim}, fh::FieldHandler, fh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts)
+    _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts) where {sdim}
 
-Main entry point to distribute dofs for a single [`FieldHandler`](@ref) on its subdomain.
+Main entry point to distribute dofs for a single [`SubDofHandler`](@ref) on its subdomain.
 """
-function _close_fieldhandler!(dh::DofHandler{sdim}, fh::FieldHandler, fh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts) where {sdim}
+function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts) where {sdim}
     ip_infos = InterpolationInfo[]
-    for interpolation in fh.field_interpolations
+    for interpolation in sdh.field_interpolations
         ip_info = InterpolationInfo(interpolation)
         begin
             next_dof_index = 1
@@ -377,16 +391,16 @@ function _close_fieldhandler!(dh::DofHandler{sdim}, fh::FieldHandler, fh_index::
     ndofs_per_cell = -1
 
     # Mapping between the local field index and the global field index
-    global_fidxs = Int[findfirst(gname -> gname === lname, dh.field_names) for lname in fh.field_names]
+    global_fidxs = Int[findfirst(gname -> gname === lname, dh.field_names) for lname in sdh.field_names]
 
     # loop over all the cells, and distribute dofs for all the fields
     # TODO: Remove BitSet construction when SubDofHandler ensures sorted collections
-    for ci in BitSet(fh.cellset)
+    for ci in BitSet(sdh.cellset)
         @debug println("Creating dofs for cell #$ci")
 
         # TODO: _check_cellset_intersections can be removed in favor of this assertion
-        @assert dh.cell_to_fieldhandler[ci] == 0
-        dh.cell_to_fieldhandler[ci] = fh_index
+        @assert dh.cell_to_subdofhandler[ci] == 0
+        dh.cell_to_subdofhandler[ci] = sdh_index
 
         cell = getcells(get_grid(dh), ci)
         len_cell_dofs_start = length(dh.cell_dofs)
@@ -394,7 +408,7 @@ function _close_fieldhandler!(dh::DofHandler{sdim}, fh::FieldHandler, fh_index::
 
         # Distribute dofs per field
         for (lidx, gidx) in pairs(global_fidxs)
-            @debug println("\tfield: $(fh.field_names[lidx])")
+            @debug println("\tfield: $(sdh.field_names[lidx])")
             nextdof = _distribute_dofs_for_cell!(
                 dh,
                 cell,
@@ -408,7 +422,7 @@ function _close_fieldhandler!(dh::DofHandler{sdim}, fh::FieldHandler, fh_index::
 
         if first_cell
             ndofs_per_cell = length(dh.cell_dofs) - len_cell_dofs_start
-            fh.ndofs_per_cell = ndofs_per_cell
+            sdh.ndofs_per_cell[] = ndofs_per_cell
             first_cell = false
         else
             @assert ndofs_per_cell == length(dh.cell_dofs) - len_cell_dofs_start
@@ -672,82 +686,75 @@ sortface(face::Tuple{Int}) = face, nothing
     find_field(dh::DofHandler, field_name::Symbol)::NTuple{2,Int}
 
 Return the index of the field with name `field_name` in a `DofHandler`. The index is a
-`NTuple{2,Int}`, where the 1st entry is the index of the `FieldHandler` within which the
-field was found and the 2nd entry is the index of the field within the `FieldHandler`.
+`NTuple{2,Int}`, where the 1st entry is the index of the `SubDofHandler` within which the
+field was found and the 2nd entry is the index of the field within the `SubDofHandler`.
 
 !!! note
     Always finds the 1st occurence of a field within `DofHandler`.
 
-See also: [`find_field(fh::FieldHandler, field_name::Symbol)`](@ref),
-[`_find_field(fh::FieldHandler, field_name::Symbol)`](@ref).
+See also: [`find_field(sdh::SubDofHandler, field_name::Symbol)`](@ref),
+[`_find_field(sdh::SubDofHandler, field_name::Symbol)`](@ref).
 """
 function find_field(dh::DofHandler, field_name::Symbol)
-    for (fh_idx, fh) in pairs(dh.fieldhandlers)
-        field_idx = _find_field(fh, field_name)
-        !isnothing(field_idx) && return (fh_idx, field_idx)
+    for (sdh_idx, sdh) in pairs(dh.subdofhandlers)
+        field_idx = _find_field(sdh, field_name)
+        !isnothing(field_idx) && return (sdh_idx, field_idx)
     end
     error("Did not find field :$field_name in DofHandler (existing fields: $(getfieldnames(dh))).")
 end
 
 """
-    find_field(fh::FieldHandler, field_name::Symbol)::Int
+    find_field(sdh::SubDofHandler, field_name::Symbol)::Int
 
-Return the index of the field with name `field_name` in a `FieldHandler`. Throw an
+Return the index of the field with name `field_name` in a `SubDofHandler`. Throw an
 error if the field is not found.
 
-See also: [`find_field(dh::DofHandler, field_name::Symbol)`](@ref), [`_find_field(fh::FieldHandler, field_name::Symbol)`](@ref).
+See also: [`find_field(dh::DofHandler, field_name::Symbol)`](@ref), [`_find_field(sdh::SubDofHandler, field_name::Symbol)`](@ref).
 """
-function find_field(fh::FieldHandler, field_name::Symbol)
-    field_idx = _find_field(fh, field_name)
+function find_field(sdh::SubDofHandler, field_name::Symbol)
+    field_idx = _find_field(sdh, field_name)
     if field_idx === nothing
-        error("Did not find field :$field_name in FieldHandler (existing fields: $(fh.field_names))")
+        error("Did not find field :$field_name in SubDofHandler (existing fields: $(sdh.field_names))")
     end
     return field_idx
 end
 
 # No error if field not found
 """
-    _find_field(fh::FieldHandler, field_name::Symbol)::Int
+    _find_field(sdh::SubDofHandler, field_name::Symbol)::Int
 
-Return the index of the field with name `field_name` in the `FieldHandler` `fh`. Return 
+Return the index of the field with name `field_name` in the `SubDofHandler` `sdh`. Return 
 `nothing` if the field is not found.
 
-See also: [`find_field(dh::DofHandler, field_name::Symbol)`](@ref), [`find_field(fh::FieldHandler, field_name::Symbol)`](@ref).
+See also: [`find_field(dh::DofHandler, field_name::Symbol)`](@ref), [`find_field(sdh::SubDofHandler, field_name::Symbol)`](@ref).
 """
-function _find_field(fh::FieldHandler, field_name::Symbol)
-    return findfirst(x -> x === field_name, fh.field_names)
+function _find_field(sdh::SubDofHandler, field_name::Symbol)
+    return findfirst(x -> x === field_name, sdh.field_names)
 end
 
 # Calculate the offset to the first local dof of a field
-function field_offset(fh::FieldHandler, field_idx::Int)
+function field_offset(sdh::SubDofHandler, field_idx::Int)
     offset = 0
     for i in 1:(field_idx-1)
-        offset += getnbasefunctions(fh.field_interpolations[i])::Int
+        offset += getnbasefunctions(sdh.field_interpolations[i])::Int
     end
     return offset
 end
-field_offset(fh::FieldHandler, field_name::Symbol) = field_offset(fh, find_field(fh, field_name))
-
-field_offset(dh::DofHandler, field_name::Symbol) = field_offset(dh, find_field(dh, field_name))
-function field_offset(dh::DofHandler, field_idxs::Tuple{Int, Int})
-    fh_idx, field_idx = field_idxs
-    field_offset(dh.fieldhandlers[fh_idx], field_idx)
-end
 
 """
-    dof_range(fh::FieldHandler, field_idx::Int)
-    dof_range(fh::FieldHandler, field_name::Symbol)
+    dof_range(sdh::SubDofHandler, field_idx::Int)
+    dof_range(sdh::SubDofHandler, field_name::Symbol)
     dof_range(dh:DofHandler, field_name::Symbol)
 
 Return the local dof range for a given field. The field can be specified by its name or
-index, where `field_idx` represents the index of a field within a `FieldHandler` and
-`field_idxs` is a tuple of the `FieldHandler`-index within the `DofHandler` and the
+index, where `field_idx` represents the index of a field within a `SubDofHandler` and
+`field_idxs` is a tuple of the `SubDofHandler`-index within the `DofHandler` and the
 `field_idx`.
 
 !!! note
-    The `dof_range` of a field can vary between different `FieldHandler`s. Therefore, it is
-    advised to use the `field_idxs` or refer to a given `FieldHandler` directly in case
-    several `FieldHandler`s exist. Using the `field_name` will always refer to the first
+    The `dof_range` of a field can vary between different `SubDofHandler`s. Therefore, it is
+    advised to use the `field_idxs` or refer to a given `SubDofHandler` directly in case
+    several `SubDofHandler`s exist. Using the `field_name` will always refer to the first
     occurence of `field` within the `DofHandler`.
 
 Example:
@@ -766,43 +773,41 @@ julia> dof_range(dh, :p)
 julia> dof_range(dh, (1,1)) # field :u
 1:9
 
-julia> dof_range(dh.fieldhandlers[1], 2) # field :p
+julia> dof_range(dh.subdofhandlers[1], 2) # field :p
 10:12
 ```
 """
-function dof_range(fh::FieldHandler, field_idx::Int)
-    offset = field_offset(fh, field_idx)
-    field_interpolation = fh.field_interpolations[field_idx]
+function dof_range(sdh::SubDofHandler, field_idx::Int)
+    offset = field_offset(sdh, field_idx)
+    field_interpolation = sdh.field_interpolations[field_idx]
     n_field_dofs = getnbasefunctions(field_interpolation)::Int
     return (offset+1):(offset+n_field_dofs)
 end
-dof_range(fh::FieldHandler, field_name::Symbol) = dof_range(fh, find_field(fh, field_name))
+dof_range(sdh::SubDofHandler, field_name::Symbol) = dof_range(sdh, find_field(sdh, field_name))
 
 function dof_range(dh::DofHandler, field_name::Symbol)
-    if length(dh.fieldhandlers) > 1
-        error("The given DofHandler has $(length(dh.fieldhandlers)) FieldHandlers.
-              Extracting the dof range based on the fieldname might not be a unique problem
-              in this case. Use `dof_range(fh::FieldHandler, field_name)` instead.")
+    if length(dh.subdofhandlers) > 1
+        error("The given DofHandler has $(length(dh.subdofhandlers)) SubDofHandlers. Extracting the dof range based on the fieldname might not be a unique problem in this case. Use `dof_range(sdh::SubDofHandler, field_name)` instead.")
     end
-    fh_idx, field_idx = find_field(dh, field_name)
-    return dof_range(dh.fieldhandlers[fh_idx], field_idx)
+    sdh_idx, field_idx = find_field(dh, field_name)
+    return dof_range(dh.subdofhandlers[sdh_idx], field_idx)
 end
 
 """
     getfieldinterpolation(dh::DofHandler, field_idxs::NTuple{2,Int})
-    getfieldinterpolation(dh::FieldHandler, field_idx::Int)
-    getfieldinterpolation(dh::FieldHandler, field_name::Symbol)
+    getfieldinterpolation(sdh::SubDofHandler, field_idx::Int)
+    getfieldinterpolation(sdh::SubDofHandler, field_name::Symbol)
 
 Return the interpolation of a given field. The field can be specified by its index (see
 [`find_field`](@ref) or its name.
 """
 function getfieldinterpolation(dh::DofHandler, field_idxs::NTuple{2,Int})
-    fh_idx, field_idx = field_idxs
-    ip = dh.fieldhandlers[fh_idx].field_interpolations[field_idx]
+    sdh_idx, field_idx = field_idxs
+    ip = dh.subdofhandlers[sdh_idx].field_interpolations[field_idx]
     return ip
 end
-getfieldinterpolation(fh::FieldHandler, field_idx::Int) = fh.field_interpolations[field_idx]
-getfieldinterpolation(fh::FieldHandler, field_name::Symbol) = getfieldinterpolation(fh, find_field(fh, field_name))
+getfieldinterpolation(sdh::SubDofHandler, field_idx::Int) = sdh.field_interpolations[field_idx]
+getfieldinterpolation(sdh::SubDofHandler, field_name::Symbol) = getfieldinterpolation(sdh, find_field(sdh, field_name))
 
 """
     evaluate_at_grid_nodes(dh::AbstractDofHandler, u::Vector{T}, fieldname::Symbol) where T
@@ -835,32 +840,32 @@ function _evaluate_at_grid_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol
         # Just evalutation at grid nodes
         data = fill(NaN * zero(RT), getnnodes(get_grid(dh)))
     end
-    # Loop over the fieldhandlers
-    for fh in dh.fieldhandlers
-        # Check if this fh contains this field, otherwise continue to the next
-        field_idx = _find_field(fh, fieldname)
+    # Loop over the subdofhandlers
+    for sdh in dh.subdofhandlers
+        # Check if this sdh contains this field, otherwise continue to the next
+        field_idx = _find_field(sdh, fieldname)
         field_idx === nothing && continue
         # Set up CellValues with the local node coords as quadrature points
-        CT = getcelltype(get_grid(dh), fh)
+        CT = getcelltype(get_grid(dh), first(sdh.cellset))
         ip_geo = default_interpolation(CT)
         local_node_coords = reference_coordinates(ip_geo)
         qr = QuadratureRule{getrefshape(ip)}(zeros(length(local_node_coords)), local_node_coords)
-        ip = getfieldinterpolation(fh, field_idx)
+        ip = getfieldinterpolation(sdh, field_idx)
         if ip isa VectorizedInterpolation
             # TODO: Remove this hack when embedding works...
             cv = CellValues(qr, ip.ip, ip_geo)
         else
             cv = CellValues(qr, ip, ip_geo)
         end
-        drange = dof_range(fh, fieldname)
+        drange = dof_range(sdh, field_idx)
         # Function barrier
-        _evaluate_at_grid_nodes!(data, dh, fh, u, cv, drange, RT)
+        _evaluate_at_grid_nodes!(data, sdh, u, cv, drange, RT)
     end
     return data
 end
 
 # Loop over the cells and use shape functions to compute the value
-function _evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, dh::DofHandler, fh::FieldHandler,
+function _evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, sdh::SubDofHandler,
         u::Vector{T}, cv::CellValues, drange::UnitRange, ::Type{RT}) where {T, RT}
     ue = zeros(T, length(drange))
     # TODO: Remove this hack when embedding works...
@@ -869,7 +874,7 @@ function _evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, dh::DofHandler, fh
     else
         uer = ue
     end
-    for cell in CellIterator(dh, fh.cellset)
+    for cell in CellIterator(sdh)
         # Note: We are only using the shape functions: no reinit!(cv, cell) necessary
         @assert getnquadpoints(cv) == length(cell.nodes)
         for (i, I) in pairs(drange)

--- a/src/Dofs/DofRenumbering.jl
+++ b/src/Dofs/DofRenumbering.jl
@@ -193,10 +193,10 @@ function compute_renumber_permutation(dh::DofHandler, _, order::DofOrder.Compone
     dofs_for_blocks = [Set{Int}() for _ in 1:nblocks]
     component_offsets = pushfirst!(cumsum(field_dims), 0)
     flags = UpdateFlags(nodes=false, coords=false, dofs=true)
-    for fh in dh.fieldhandlers
-        dof_ranges = [dof_range(fh, f) for f in fh.field_names]
-        global_idxs = [findfirst(x -> x === f, dh.field_names) for f in fh.field_names]
-        for cell in CellIterator(dh, fh.cellset, flags)
+    for sdh in dh.subdofhandlers
+        dof_ranges = [dof_range(sdh, f) for f in eachindex(sdh.field_names)]
+        global_idxs = [findfirst(x -> x === f, dh.field_names) for f in sdh.field_names]
+        for cell in CellIterator(dh, sdh.cellset, flags)
             cdofs = celldofs(cell)
             for (local_idx, global_idx) in pairs(global_idxs)
                 rng = dof_ranges[local_idx]

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -41,6 +41,8 @@ get_coordinate_eltype(::Node{dim,T}) where {dim,T} = T
 
 abstract type AbstractCell{refshape <: AbstractRefShape} end
 
+getrefshape(::AbstractCell{refshape}) where refshape = refshape
+
 nvertices(c::AbstractCell) = length(vertices(c))
 nedges(   c::AbstractCell) = length(edges(c))
 nfaces(   c::AbstractCell) = length(faces(c))

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -51,9 +51,8 @@ function L2Projector(
 
     # Create an internal scalar valued field. This is enough since the projection is done on a component basis, hence a scalar field.
     dh = DofHandler(grid)
-    field = Field(:_, func_ip) # we need to create the field, but the interpolation is not used here
-    fh = FieldHandler([field], Set(set))
-    add!(dh, fh)
+    sdh = SubDofHandler(dh, Set(set))
+    add!(sdh, :_, func_ip) # we need to create the field, but the interpolation is not used here
     close!(dh)
 
     M = _assemble_L2_matrix(fe_values_mass, set, dh)  # the "mass" matrix

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -67,7 +67,7 @@ function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid,
             # loop over points
             for node in nearest_nodes[point_idx]
                 possible_cells = get(node_cell_dict, node, nothing)
-                possible_cells === nothing && continue # if node is not part of the fieldhandler, try the next node
+                possible_cells === nothing && continue # if node is not part of the subdofhandler, try the next node
                 for cell in possible_cells
                     cell_coords = get_cell_coordinates(grid, cell)
                     is_in_cell, local_coord = point_in_cell(geom_interpol, cell_coords, points[point_idx])
@@ -213,11 +213,11 @@ function get_point_values!(out_vals::Vector{T2},
     # TODO: I don't think this is correct??
     length(dof_vals) == ndofs(dh) || error("You must supply values for all $(ndofs(dh)) dofs.")
 
-    for fh_idx in eachindex(dh.fieldhandlers)
-        ip = func_interpolations[fh_idx]
+    for (sdh_idx, sdh) in pairs(dh.subdofhandlers)
+        ip = func_interpolations[sdh_idx]
         if ip !== nothing
-            dofrange = dof_range(dh.fieldhandlers[fh_idx], fname)
-            cellset = dh.fieldhandlers[fh_idx].cellset
+            dofrange = dof_range(sdh, fname)
+            cellset = sdh.cellset
             _get_point_values!(out_vals, dof_vals, ph, dh, ip, cellset, dofrange)
         end
     end
@@ -262,12 +262,12 @@ end
 
 function get_func_interpolations(dh::DofHandler, fieldname)
     func_interpolations = Union{Interpolation,Nothing}[]
-    for fh in dh.fieldhandlers
-        j = _find_field(fh, fieldname)
+    for sdh in dh.subdofhandlers
+        j = _find_field(sdh, fieldname)
         if j === nothing
             push!(func_interpolations, nothing)
         else
-            push!(func_interpolations, fh.field_interpolations[j])
+            push!(func_interpolations, sdh.field_interpolations[j])
         end
     end
     return func_interpolations

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -8,7 +8,7 @@ import Base: push!
 @deprecate faces(ip::Interpolation) facedof_indices(ip) false
 @deprecate edges(ip::Interpolation) edgedof_indices(ip) false
 @deprecate nfields(dh::AbstractDofHandler) length(getfieldnames(dh)) false
-@deprecate add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet) add!(ch, dbc)
+# @deprecate add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet) add!(ch, dbc)
 
 @deprecate getcoordinates(node::Node) get_node_coordinate(node) true
 @deprecate getcoordinates(args...) get_cell_coordinates(args...) true
@@ -332,3 +332,9 @@ end
 @deprecate value(ip::Interpolation, ξ::Vec) [shape_value(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
 @deprecate derivative(ip::Interpolation, ξ::Vec) [shape_gradient(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
 @deprecate value(ip::Interpolation, i::Int, ξ::Vec) shape_value(ip, ξ, i) false
+
+export MixedDofHandler
+function MixedDofHandler(::AbstractGrid)
+    error("MixedDofHandler is the standard DofHandler in Ferrite now and has been renamed to DofHandler.
+Use DofHandler even for mixed grids and fields on subdomains.")
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -105,7 +105,7 @@ export
 
 # Dofs
     DofHandler,
-    MixedDofHandler, # only for getting an error message redirecting to DofHandler
+    SubDofHandler,
     close!,
     ndofs,
     ndofs_per_cell,
@@ -116,8 +116,6 @@ export
     dof_range,
     renumber!,
     DofOrder,
-    FieldHandler,
-    Field,
     evaluate_at_grid_nodes,
     apply_analytical!,
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -66,6 +66,10 @@ function CellCache(dh::DofHandler{dim}, flags::UpdateFlags=UpdateFlags()) where 
     return CellCache(flags, get_grid(dh), ScalarWrapper(-1), nodes, coords, dh, celldofs)
 end
 
+function CellCache(sdh::SubDofHandler, flags::UpdateFlags=UpdateFlags())
+    CellCache(flags, sdh.dh.grid, ScalarWrapper(-1), Int[], Vec{2,Float64}[], sdh, Int[])
+end
+
 function reinit!(cc::CellCache, i::Int)
     cc.cellid[] = i
     if cc.flags.nodes
@@ -137,11 +141,11 @@ struct CellIterator{CC<:CellCache, IC<:IntegerCollection}
     set::IC
 end
 
-function CellIterator(gridordh::Union{Grid,AbstractDofHandler},
+function CellIterator(gridordh::Union{Grid,DofHandler},
                       set::Union{IntegerCollection,Nothing}=nothing,
                       flags::UpdateFlags=UpdateFlags())
     if set === nothing
-        grid = gridordh isa AbstractDofHandler ? get_grid(gridordh) : gridordh
+        grid = gridordh isa DofHandler ? get_grid(gridordh) : gridordh
         set = 1:getncells(grid)
     end
     if gridordh isa DofHandler && !isconcretetype(getcelltype(get_grid(gridordh)))
@@ -151,8 +155,12 @@ function CellIterator(gridordh::Union{Grid,AbstractDofHandler},
     end
     return CellIterator(CellCache(gridordh, flags), set)
 end
-function CellIterator(gridordh::Union{Grid,AbstractDofHandler}, flags::UpdateFlags)
+function CellIterator(gridordh::Union{Grid,DofHandler}, flags::UpdateFlags)
     return CellIterator(gridordh, nothing, flags)
+end
+
+function CellIterator(sdh::SubDofHandler, flags::UpdateFlags=UpdateFlags())
+    CellIterator(sdh.dh, sdh.cellset, flags)
 end
 
 # Iterator interface

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -51,34 +51,34 @@
         else
             error("Only dim=1 & 2 supported")
         end
-        mdh = DofHandler(grid)
         default_ip_A = Ferrite.default_interpolation(getcelltype(grid, first(getcellset(grid,"A"))))
         default_ip_B = Ferrite.default_interpolation(getcelltype(grid, first(getcellset(grid,"B"))))
-        ufield_A = Field(:u, change_ip_order(default_ip_A, ip_order_u)^dim)
-        pfield_A = Field(:p, change_ip_order(default_ip_A, ip_order_p))
-        ufield_B = Field(:u, change_ip_order(default_ip_B, ip_order_u)^dim)
-        add!(mdh, FieldHandler([ufield_A, pfield_A], getcellset(grid,"A")))
-        add!(mdh, FieldHandler([ufield_B,], getcellset(grid, "B")))
-        close!(mdh)
-        return mdh
+        dh = DofHandler(grid)
+        sdh_A = SubDofHandler(dh, getcellset(grid, "A"))
+        add!(sdh_A, :u, change_ip_order(default_ip_A, ip_order_u)^dim)
+        add!(sdh_A, :p, change_ip_order(default_ip_A, ip_order_p))
+        sdh_B = SubDofHandler(dh, getcellset(grid, "B"))
+        add!(sdh_B, :u, change_ip_order(default_ip_B, ip_order_u)^dim)
+        close!(dh)
+        return dh
     end
 
     # The following can be removed after #457 is merged if that will include the MixedDofHandler
     function _global_dof_range(dh::DofHandler, field_name::Symbol)
         dofs = Set{Int}()
-        for fh in dh.fieldhandlers
-            if !isnothing(Ferrite._find_field(fh, field_name))
-                _global_dof_range!(dofs, dh, fh, field_name, fh.cellset)
+        for sdh in dh.subdofhandlers
+            if !isnothing(Ferrite._find_field(sdh, field_name))
+                _global_dof_range!(dofs, sdh, field_name, sdh.cellset)
             end
         end
         return sort!(collect(Int, dofs))
     end
 
-    function _global_dof_range!(dofs, dh, dh_fh, field_name, cellset)
-        eldofs = celldofs(dh, first(cellset))
-        field_range = dof_range(dh_fh, field_name)
+    function _global_dof_range!(dofs, sdh, field_name, cellset)
+        eldofs = celldofs(sdh.dh, first(cellset))
+        field_range = dof_range(sdh, field_name)
         for i in cellset
-            celldofs!(eldofs, dh, i)
+            celldofs!(eldofs, sdh.dh, i)
             for j in field_range
                 @inbounds d = eldofs[j]
                 d in dofs || push!(dofs, d)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -107,11 +107,11 @@ end
 
    ip_quadratic = Lagrange{RefQuadrilateral, 2}()^dim
    ip_linear = Lagrange{RefQuadrilateral, 1}()
-   field_u = Field(:u, ip_quadratic)
-   field_c = Field(:c, ip_linear)
-   add!(dh, FieldHandler([field_u, field_c], getcellset(mesh, "set1")))
-   add!(dh, FieldHandler([field_u], getcellset(mesh, "set2")))
-
+   sdh1 = SubDofHandler(dh, getcellset(mesh, "set1"))
+   add!(sdh1, :u, ip_quadratic)
+   add!(sdh1, :c, ip_linear)
+   sdh2 = SubDofHandler(dh, getcellset(mesh, "set2"))
+   add!(sdh2, :u, ip_quadratic)
    close!(dh)
 
    ch = ConstraintHandler(dh)
@@ -130,12 +130,13 @@ end
    addcellset!(mesh, "set2", Set(2))
 
    ip = Lagrange{RefQuadrilateral, 1}()
-   field_u = Field(:u, ip^dim)
-   field_c = Field(:c, ip)
 
    dh = DofHandler(mesh)
-   add!(dh, FieldHandler([field_u], getcellset(mesh, "set1")))
-   add!(dh, FieldHandler([field_u, field_c], getcellset(mesh, "set2")))
+   sdh1 = SubDofHandler(dh, getcellset(mesh, "set1"))
+   add!(sdh1, :u, ip^dim)
+   sdh2 = SubDofHandler(dh, getcellset(mesh, "set2"))
+   add!(sdh2, :u, ip^dim)
+   add!(sdh2, :c, ip)
    close!(dh)
 
    ch = ConstraintHandler(dh)

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -1,3 +1,33 @@
+@testset "DofHandler construction" begin
+    grid = generate_grid(Quadrilateral, (2,1))
+    dh = DofHandler(grid)
+    # incompatible refshape (#638)
+    @test_throws ErrorException add!(dh, :u, Lagrange{RefTriangle, 1}())
+    @test_throws ErrorException add!(dh, :u, Lagrange{RefTetrahedron, 1}())
+    # field already exists
+    add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+    @test_throws ErrorException add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+
+    # Invalid SubDofHandler construction
+    dh = DofHandler(grid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1,))
+    # Subdomains not disjoint
+    @test_throws ErrorException Ferrite.SubDofHandler(dh, Set(1:getncells(grid)))
+    # add field to DofHandler that has subdomains
+    @test_throws ErrorException add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+
+    # inconsistent field across several SubDofHandlers
+    dh = DofHandler(grid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1,))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(2,))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}())
+    # different number of components in different sdh
+    @test_throws ErrorException add!(sdh2, :u, Lagrange{RefQuadrilateral, 1}()^2)
+    # different interpolation order in different sdh
+    @test_logs (:warn,) add!(sdh2, :u, Lagrange{RefQuadrilateral, 2}())
+end
+
+
 # misc dofhandler unit tests
 @testset "dofs" begin
 
@@ -11,14 +41,15 @@ close!(dh)
 # dof_range
 @test (@inferred dof_range(dh, :u)) == 1:12
 @test (@inferred dof_range(dh, :p)) == 13:15
-# dof_range for FieldHandler
+# dof_range for SubDofHandler
 ip = Lagrange{RefTriangle, 1}()
-field_u = Field(:u, ip^2)
-field_c = Field(:c, ip)
-fh = FieldHandler([field_u, field_c], Set(1:getncells(grid)))
-@test dof_range(fh, :u) == 1:6
-@test dof_range(fh, :c) == 7:9
+dh = DofHandler(grid)
+sdh = SubDofHandler(dh, Set(1:getncells(grid)))
+add!(sdh, :u, ip^2)
+add!(sdh, :c, ip)
 
+@test dof_range(sdh, Ferrite.find_field(sdh, :u)) == 1:6
+@test dof_range(sdh, Ferrite.find_field(sdh, :c)) == 7:9
 end # testset
 
 @testset "Dofs for Line2" begin
@@ -108,8 +139,10 @@ end
         close!(dh)
         # subdomains
         mdh = DofHandler(grid)
-        add!(mdh, FieldHandler([Field(:u, Lagrange{RefTriangle,1}())], Set(1:getncells(grid)÷2)))
-        add!(mdh, FieldHandler([Field(:u, Lagrange{RefTriangle,1}())], Set((getncells(grid)÷2+1):getncells(grid))))
+        sdh1 = SubDofHandler(mdh, Set(1:getncells(grid)÷2))
+        add!(sdh1, :u, Lagrange{RefTriangle,1}())
+        sdh2 = SubDofHandler(mdh, Set((getncells(grid)÷2+1):getncells(grid)))
+        add!(sdh2, :u, Lagrange{RefTriangle,1}())
         close!(mdh)
         ch = ConstraintHandler(dh)
         add!(ch, Dirichlet(:u, getfaceset(grid, "left"), (x, t) -> 0))
@@ -265,8 +298,11 @@ end
         grid = generate_grid(Quadrilateral, (2, 1))
         ip = Lagrange{RefQuadrilateral,1}()
         dh = DofHandler(grid)
-        add!(dh, FieldHandler([Field(:v, ip^2), Field(:s, ip)], Set(1)))
-        add!(dh, FieldHandler([Field(:v, ip^2)], Set(2)))
+        sdh1 = SubDofHandler(dh, Set(1))
+        add!(sdh1, :v, ip^2)
+        add!(sdh1, :s, ip)
+        sdh2 = SubDofHandler(dh, Set(2))
+        add!(sdh2, :v, ip^2)
         close!(dh)
         ch = ConstraintHandler(dh)
         add!(ch, Dirichlet(:v, getfaceset(grid, "left"), (x, t) -> 0, [2]))
@@ -296,11 +332,11 @@ end
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16]
     @test celldofs(dh, 2) == [3, 4, 9, 10, 11, 12, 5, 6]
     @test ch.prescribed_dofs == sort!([2, 8, 13, 16, 9])
-    for r in [dof_range(dh.fieldhandlers[1], :v), dof_range(dh.fieldhandlers[1], :s)]
+    for r in [dof_range(dh.subdofhandlers[1], :v), dof_range(dh.subdofhandlers[1], :s)]
         # Test stability within each block: i < j -> p(i) < p(j), i > j -> p(i) > p(j)
         @test sign.(diff(celldofs(dh, 1)[r])) == sign.(diff(celldofs(dho, 1)[r]))
     end
-    r = dof_range(dh.fieldhandlers[2], :v)
+    r = dof_range(dh.subdofhandlers[2], :v)
     @test sign.(diff(celldofs(dh, 2)[r])) == sign.(diff(celldofs(dho, 2)[r]))
 
     # By field, reordered
@@ -313,11 +349,11 @@ end
     @test celldofs(dh, 1) == [5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4]
     @test celldofs(dh, 2) == [7, 8, 13, 14, 15, 16, 9, 10]
     @test ch.prescribed_dofs == sort!([6, 12, 1, 4, 13])
-    for r in [dof_range(dh.fieldhandlers[1], :v), dof_range(dh.fieldhandlers[1], :s)]
+    for r in [dof_range(dh.subdofhandlers[1], :v), dof_range(dh.subdofhandlers[1], :s)]
         # Test stability within each block: i < j -> p(i) < p(j), i > j -> p(i) > p(j)
         @test sign.(diff(celldofs(dh, 1)[r])) == sign.(diff(celldofs(dho, 1)[r]))
     end
-    r = dof_range(dh.fieldhandlers[2], :v)
+    r = dof_range(dh.subdofhandlers[2], :v)
     @test sign.(diff(celldofs(dh, 2)[r])) == sign.(diff(celldofs(dho, 2)[r]))
 
     # By component
@@ -330,13 +366,13 @@ end
     @test celldofs(dh, 1) == [1, 7, 2, 8, 3, 9, 4, 10, 13, 14, 15, 16]
     @test celldofs(dh, 2) == [2, 8, 5, 11, 6, 12, 3, 9]
     @test ch.prescribed_dofs == sort!([7, 10, 13, 16, 5])
-    dof_range_v1 = dof_range(dh.fieldhandlers[1], :v)
-    dof_range_s1 = dof_range(dh.fieldhandlers[1], :s)
+    dof_range_v1 = dof_range(dh.subdofhandlers[1], :v)
+    dof_range_s1 = dof_range(dh.subdofhandlers[1], :s)
     for r in [dof_range_v1[1:2:end], dof_range_v1[2:2:end], dof_range_s1]
         # Test stability within each block: i < j -> p(i) < p(j), i > j -> p(i) > p(j)
         @test sign.(diff(celldofs(dh, 1)[r])) == sign.(diff(celldofs(dho, 1)[r]))
     end
-    dof_range_v2 = dof_range(dh.fieldhandlers[2], :v)
+    dof_range_v2 = dof_range(dh.subdofhandlers[2], :v)
     for r in [dof_range_v2[1:2:end], dof_range_v2[2:2:end]]
         @test sign.(diff(celldofs(dh, 2)[r])) == sign.(diff(celldofs(dho, 2)[r]))
     end
@@ -351,13 +387,13 @@ end
     @test celldofs(dh, 1) == [11, 1, 12, 2, 13, 3, 14, 4, 7, 8, 9, 10]
     @test celldofs(dh, 2) == [12, 2, 15, 5, 16, 6, 13, 3, ]
     @test ch.prescribed_dofs == sort!([1, 4, 7, 10, 15])
-    dof_range_v1 = dof_range(dh.fieldhandlers[1], :v)
-    dof_range_s1 = dof_range(dh.fieldhandlers[1], :s)
+    dof_range_v1 = dof_range(dh.subdofhandlers[1], :v)
+    dof_range_s1 = dof_range(dh.subdofhandlers[1], :s)
     for r in [dof_range_v1[1:2:end], dof_range_v1[2:2:end], dof_range_s1]
         # Test stability within each block: i < j -> p(i) < p(j), i > j -> p(i) > p(j)
         @test sign.(diff(celldofs(dh, 1)[r])) == sign.(diff(celldofs(dho, 1)[r]))
     end
-    dof_range_v2 = dof_range(dh.fieldhandlers[2], :v)
+    dof_range_v2 = dof_range(dh.subdofhandlers[2], :v)
     for r in [dof_range_v2[1:2:end], dof_range_v2[2:2:end]]
         @test sign.(diff(celldofs(dh, 2)[r])) == sign.(diff(celldofs(dho, 2)[r]))
     end
@@ -469,22 +505,17 @@ end
     # Test coupling with subdomains
     grid = generate_grid(Quadrilateral, (1, 2))
     dh = DofHandler(grid)
-    fh1 = FieldHandler(
-        [Field(:u, Lagrange{RefQuadrilateral,1}()^2), Field(:p, Lagrange{RefQuadrilateral,1}()^2)],
-        Set(1)
-    )
-    add!(dh, fh1)
-    fh2 = FieldHandler(
-        [Field(:u, Lagrange{RefQuadrilateral,1}()^2)],
-        Set(2)
-    )
-    add!(dh, fh2)
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral,1}()^2)
+    add!(sdh1, :p, Lagrange{RefQuadrilateral,1}())
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefQuadrilateral,1}()^2)
     close!(dh)
     K = create_sparsity_pattern(dh; coupling = [true true; true false])
     KS = create_symmetric_sparsity_pattern(dh; coupling = [true true; true false])
     # Subdomain 1: u and p
-    udofs = celldofs(dh, 1)[dof_range(fh1, :u)]
-    pdofs = celldofs(dh, 1)[dof_range(fh1, :p)]
+    udofs = celldofs(dh, 1)[dof_range(sdh1, :u)]
+    pdofs = celldofs(dh, 1)[dof_range(sdh1, :p)]
     for j in udofs, i in Iterators.flatten((udofs, pdofs))
         @test is_stored(K, i, j)
         @test is_stored(KS, i, j) == (i <= j)
@@ -498,7 +529,7 @@ end
         @test is_stored(KS, i, j) == (i == j)
     end
     # Subdomain 2: u
-    udofs = celldofs(dh, 2)[dof_range(fh2, :u)]
+    udofs = celldofs(dh, 2)[dof_range(sdh2, :u)]
     for j in udofs, i in udofs
         @test is_stored(K, i, j)
         @test is_stored(KS, i, j) == (i <= j)

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -512,7 +512,8 @@ end
         add!(dh1, :u, VectorLagrangeTest{RefLine,1,2}())
         close!(dh1)
         dh2 = DofHandler(grid)
-        add!(dh2, :u, Lagrange{RefQuadrilateral,1}()^2)
+        # TODO: Why was this RefQuadrilateral? Check it is correct to test with RefLine
+        add!(dh2, :u, Lagrange{RefLine,1}()^2)
         close!(dh2)
         @test dh1.cell_dofs == dh2.cell_dofs
 
@@ -521,7 +522,8 @@ end
         add!(dh1, :u, VectorLagrangeTest{RefLine,1,3}())
         close!(dh1)
         dh2 = DofHandler(grid)
-        add!(dh2, :u, Lagrange{RefQuadrilateral,1}()^3)
+        # TODO: Why was this RefQuadrilateral? Check it is correct to test with RefLine
+        add!(dh2, :u, Lagrange{RefLine,1}()^3)
         close!(dh2)
         @test dh1.cell_dofs == dh2.cell_dofs
     end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -3,14 +3,6 @@ function get_cellset(cell_type, cells)
     return Set(findall(c-> typeof(c) == cell_type, cells))
 end
 
-function create_field(;name, field_dim, order, reference_dim, cellshape)
-    interpolation = Lagrange{cellshape, order}()
-    if field_dim > 1
-        interpolation = interpolation^field_dim
-    end
-    return Field(name, interpolation)
-end
-
 function get_2d_grid()
     # GIVEN: two cells, a quad and a triangle sharing one face
     cells = [
@@ -34,13 +26,14 @@ function test_1d_bar_beam()
     nodes = [Node(coord) for coord in zeros(Vec{2,Float64}, 3)]
     grid = Grid(cells, nodes)
 
-    field1 = create_field(name=:u, reference_dim=1, field_dim=2, order=1, cellshape=RefLine)
-    field2 = create_field(name=:u, reference_dim=1, field_dim=2, order=1, cellshape=RefLine)
-    field3 = create_field(name=:θ, reference_dim=1, field_dim=1, order=1, cellshape=RefLine)
+    ip = Lagrange{RefLine, 1}()
 
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field2, field3], Set(3)));
-    add!(dh, FieldHandler([field1], Set((1, 2))));
+    sdh1 = SubDofHandler(dh, Set(3))
+    add!(sdh1, :u, ip^2)
+    add!(sdh1, :θ, ip)
+    sdh2 = SubDofHandler(dh, Set((1,2)))
+    add!(sdh2, :u, ip^2)
     close!(dh)
     @test ndofs(dh) == 8
     @test celldofs(dh, 3) == collect(1:6)
@@ -58,11 +51,11 @@ function test_2d_scalar()
 
     grid = get_2d_grid()
     # WHEN: adding a scalar field for each cell and generating dofs
-    field1 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefQuadrilateral)
-    field2 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2], Set(2)));
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}())
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefTriangle, 1}())
     close!(dh)
 
     # THEN: we expect 5 dofs and dof 2 and 3 being shared
@@ -73,28 +66,28 @@ function test_2d_scalar()
 end
 
 function test_2d_error()
-
     grid = get_2d_grid()
     # the refshape of the field must be the same as the refshape of the elements it is added to
-    field1 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefTriangle)
-    field2 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefQuadrilateral)
     dh = DofHandler(grid);
-    @test_throws ErrorException add!(dh, FieldHandler([field1], Set(1)));
-    @test_throws ErrorException add!(dh, FieldHandler([field2], Set(2)));
-    # all cells within a FieldHandler should be of the same celltype
-    @test_throws ErrorException add!(dh, FieldHandler([field1], Set([1,2])));
+    # wrong refshape compared to cell
+    sdh1 = SubDofHandler(dh, Set(1))
+    @test_throws ErrorException add!(sdh1, :u, Lagrange{RefTriangle, 1}());
+    sdh2 = SubDofHandler(dh, Set(2))
+    @test_throws ErrorException add!(sdh2, :u, Lagrange{RefQuadrilateral, 1}())
 
+    # all cells within a SubDofHandler should be of the same celltype
+    @test_throws ErrorException SubDofHandler(dh, Set((1,2)))
 end
 
 function test_2d_vector()
 
     grid = get_2d_grid()
     ## vector field
-    field1 = create_field(name = :u, reference_dim=2, field_dim = 2, order = 1, cellshape = RefQuadrilateral)
-    field2 = create_field(name = :u, reference_dim=2, field_dim = 2, order = 1, cellshape = RefTriangle)
-    dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2], Set(2)));
+    dh = DofHandler(grid)
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}()^2)
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefTriangle, 1}()^2)
     close!(dh)
 
     # THEN: we expect 10 dofs and dof 3-6 being shared
@@ -107,10 +100,10 @@ end
 function test_2d_mixed_1_el()
     grid = get_2d_grid()
     ## mixed field of same order
-    field1 = create_field(name = :u, reference_dim=2, field_dim = 2, order = 1, cellshape = RefQuadrilateral)
-    field2 = create_field(name = :p, reference_dim=2, field_dim = 1, order = 1, cellshape = RefQuadrilateral)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1, field2], Set(1)));
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}()^2)
+    add!(sdh1, :p, Lagrange{RefQuadrilateral, 1}())
     close!(dh)
 
     # THEN: we expect 12 dofs
@@ -118,28 +111,28 @@ function test_2d_mixed_1_el()
     @test ndofs_per_cell(dh, 1) == 12
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     
-    @test Set(Ferrite.getfieldnames(dh)) == Set(Ferrite.getfieldnames(dh.fieldhandlers[1]))
+    @test Set(Ferrite.getfieldnames(dh)) == Set(Ferrite.getfieldnames(dh.subdofhandlers[1]))
 end
 
 function test_2d_mixed_2_el()
 
     grid = get_2d_grid()
     ## mixed field of same order
-    field1_quad = create_field(name = :u, reference_dim=2, field_dim = 2, order = 1, cellshape = RefQuadrilateral)
-    field2_quad = create_field(name = :p, reference_dim=2, field_dim = 1, order = 1, cellshape = RefQuadrilateral)
-    field1_tri = create_field(name = :u, reference_dim=2, field_dim = 2, order = 1, cellshape = RefTriangle)
-    field2_tri = create_field(name = :p, reference_dim=2, field_dim = 1, order = 1, cellshape = RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1_quad, field2_quad], Set(1)));
-    add!(dh, FieldHandler([field1_tri, field2_tri], Set(2)));
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}()^2)
+    add!(sdh1, :p, Lagrange{RefQuadrilateral, 1}())
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefTriangle, 1}()^2)
+    add!(sdh2, :p, Lagrange{RefTriangle, 1}())
     close!(dh)
 
     # THEN: we expect 15 dofs
     @test ndofs(dh) == 15
     @test ndofs_per_cell(dh, 1) == 12
-    @test ndofs_per_cell(dh.fieldhandlers[1]) == 12
+    @test ndofs_per_cell(dh.subdofhandlers[1]) == 12
     @test ndofs_per_cell(dh, 2) == 9
-    @test ndofs_per_cell(dh.fieldhandlers[2]) == 9
+    @test ndofs_per_cell(dh.subdofhandlers[2]) == 9
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     @test celldofs(dh, 2) == [5, 6, 3, 4, 13, 14, 11, 10, 15]
 end
@@ -151,10 +144,8 @@ function test_face_dofs_2_tri()
         ]
     nodes = [Node(coord) for coord in zeros(Vec{2,Float64}, 4)]
     grid = Grid(cells, nodes);
-    field1 = create_field(name = :u, reference_dim = 2, field_dim = 2, order = 2, cellshape = RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set((1, 2))));
-    #add!(dh, FieldHandler([field2], Set(2)));
+    add!(dh, :u, Lagrange{RefTriangle, 2}()^2)
     close!(dh)
 
     # THEN:
@@ -174,9 +165,8 @@ function test_3d_tetrahedrons()
         ]
     nodes = [Node(coord) for coord in zeros(Vec{3,Float64}, 8)]
     grid = Grid(cells, nodes)
-    field = create_field(name = :u, reference_dim=3,  field_dim = 3, order = 2, cellshape = RefTetrahedron)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field], Set((1, 2, 3, 4, 5, 6))));
+    add!(dh, :u, Lagrange{RefTetrahedron, 2}()^3)
     close!(dh)
 
     # reference using the regular DofHandler
@@ -193,11 +183,11 @@ end
 function test_face_dofs_quad_tri()
     # quadratic quad and quadratic triangle
     grid = get_2d_grid()
-    field1 = create_field(name = :u, reference_dim = 2, field_dim = 2, order = 2, cellshape = RefQuadrilateral)
-    field2 = create_field(name = :u, reference_dim = 2, field_dim = 2, order = 2, cellshape = RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2], Set(2)));
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 2}()^2)
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefTriangle, 2}()^2)
     close!(dh)
 
     # THEN:
@@ -210,11 +200,11 @@ function test_serendipity_quad_tri()
     # bi-quadratic quad (Serendipity) and quadratic triangle
     grid = get_2d_grid()
     interpolation = Serendipity{RefQuadrilateral, 2}()
-    field1 = Field(:u, interpolation^2)
-    field2 = create_field(name = :u, reference_dim = 2, field_dim = 2, order = 2, cellshape = RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2], Set(2)));
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, interpolation^2)
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefTriangle,2}()^2)
     close!(dh)
 
     # THEN:
@@ -233,10 +223,9 @@ function test_2d_mixed_field_triangles()
         ]
     nodes = [Node(coord) for coord in zeros(Vec{2,Float64}, 4)]
     grid = Grid(cells, nodes)
-    field1 = create_field(name=:u, reference_dim=2, field_dim=2, order=2, cellshape=RefTriangle)
-    field2 = create_field(name=:p, reference_dim=2, field_dim=1, order=1, cellshape=RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1, field2], Set((1, 2))));
+    add!(dh, :u, Lagrange{RefTriangle, 2}()^2)
+    add!(dh, :p, Lagrange{RefTriangle, 1}())
     close!(dh)
     @test ndofs(dh) == 22
     @test celldofs(dh, 1) == collect(1:15)
@@ -249,13 +238,13 @@ function test_2d_mixed_field_mixed_celltypes()
     # celltypes: 1 Quadrilateral and 1 Triangle
 
     grid = get_2d_grid()
-    field1 = create_field(name=:u, reference_dim=2, field_dim=2, order=2, cellshape=RefQuadrilateral)
-    field2 = create_field(name=:p, reference_dim=2, field_dim=1, order=1, cellshape=RefQuadrilateral)
-    field3 = create_field(name=:u, reference_dim=2, field_dim=2, order=2, cellshape=RefTriangle)
-    field4 = create_field(name=:p, reference_dim=2, field_dim=1, order=1, cellshape=RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1, field2], Set(1)));
-    add!(dh, FieldHandler([field3, field4], Set(2)));
+    sdh_quad = SubDofHandler(dh, Set(1))
+    add!(sdh_quad, :u, Lagrange{RefQuadrilateral, 2}()^2)
+    add!(sdh_quad, :p, Lagrange{RefQuadrilateral, 1}())
+    sdh_tri = SubDofHandler(dh, Set(2))
+    add!(sdh_tri, :u, Lagrange{RefTriangle, 2}()^2)
+    add!(sdh_tri, :p, Lagrange{RefTriangle, 1}())
     close!(dh)
     @test ndofs(dh) == 29
     @test celldofs(dh, 1) == collect(1:22)
@@ -274,16 +263,16 @@ function test_3d_mixed_field_mixed_celltypes()
     nodes = [Node(coord) for coord in zeros(Vec{3,Float64}, 10)]
     grid = Grid(cells, nodes)
 
-    # E.g. 3d continuum el -> 3dofs/node
-    field1 = create_field(name=:u, reference_dim=3, field_dim=3, order=1, cellshape=RefHexahedron)
-    # E.g. displacement field + rotation field -> 6 dofs/node
-    field2 = create_field(name=:u, reference_dim=2, field_dim=3, order=1, cellshape=RefQuadrilateral)
-    field3 = create_field(name=:θ, reference_dim=2, field_dim=3, order=1, cellshape=RefQuadrilateral)
-
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2, field3], Set(2)));
+    # E.g. 3d continuum el -> 3dofs/node
+    sdh_hex = SubDofHandler(dh, Set(1))
+    add!(sdh_hex, :u, Lagrange{RefHexahedron, 1}()^3)
+    # E.g. displacement field + rotation field -> 6 dofs/node
+    sdh_quad = SubDofHandler(dh, Set(2))
+    add!(sdh_quad, :u, Lagrange{RefQuadrilateral, 1}()^3)
+    add!(sdh_quad, :θ, Lagrange{RefQuadrilateral, 1}()^3)
     close!(dh)
+
     @test ndofs(dh) == 42
     @test celldofs(dh, 1) == collect(1:24)
     @test celldofs(dh, 2) == [7, 8, 9, 4, 5, 6, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
@@ -293,17 +282,13 @@ function test_2_element_heat_eq()
     # Regression test solving the heat equation.
     # The grid consists of two quad elements treated as two different cell types to test the Grid and all other necessary functions
 
-    temp_grid = generate_grid(Quadrilateral, (2, 1))
-    grid = Grid(temp_grid.cells, temp_grid.nodes)  # regular grid -> mixed grid
-    grid.facesets = temp_grid.facesets;
-
-    # Create two identical fields
-    f1 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefQuadrilateral)
-    f2 = create_field(name=:u, reference_dim=2, field_dim=1, order=1, cellshape=RefQuadrilateral)
+    grid = generate_grid(Quadrilateral, (2, 1))
 
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([f1], Set(1)));  # first field applies to cell 1
-    add!(dh, FieldHandler([f2], Set(2)));  # second field applies to cell 2
+    sdh1 = SubDofHandler(dh, Set(1))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 1}())
+    sdh2 = SubDofHandler(dh, Set(2))
+    add!(sdh2, :u, Lagrange{RefQuadrilateral, 1}())
     close!(dh)
 
     # Create two Dirichlet boundary conditions - one for each field.
@@ -352,11 +337,11 @@ function test_2_element_heat_eq()
     f = zeros(ndofs(dh));
     assembler = start_assemble(K, f);
     # Use the same assemble function since it is the same weak form for both cell-types
-    for fh in dh.fieldhandlers
+    for sdh in dh.subdofhandlers
         qr = QuadratureRule{RefQuadrilateral}(2)
-        interp = fh.field_interpolations[1]
+        interp = sdh.field_interpolations[1]
         cellvalues = CellValues(qr, interp)
-        doassemble(fh.cellset, cellvalues, assembler, dh)
+        doassemble(sdh.cellset, cellvalues, assembler, dh)
     end
 
     update!(ch, 0.0);
@@ -396,13 +381,13 @@ function test_element_order()
         ]
     nodes = [Node(coord) for coord in zeros(Vec{2,Float64}, 6)]
     grid = Grid(cells, nodes)
-    field1_tri = create_field(name=:u, reference_dim=2, field_dim=2, order=1, cellshape=RefTriangle)
-    field1_quad = create_field(name=:u, reference_dim=2, field_dim=2, order=1, cellshape=RefQuadrilateral)
 
     dh = DofHandler(grid);
     # Note the jump in cell numbers
-    add!(dh, FieldHandler([field1_tri], Set((1, 3))));
-    add!(dh, FieldHandler([field1_quad], Set(2)));
+    sdh_tri = SubDofHandler(dh, Set((1,3)))
+    add!(sdh_tri, :u, Lagrange{RefTriangle,1}()^2)
+    sdh_quad = SubDofHandler(dh, Set(2))
+    add!(sdh_quad, :u, Lagrange{RefQuadrilateral,1}()^2)
     # Dofs are first created for cell 1 and 3, thereafter cell 2
     close!(dh)
 
@@ -420,12 +405,12 @@ function test_field_on_subdomain()
     # :v lives on both cells, :s lives only on the triangle
     ip_tri = Lagrange{RefTriangle,1}()
     ip_quad = Lagrange{RefQuadrilateral,1}()
-    v_tri = Field(:v, ip_tri^2)
-    v_quad = Field(:v, ip_quad^2)
-    s = Field(:s, ip_tri)
 
-    add!(dh, FieldHandler([v_quad], Set((1,))))
-    add!(dh, FieldHandler([v_tri, s], Set((2,))))
+    sdh_quad = SubDofHandler(dh, Set(1))
+    add!(sdh_quad, :v, ip_quad^2)
+    sdh_tri = SubDofHandler(dh, Set(2))
+    add!(sdh_tri, :v, ip_tri^2)
+    add!(sdh_tri, :s, ip_tri)
 
     close!(dh)
 
@@ -433,11 +418,11 @@ function test_field_on_subdomain()
     @test Ferrite.getfielddim(dh, :v) == 2
     @test Ferrite.getfielddim(dh, :s) ==1
 
-    # find field in FieldHandler
-    @test Ferrite.find_field(dh.fieldhandlers[1], :v) == 1
-    @test Ferrite.find_field(dh.fieldhandlers[2], :v) == 1
-    @test Ferrite.find_field(dh.fieldhandlers[2], :s) == 2
-    @test_throws ErrorException Ferrite.find_field(dh.fieldhandlers[1], :s)
+    # find field in SubDofHandler
+    @test Ferrite.find_field(dh.subdofhandlers[1], :v) == 1
+    @test Ferrite.find_field(dh.subdofhandlers[2], :v) == 1
+    @test Ferrite.find_field(dh.subdofhandlers[2], :s) == 2
+    @test_throws ErrorException Ferrite.find_field(dh.subdofhandlers[1], :s)
 end
 
 function test_evaluate_at_grid_nodes()
@@ -467,13 +452,11 @@ function test_evaluate_at_grid_nodes()
     ip_tri = Lagrange{RefTriangle,1}()
 
     dh = DofHandler(mesh)
-    field_v_tri = Field(:v, ip_tri^2) # vector field :v everywhere
-    fh_tri = FieldHandler([field_v_tri], getcellset(mesh, "tris"))
-    add!(dh, fh_tri)
-    field_v_quad = Field(:v, ip_quad^2)
-    field_s_quad = Field(:s, ip_quad) # scalar field :s only on quad
-    fh_quad = FieldHandler([field_v_quad, field_s_quad], getcellset(mesh, "quads"))
-    add!(dh, fh_quad)
+    sdh_tri = SubDofHandler(dh, getcellset(mesh, "tris"))
+    add!(sdh_tri, :v, ip_tri^2)
+    sdh_quad = SubDofhandler(dh, getcellset(mesh, "quads"))
+    add!(sdh_quad, :v, ip_quad^2)
+    add!(sdh_quad, :s, ip_quad) # scalar field :s only on quad
     close!(dh)
 
     u = collect(1.:16.)
@@ -502,11 +485,8 @@ function test_subparametric_quad()
     grid = generate_grid(Quadrilateral, (1,1))
     ip      = Lagrange{RefQuadrilateral,2}()
     
-    field = Field(:u, ip^2)
-    fh = FieldHandler([field], Set(1:getncells(grid)))
-    
     dh = DofHandler(grid)
-    add!(dh, fh)
+    add!(dh, :u, ip^2)
     close!(dh)
     
     ch = ConstraintHandler(dh)
@@ -514,7 +494,7 @@ function test_subparametric_quad()
     add!(ch, dbc1)
     close!(ch)
     update!(ch, 1.0)
-    @test getnbasefunctions(Ferrite.getfieldinterpolation(fh,1)) == 18 # algebraic nbasefunctions
+    @test getnbasefunctions(Ferrite.getfieldinterpolation(dh.subdofhandlers[1],1)) == 18 # algebraic nbasefunctions
     @test celldofs(dh, 1) == [i for i in 1:18]
 end
 
@@ -524,11 +504,8 @@ function test_subparametric_triangle()
 
     ip = Lagrange{RefTriangle,2}()
     
-    field = Field(:u, ip^2)
-    fh = FieldHandler([field], Set(1:getncells(grid)))
-    
     dh = DofHandler(grid)
-    add!(dh, fh)
+    add!(dh, :u, ip^2)
     close!(dh)
     
     ch = ConstraintHandler(dh)
@@ -536,7 +513,7 @@ function test_subparametric_triangle()
     add!(ch, dbc1)
     close!(ch)
     update!(ch, 1.0)
-    @test getnbasefunctions(Ferrite.getfieldinterpolation(fh,1)) == 12 # algebraic nbasefunctions
+    @test getnbasefunctions(Ferrite.getfieldinterpolation(dh.subdofhandlers[1],1)) == 12 # algebraic nbasefunctions
     @test celldofs(dh, 1) == [i for i in 1:12]
 end
 
@@ -562,16 +539,15 @@ function test_separate_fields_on_separate_domains()
     addcellset!(mesh, "quads", Set{Int}((1,)))
     addcellset!(mesh, "tris", Set{Int}((2, 3)))
 
-    dh = DofHandler(mesh)
     ip_tri = Lagrange{RefTriangle,1}()
     ip_quad = Lagrange{RefQuadrilateral,1}()
-    field = Field(:q, ip_quad^2) # vector field :q only on quad
-    fh_quad = FieldHandler([field], getcellset(mesh, "quads"))
-    add!(dh, fh_quad)
 
-    field = Field(:t, ip_tri) # scalar field :t only on tris
-    fh_tri = FieldHandler([field], getcellset(mesh, "tris"))
-    add!(dh, fh_tri)
+    dh = DofHandler(mesh)
+    sdh_quad = SubDofHandler(dh, getcellset(mesh, "quads"))
+    add!(sdh_quad, :q, ip_quad^2) # vector field :q only on quad
+
+    sdh_tri = SubDofHandler(dh, getcellset(mesh, "tris"))
+    add!(sdh_tri, :t, ip_tri)
     close!(dh)
 
     # Expect: 8 dofs for the quad and 4 new dofs for the triangles
@@ -587,25 +563,36 @@ function test_unique_cellsets()
     set_u = Set(1:2)
     set_v = Set(1:1)
 
-    dim = Ferrite.getdim(grid)
     ip = Lagrange{RefQuadrilateral,1}()
 
     # bug
     dh = DofHandler(grid)
-    add!(dh, FieldHandler([Field(:u, ip)], set_u))
-    @test_throws ErrorException add!(dh, FieldHandler([Field(:v, ip)], set_v))
+    sdh_u = SubDofHandler(dh, set_u)
+    @test_throws ErrorException SubDofHandler(dh, set_v)
 end
 
 function test_show()
+    # single SubDofHandler
+    grid = generate_grid(Triangle, (1,1))
+    dh = DofHandler(grid)
+    add!(dh, :u, Lagrange{RefTriangle, 1}()^2)
+    close!(dh)
+    @test repr("text/plain", dh) == string(
+        repr(typeof(dh)), "\n  Fields:\n    :u, ",
+        repr(dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 6\n  Total dofs: 8")
+
+    # multiple SubDofHandlers
     grid = get_2d_grid()
-    # WHEN: adding a scalar field for each cell and generating dofs
-    field1 = create_field(name=:u, reference_dim=2, field_dim=2, order=1, cellshape=RefQuadrilateral)
-    field2 = create_field(name=:u, reference_dim=2, field_dim=2, order=1, cellshape=RefTriangle)
     dh = DofHandler(grid);
-    add!(dh, FieldHandler([field1], Set(1)));
-    add!(dh, FieldHandler([field2], Set(2)));
+    sdh_quad = SubDofHandler(dh, Set(1))
+    add!(sdh_quad, :u, Lagrange{RefQuadrilateral, 1}()^2)
+    sdh_tri = SubDofHandler(dh, Set(2))
+    add!(sdh_tri, :u, Lagrange{RefTriangle, 1}()^2)
     close!(dh)
     @test repr("text/plain", dh) == repr(typeof(dh)) * "\n  Fields:\n    :u, dim: 2\n  Total dofs: 10"
+    @test repr("text/plain", dh.subdofhandlers[1]) == string(
+        repr(typeof(dh.subdofhandlers[1])), "\n  Cell type: Quadrilateral\n  Fields:\n    :u, ",
+            repr(dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 8\n")
 end
 
 @testset "DofHandler" begin
@@ -617,8 +604,8 @@ end
     test_2d_mixed_2_el();
     test_face_dofs_2_tri();
     test_face_dofs_quad_tri();
-    test_serendipity_quad_tri();
     test_3d_tetrahedrons();
+    test_serendipity_quad_tri();
     test_2d_mixed_field_triangles();
     test_2d_mixed_field_mixed_celltypes();
     test_3d_mixed_field_mixed_celltypes();

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -263,12 +263,10 @@ function mixed_grid()
 
     # second alternative: assume a vector field :v
     dh = DofHandler(mesh)
-    field = Field(:v, ip_quad^2)
-    fh_quad = FieldHandler([field], getcellset(mesh, "quads"))
-    add!(dh, fh_quad)
-    field = Field(:v, ip_tri^2)
-    fh_tri = FieldHandler([field], getcellset(mesh, "tris"))
-    add!(dh, fh_tri)
+    sdh_quad = SubDofHandler(dh, getcellset(mesh, "quads"))
+    add!(sdh_quad, :v, ip_quad^2)
+    sdh_tri = SubDofHandler(dh, getcellset(mesh, "tris"))
+    add!(sdh_tri, :v, ip_tri^2)
     close!(dh)
 
     dof_vals = [1., 1., 2., 2., 4., 4., 3., 3., 6., 6., 5., 5.]


### PR DESCRIPTION
This PR follows up on the discussion in #644. `FieldHandler` is replaced by a more capable
`SubDofHandler` for the description of subdomains. Subdomain here refers to one or both of:
- several element types in the grid
- one or more fields live on part of the domain

Constructing a `DofHandler` for Taylor-Hood elements on a domain with triangles and quads used to look like this:
```julia
field_u_quad = Field(:u, Lagrange{RefQuadrilateral, 2}()^2)
field_p_quad = Field(:p, Lagrange{RefQuadrilateral, 1}())
fh_quad = FieldHandler([field_u, field_p], getcellset(grid, "quads"))

field_u_tri = Field(:u, Lagrange{RefTriangle, 2}()^2)
field_p_quad = Field(:p, Lagrange{RefTriangle, 1}())
fh_quad = FieldHandler([field_u, field_p], getcellset(grid, "tris"))

dh = DofHandler(grid);
add!(dh, fh1);
add!(dh, fh2);
close!(dh)
```

The new syntax looks as follows:
```julia
dh = DofHandler(grid)

sdh_quad = SubDofHandler(dh, getcellset(grid, "quads"))
add!(sdh_quad, :u, Lagrange{RefQuadrilateral, 2}()^2)
add!(sdh_quad, :p, Lagrange{RefQuadrilateral, 1}())

sdh_tri = SubDofHandler(dh, getcellset(grid, "tris"))
add!(sdh_tri, :u, Lagrange{RefTriangle, 2}()^2)
add!(sdh_tri, :p, Lagrange{RefTriangle, 1}())

close!(dh)
```

Major motivation settling for this syntax were:
- Improved error messages during construction 
- Similarity to `DofHandler` construction without subdomains
- Self-contained `SubDofHandler`:  Before it was necessary to pass around `DofHandler` + `FieldHandler` for a complete description of the subdomains, now `SubDofHandler` covers this alone.


closes #644, #638


<details>
  <summary>Some examples of improved error messages:</summary>

Interpolation incompatible with cell type:
```julia
grid = generate_grid(Triangle, (1,1));
ip = Lagrange{RefQuadrilateral, 1}(); # incompatible with grid

# silently failed on #master, compare #638
julia> dh = DofHandler(grid);
julia> add!(dh, :u, ip^2);
julia> close!(dh);

# errors on PR
julia> dh = DofHandler(grid);
julia> add!(dh, :u, ip^2);
ERROR: The refshape of the interpolation RefQuadrilateral is incompatible with the refshape RefTriangle of the cells.
```

```julia
julia> grid = generate_grid(Triangle, (1,1));
julia> ip = Lagrange{RefQuadrilateral, 1}(); # incompatible with grid

# error when adding FieldHandler on #master
julia> dh = DofHandler(grid);
julia> fh = FieldHandler([Field(:u, ip^2)], Set(1:getncells(grid))); # no error here
julia> add!(dh, fh) # error could be for any field in FieldHandler
ERROR: The RefShapes of the fieldhandlers interpolations must correspond to the RefShape of the cells it is applied to.

# error when adding incompatible field on PR
julia> dh = DofHandler(grid);
julia> sdh = SubDofHandler(dh, Set(1:getncells(grid)))
julia> add!(sdh, :u, ip^2) # clear which field is problematic here
ERROR: The refshape of the interpolation RefQuadrilateral is incompatible with the refshape RefTriangle of the cells.
```

Different number of components for same field:
```julia
julia> grid = generate_grid(Triangle, (1,1));
julia> ip = Lagrange{RefTriangle, 1}(); 

# silent on #master
julia> dh = DofHandler(grid);
julia> fh1 = FieldHandler([Field(:u, ip^2)], Set(1)); # vector field :u
julia> fh2 = FieldHandler([Field(:u, ip)], Set(2)); # scalar field :u
julia> add!(dh, fh1); add!(dh, fh2);
julia> close!(dh) # scalar field reuses first dof of vector field on shared nodes
DofHandler{2, Grid{2, Triangle, Float64}}
  Fields:
    :u, dim: 2
  Total dofs: 7

# error on PR
julia> dh = DofHandler(grid);
julia> sdh1 = SubDofHandler(dh, Set(1))
julia> add!(sdh1, :u, ip^2) # vector field :u
julia> sdh2 = SubDofHandler(dh, Set(2))
julia> add!(sdh2, :u, ip) # scalar field :u
ERROR: Field :u has a different number of components in another SubDofHandler. Use a different field name.
```

Different interpolation type for same field:
```julia
julia> grid = generate_grid(Triangle, (1,1));

# silent on #master
julia> dh = DofHandler(grid);
julia> fh1 = FieldHandler([Field(:u, Lagrange{RefTriangle,1}())], Set(1)); # linear interpolation
julia> fh2 = FieldHandler([Field(:u, Lagrange{RefTriangle,2}())], Set(2)); # do you really want a quadratic interpolation here?
julia> add!(dh, fh1); add!(dh, fh2);
julia> close!(dh)
DofHandler{2, Grid{2, Triangle, Float64}}
  Fields:
    :u, dim: 1
  Total dofs: 7

# warn on PR
julia> dh = DofHandler(grid);
julia> sdh1 = SubDofHandler(dh, Set(1))
julia> add!(sdh1, :u, Lagrange{RefTriangle, 1}()) # linear interpolation
julia> sdh2 = SubDofHandler(dh, Set(2))
julia> add!(sdh2, :u, Lagrange{RefTriangle,2}()) # do you really want a quadratic interpolation here?
┌ Warning: Field :u uses a different interpolation order in another SubDofHandler.
└ @ Ferrite ~/.julia/dev/Ferrite/src/Dofs/DofHandler.jl:186
SubDofHandler{DofHandler{2, Grid{2, Triangle, Float64}}}
  Cell type: Triangle
  Fields:
    :u, Lagrange{RefTriangle, 2}()
  Not closed!
```

Invalid subdomain:
```julia
julia> nodes = [Node(zero(Vec{2})) for _ in 1:6]
julia> cells = [Quadrilateral((1,2,5,4)), Triangle((2,3,6)), Triangle((2,6,5))]
julia> grid = Grid(cells, nodes)

# Error only after constructing invalid FieldHandler on #master
julia> dh = DofHandler(grid)
julia> fh = FieldHandler([Field(:u, Lagrange{RefQuadrilateral, 1}())], Set((1,2))) # interpolation added before cellset is checked
julia> add!(dh, fh) # cellset check happens here
ERROR: The cells in the cellset are not all of the same celltype.

# Error while constructing invalid SubDofHandler on PR
julia> dh = DofHandler(grid)
julia> sdh = SubDofHandler(dh, Set((1,2)) # cellset check 
ERROR: all cells in a SubDofHandler must be of the same type
```

</details>