### PR TITLE
Rework `find_field` and related function

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -945,7 +945,8 @@ function add!(ch::ConstraintHandler, pdbc::PeriodicDirichlet)
         end
     end
     field_idx = find_field(ch.dh, pdbc.field_name)
-    interpolation = getfieldinterpolation(ch.dh, field_idx)
+    field_idx === nothing && throw_field_not_found(pdbc.field_name)
+    interpolation = getfieldinterpolation(ch.dh.subdofhandlers[field_idx[1]], field_idx[2])
     n_comp = n_dbc_components(interpolation)
     if interpolation isa VectorizedInterpolation
         interpolation = interpolation.ip

--- a/src/Dofs/DofRenumbering.jl
+++ b/src/Dofs/DofRenumbering.jl
@@ -194,7 +194,7 @@ function compute_renumber_permutation(dh::DofHandler, _, order::DofOrder.Compone
     component_offsets = pushfirst!(cumsum(field_dims), 0)
     flags = UpdateFlags(nodes=false, coords=false, dofs=true)
     for sdh in dh.subdofhandlers
-        dof_ranges = [dof_range(sdh, f) for f in eachindex(sdh.field_names)]
+        dof_ranges = [dof_range(sdh, f) for f in sdh.field_names]
         global_idxs = [findfirst(x -> x === f, dh.field_names) for f in sdh.field_names]
         for cell in CellIterator(dh, sdh.cellset, flags)
             cdofs = celldofs(cell)

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -33,7 +33,7 @@ function apply_analytical!(
     ip_geos = _default_interpolations(dh)
 
     for (sdh, ip_geo) in zip(dh.subdofhandlers, ip_geos)
-        isnothing(_find_field(sdh, fieldname)) && continue
+        find_field(sdh, fieldname) === nothing && continue
         field_idx = find_field(sdh, fieldname)
         ip_fun = getfieldinterpolation(sdh, field_idx)
         field_dim = getfielddim(sdh, field_idx)

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -183,7 +183,9 @@ function get_point_values(ph::PointEvalHandler{<:Any, dim, T1}, dh::AbstractDofH
                            fname::Symbol=find_single_field(dh)) where {dim, T1, T2}
     npoints = length(ph.cells)
     # Figure out the value type by creating a dummy PointValuesInternal
-    ip = getfieldinterpolation(dh, find_field(dh, fname))
+    idx = find_field(dh, fname)
+    idx === nothing && throw_field_not_found(fname)
+    ip = getfieldinterpolation(dh.subdofhandlers[idx[1]], idx[2])
     pv = PointValuesInternal(zero(Vec{dim, T1}), ip)
     zero_val = function_value_init(pv, dof_vals)
     # Allocate the output as NaNs
@@ -263,7 +265,7 @@ end
 function get_func_interpolations(dh::DofHandler, fieldname)
     func_interpolations = Union{Interpolation,Nothing}[]
     for sdh in dh.subdofhandlers
-        j = _find_field(sdh, fieldname)
+        j = find_field(sdh, fieldname)
         if j === nothing
             push!(func_interpolations, nothing)
         else

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -67,7 +67,7 @@
     function _global_dof_range(dh::DofHandler, field_name::Symbol)
         dofs = Set{Int}()
         for sdh in dh.subdofhandlers
-            if !isnothing(Ferrite._find_field(sdh, field_name))
+            if Ferrite.find_field(sdh, field_name) !== nothing
                 _global_dof_range!(dofs, sdh, field_name, sdh.cellset)
             end
         end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -56,7 +56,7 @@
     pdbc = PeriodicDirichlet(:s, face_map, [1, 2])
     @test_throws ErrorException("components [1, 2] not within range of field :s (1 dimension(s))") add!(ConstraintHandler(dh), pdbc)
     pdbc = PeriodicDirichlet(:p, face_map)
-    @test_throws ErrorException("Did not find field :p in DofHandler (existing fields: [:s, :v, :z, :sd, :vd]).") add!(ConstraintHandler(dh), pdbc)
+    @test_throws ArgumentError("field :p not found") add!(ConstraintHandler(dh), pdbc)
     ## Vector
     pdbc = PeriodicDirichlet(:v, face_map)
     add!(ConstraintHandler(dh), pdbc)

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -47,9 +47,10 @@ dh = DofHandler(grid)
 sdh = SubDofHandler(dh, Set(1:getncells(grid)))
 add!(sdh, :u, ip^2)
 add!(sdh, :c, ip)
+close!(dh)
 
-@test dof_range(sdh, Ferrite.find_field(sdh, :u)) == 1:6
-@test dof_range(sdh, Ferrite.find_field(sdh, :c)) == 7:9
+@test (@inferred dof_range(sdh, :u)) == 1:6
+@test (@inferred dof_range(sdh, :c)) == 7:9
 end # testset
 
 @testset "Dofs for Line2" begin

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -422,7 +422,7 @@ function test_field_on_subdomain()
     @test Ferrite.find_field(dh.subdofhandlers[1], :v) == 1
     @test Ferrite.find_field(dh.subdofhandlers[2], :v) == 1
     @test Ferrite.find_field(dh.subdofhandlers[2], :s) == 2
-    @test_throws ErrorException Ferrite.find_field(dh.subdofhandlers[1], :s)
+    @test Ferrite.find_field(dh.subdofhandlers[1], :s) === nothing
 end
 
 function test_evaluate_at_grid_nodes()


### PR DESCRIPTION
This patch changes `find_field` to return `nothing` instead of throwing if the field is not found. This patch also changes `dof_range` to always throw if there are more than one `SubDofHandler`.

Replaces #725