### PR TITLE
pretty printing for `VectorizedInterpolation`

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1259,6 +1259,10 @@ function Base.literal_pow(::typeof(^), ip::ScalarInterpolation, ::Val{vdim}) whe
     return VectorizedInterpolation{vdim}(ip)
 end
 
+function Base.show(io::IO, ::MIME"text/plain", ip::VectorizedInterpolation{vdim}) where vdim
+    print(io, ip.ip, "^", vdim)
+end
+
 # Helper to get number of copies for DoF distribution
 get_n_copies(::VectorizedInterpolation{vdim}) where vdim = vdim
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1259,8 +1259,9 @@ function Base.literal_pow(::typeof(^), ip::ScalarInterpolation, ::Val{vdim}) whe
     return VectorizedInterpolation{vdim}(ip)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", ip::VectorizedInterpolation{vdim}) where vdim
-    print(io, ip.ip, "^", vdim)
+function Base.show(io::IO, mime::MIME"text/plain", ip::VectorizedInterpolation{vdim}) where vdim
+    show(io, mime, ip.ip)
+    print(io, "^", vdim)
 end
 
 # Helper to get number of copies for DoF distribution

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -156,6 +156,8 @@
     v_interpolation_2 = (d = 2; interpolation^d)
     @test getnbasefunctions(v_interpolation_1) == getnbasefunctions(v_interpolation_2) ==
           getnbasefunctions(interpolation) * 2
+    # pretty printing
+    @test repr("text/plain", v_interpolation_1) == repr(v_interpolation_1.ip) * "^2"
 end
 
 @test Ferrite.reference_coordinates(DiscontinuousLagrange{RefTriangle,0}()) ≈ [Vec{2,Float64}((1/3,1/3))]


### PR DESCRIPTION
Prints vectorized interpolations as
```
Lagrange{RefQuadrilateral, 1}()^2
```
instead of 
```
VectorizedInterpolation{2, RefQuadrilateral, 1, Lagrange{RefQuadrilateral, 1, Nothing}}(Lagrange{RefQuadrilateral, 1}()) 
```