### PR TITLE
Make benchmarks work with master branch

### DIFF
--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -14,7 +14,7 @@ for spatial_dim ∈ 1:3
 
         grid = generate_grid(geo_type, tuple(repeat([1], spatial_dim)...));
         ip_geo = Ferrite.default_interpolation(geo_type)
-        ref_type = geo_type.super.parameters[1]
+        ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
 
         # Nodal interpolation tests
         for order ∈ 1:2, ip_type ∈ [Lagrange, Serendipity]

--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -13,8 +13,8 @@ for spatial_dim ∈ 1:3
         COMMON_LOCAL_ASSEMBLY["spatial-dim",spatial_dim][string(geo_type)] = BenchmarkGroup()
 
         grid = generate_grid(geo_type, tuple(repeat([1], spatial_dim)...));
-        ref_type = FerriteBenchmarkHelper.default_refshape(geo_type)
         ip_geo = Ferrite.default_interpolation(geo_type)
+        ref_type = geo_type.super.parameters[1]
 
         # Nodal interpolation tests
         for order ∈ 1:2, ip_type ∈ [Lagrange, Serendipity]
@@ -23,7 +23,7 @@ for spatial_dim ∈ 1:3
             ip_vectorized = ip^spatial_dim
 
             # Skip over elements which are not implemented
-            !applicable(Ferrite.value, ip, 1, ξ_dummy) && continue
+            !applicable(Ferrite.shape_value, ip, ξ_dummy, 1) && continue
 
             qr = QuadratureRule{ref_type}(2*order-1)
 
@@ -33,7 +33,7 @@ for spatial_dim ∈ 1:3
             LAGRANGE_SUITE["fe-values"] = BenchmarkGroup()
             LAGRANGE_SUITE["ritz-galerkin"] = BenchmarkGroup()
             LAGRANGE_SUITE["petrov-galerkin"] = BenchmarkGroup()
-            
+
             # Note: at the time of writing this PR the ctor makes the heavy lifting and caches important values.
             LAGRANGE_SUITE["fe-values"]["scalar"] = @benchmarkable CellValues($qr, $ip, $ip_geo);
             LAGRANGE_SUITE["fe-values"]["vector"] = @benchmarkable CellValues($qr, $ip_vectorized, $ip_geo);

--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -18,12 +18,14 @@ for spatial_dim ∈ 1:3
 
         # Nodal interpolation tests
         for order ∈ 1:2, ip_type ∈ [Lagrange, Serendipity]
-            ip = ip_type{spatial_dim, ref_type, order}()
+            ip_type == Serendipity && (order < 2 || ref_type ∉ (RefQuadrilateral, RefHexahedron)) && continue
+            ip = ip_type{ref_type, order}()
+            ip_vectorized = ip^spatial_dim
 
             # Skip over elements which are not implemented
             !applicable(Ferrite.value, ip, 1, ξ_dummy) && continue
 
-            qr = QuadratureRule{spatial_dim, ref_type}(2*order-1)
+            qr = QuadratureRule{ref_type}(2*order-1)
 
             # Currently we just benchmark nodal Lagrange bases.
             COMMON_LOCAL_ASSEMBLY["spatial-dim",spatial_dim][string(geo_type)][string(ip_type),string(order)] = BenchmarkGroup()
@@ -31,16 +33,16 @@ for spatial_dim ∈ 1:3
             LAGRANGE_SUITE["fe-values"] = BenchmarkGroup()
             LAGRANGE_SUITE["ritz-galerkin"] = BenchmarkGroup()
             LAGRANGE_SUITE["petrov-galerkin"] = BenchmarkGroup()
-
+            
             # Note: at the time of writing this PR the ctor makes the heavy lifting and caches important values.
-            LAGRANGE_SUITE["fe-values"]["scalar"] = @benchmarkable CellScalarValues($qr, $ip, $ip_geo);
-            LAGRANGE_SUITE["fe-values"]["vector"] = @benchmarkable CellVectorValues($qr, $ip, $ip_geo);
+            LAGRANGE_SUITE["fe-values"]["scalar"] = @benchmarkable CellValues($qr, $ip, $ip_geo);
+            LAGRANGE_SUITE["fe-values"]["vector"] = @benchmarkable CellValues($qr, $ip_vectorized, $ip_geo);
 
-            csv = CellScalarValues(qr, ip, ip_geo);
-            csv2 = CellScalarValues(qr, ip, ip_geo);
+            csv = CellValues(qr, ip, ip_geo);
+            csv2 = CellValues(qr, ip, ip_geo);
 
-            cvv = CellVectorValues(qr, ip, ip_geo);
-            cvv2 = CellVectorValues(qr, ip, ip_geo);
+            cvv = CellValues(qr, ip_vectorized, ip_geo);
+            cvv2 = CellValues(qr, ip_vectorized, ip_geo);
 
             # Scalar shape φ and test ψ: ∫ φ ψ
             LAGRANGE_SUITE["ritz-galerkin"]["mass"] = @benchmarkable FerriteAssemblyHelper._generalized_ritz_galerkin_assemble_local_matrix($grid, $csv, shape_value, shape_value, *)
@@ -58,9 +60,9 @@ for spatial_dim ∈ 1:3
             LAGRANGE_SUITE["petrov-galerkin"]["pressure-velocity"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_local_matrix($grid, $cvv, shape_divergence, $csv, shape_value, *)
 
             if spatial_dim > 1
-                qr_face = QuadratureRule{spatial_dim-1, ref_type}(2*order-1)
-                fsv = FaceScalarValues(qr_face, ip, ip_geo);
-                fsv2 = FaceScalarValues(qr_face, ip, ip_geo);
+                qr_face = FaceQuadratureRule{ref_type}(2*order-1)
+                fsv = FaceValues(qr_face, ip, ip_geo);
+                fsv2 = FaceValues(qr_face, ip, ip_geo);
 
                 LAGRANGE_SUITE["ritz-galerkin"]["face-flux"] = @benchmarkable FerriteAssemblyHelper._generalized_ritz_galerkin_assemble_local_matrix($grid, $fsv, shape_gradient, shape_value, *)
                 LAGRANGE_SUITE["petrov-galerkin"]["face-flux"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_local_matrix($grid, $fsv, shape_gradient, $fsv2, shape_value, *)

--- a/benchmark/benchmarks-boundary-conditions.jl
+++ b/benchmark/benchmarks-boundary-conditions.jl
@@ -17,9 +17,9 @@ for spatial_dim ∈ [2]
     order = 2
 
     # assemble a mass matrix to apply BCs on (because its cheap)
-    ip = Lagrange{spatial_dim, ref_type, order}()
-    qr = QuadratureRule{spatial_dim, ref_type}(2*order-1)
-    cellvalues = CellScalarValues(qr, ip, ip_geo);
+    ip = Lagrange{ref_type, order}()
+    qr = QuadratureRule{ref_type}(2*order-1)
+    cellvalues = CellValues(qr, ip, ip_geo);
     dh = DofHandler(grid)
     push!(dh, :u, 1, ip)
     close!(dh);

--- a/benchmark/benchmarks-boundary-conditions.jl
+++ b/benchmark/benchmarks-boundary-conditions.jl
@@ -12,7 +12,7 @@ for spatial_dim ∈ [2]
 
     geo_type = Quadrilateral
     grid = generate_grid(geo_type, ntuple(x->2, spatial_dim));
-    ref_type = FerriteBenchmarkHelper.default_refshape(geo_type)
+    ref_type = geo_type.super.parameters[1]
     ip_geo = Ferrite.default_interpolation(geo_type)
     order = 2
 

--- a/benchmark/benchmarks-boundary-conditions.jl
+++ b/benchmark/benchmarks-boundary-conditions.jl
@@ -12,7 +12,7 @@ for spatial_dim ∈ [2]
 
     geo_type = Quadrilateral
     grid = generate_grid(geo_type, ntuple(x->2, spatial_dim));
-    ref_type = geo_type.super.parameters[1]
+    ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
     ip_geo = Ferrite.default_interpolation(geo_type)
     order = 2
 

--- a/benchmark/benchmarks-dofs.jl
+++ b/benchmark/benchmarks-dofs.jl
@@ -53,23 +53,22 @@ for spatial_dim ∈ [3]# 1:3
                     end
                     LAGRANGE_SUITE["DofHandler"]["two-fields"] = @benchmarkable $close_helper($grid, $ip, $ip2)
 
-
-                    f1 = Field(:u, ip, field_dim)
-                    f2 = Field(:p, ip2, 1)
-
-                    close_helper = function(grid, f1)
+                    close_helper = function(grid)
                         dh = DofHandler(grid)
-                        push!(dh, FieldHandler([f1], Set(1:Int(round(getncells(grid)/2)))))
+                        sdh = SubDofHandler(dh, Set(1:Int(round(getncells(grid)/2))))
+                        add!(sdh, :u, ip^field_dim)
                         close!(dh)
                     end
-                    LAGRANGE_SUITE["DofHandler"]["one-field-subdomain"] = @benchmarkable $close_helper($grid, $f1)
+                    LAGRANGE_SUITE["DofHandler"]["one-field-subdomain"] = @benchmarkable $close_helper($grid)
 
-                    close_helper = function(grid, f1, f2)
+                    close_helper = function(grid)
                         dh = DofHandler(grid)
-                        push!(dh, FieldHandler([f1, f2], Set(1:Int(round(getncells(grid)/2)))))
+                        sdh = SubDofHandler(dh, Set(1:Int(round(getncells(grid)/2))))
+                        add!(sdh, :u, ip^field_dim)
+                        add!(sdh, :p, ip2)
                         close!(dh)
                     end
-                    LAGRANGE_SUITE["DofHandler"]["two-fields-subdomain"] = @benchmarkable $close_helper($grid, $f1, $f2)
+                    LAGRANGE_SUITE["DofHandler"]["two-fields-subdomain"] = @benchmarkable $close_helper($grid)
                 end
             end
         end

--- a/benchmark/benchmarks-dofs.jl
+++ b/benchmark/benchmarks-dofs.jl
@@ -11,7 +11,7 @@ for spatial_dim ∈ [3]# 1:3
     for geo_type ∈ FerriteBenchmarkHelper.geo_types_for_spatial_dim(spatial_dim)
         NUMBERING_SUITE["spatial-dim",spatial_dim][string(geo_type)] = BenchmarkGroup()
 
-        ref_type = geo_type.super.parameters[1]
+        ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
 
         for grid_size ∈ [2]#[3, 6, 9] #multiple grid sized to estimate computational complexity...
             NUMBERING_SUITE["spatial-dim",spatial_dim][string(geo_type)]["grid-size-",grid_size] = BenchmarkGroup()
@@ -28,7 +28,6 @@ for spatial_dim ∈ [3]# 1:3
 
                     # Skip over elements which are not implemented
                     ξ_dummy = Vec{spatial_dim}(ntuple(x->0.0, spatial_dim))
-                    !applicable(Ferrite.shape_value, ip, ξ_dummy, 1) && continue
                     !applicable(Ferrite.shape_value, ip, ξ_dummy, 1) && continue
 
                     NUMBERING_FIELD_DIM_SUITE["Lagrange",order] = BenchmarkGroup()

--- a/benchmark/benchmarks-dofs.jl
+++ b/benchmark/benchmarks-dofs.jl
@@ -11,7 +11,7 @@ for spatial_dim ∈ [3]# 1:3
     for geo_type ∈ FerriteBenchmarkHelper.geo_types_for_spatial_dim(spatial_dim)
         NUMBERING_SUITE["spatial-dim",spatial_dim][string(geo_type)] = BenchmarkGroup()
 
-        ref_type = FerriteBenchmarkHelper.default_refshape(geo_type)
+        ref_type = geo_type.super.parameters[1]
 
         for grid_size ∈ [2]#[3, 6, 9] #multiple grid sized to estimate computational complexity...
             NUMBERING_SUITE["spatial-dim",spatial_dim][string(geo_type)]["grid-size-",grid_size] = BenchmarkGroup()
@@ -28,8 +28,8 @@ for spatial_dim ∈ [3]# 1:3
 
                     # Skip over elements which are not implemented
                     ξ_dummy = Vec{spatial_dim}(ntuple(x->0.0, spatial_dim))
-                    !applicable(Ferrite.value, ip, 1, ξ_dummy) && continue
-                    !applicable(Ferrite.value, ip, 1, ξ_dummy) && continue
+                    !applicable(Ferrite.shape_value, ip, ξ_dummy, 1) && continue
+                    !applicable(Ferrite.shape_value, ip, ξ_dummy, 1) && continue
 
                     NUMBERING_FIELD_DIM_SUITE["Lagrange",order] = BenchmarkGroup()
                     LAGRANGE_SUITE = NUMBERING_FIELD_DIM_SUITE["Lagrange",order]

--- a/benchmark/benchmarks-dofs.jl
+++ b/benchmark/benchmarks-dofs.jl
@@ -24,7 +24,7 @@ for spatial_dim ∈ [3]# 1:3
                 NUMBERING_FIELD_DIM_SUITE = NUMBERING_SUITE["spatial-dim",spatial_dim][string(geo_type)]["grid-size-",grid_size]["field-dim-", field_dim]
                 # Lagrange tests
                 for order ∈ 1:2
-                    ip = Lagrange{spatial_dim, ref_type, order}()
+                    ip = Lagrange{ref_type, order}()
 
                     # Skip over elements which are not implemented
                     ξ_dummy = Vec{spatial_dim}(ntuple(x->0.0, spatial_dim))
@@ -34,7 +34,7 @@ for spatial_dim ∈ [3]# 1:3
                     NUMBERING_FIELD_DIM_SUITE["Lagrange",order] = BenchmarkGroup()
                     LAGRANGE_SUITE = NUMBERING_FIELD_DIM_SUITE["Lagrange",order]
                     order2 = max(order-1, 1)
-                    ip2 = Lagrange{spatial_dim, ref_type, order2}()
+                    ip2 = Lagrange{ref_type, order2}()
 
                     LAGRANGE_SUITE["DofHandler"] = BenchmarkGroup()
 

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -8,8 +8,6 @@ function geo_types_for_spatial_dim(spatial_dim)
     spatial_dim == 3 && return [Tetrahedron, Hexahedron] # Quadratic* not yet functional in 3D. 3D triangle missing. Embedded also missing.
 end
 
-default_refshape(t::Type{C}) where {C <: Ferrite.AbstractCell} = typeof(Ferrite.default_interpolation(t)).parameters[1]
-
 end
 
 

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -8,6 +8,8 @@ function geo_types_for_spatial_dim(spatial_dim)
     spatial_dim == 3 && return [Tetrahedron, Hexahedron] # Quadratic* not yet functional in 3D. 3D triangle missing. Embedded also missing.
 end
 
+getrefshape(::Type{T}) where {refshape, T <: Ferrite.AbstractCell{refshape}} = refshape
+
 end
 
 
@@ -16,7 +18,7 @@ module FerriteAssemblyHelper
 using Ferrite
 
 # Minimal Ritz-Galerkin type local assembly loop.
-function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues::CellValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, f_test, op) where {dim}
+function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues::CellValues, f_shape, f_test, op)
     n_basefuncs = getnbasefunctions(cellvalues)
 
     Ke = zeros(n_basefuncs, n_basefuncs)
@@ -38,7 +40,7 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
     Ke
 end
 
-function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, f_test, op) where {dim}
+function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues::FaceValues, f_shape, f_test, op)
     n_basefuncs = getnbasefunctions(facevalues)
 
     f = zeros(n_basefuncs)
@@ -92,7 +94,7 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     Ke
 end
 
-function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues_shape::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, facevalues_test::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_test, op) where {dim}
+function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues_shape::FaceValues, f_shape, facevalues_test::FaceValues, f_test, op)
     n_basefuncs_shape = getnbasefunctions(facevalues_shape)
     n_basefuncs_test = getnbasefunctions(facevalues_test)
 

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -8,7 +8,7 @@ function geo_types_for_spatial_dim(spatial_dim)
     spatial_dim == 3 && return [Tetrahedron, Hexahedron] # Quadratic* not yet functional in 3D. 3D triangle missing. Embedded also missing.
 end
 
-default_refshape(t::Type{C}) where {C <: Ferrite.AbstractCell} = typeof(Ferrite.default_interpolation(t)).parameters[2]
+default_refshape(t::Type{C}) where {C <: Ferrite.AbstractCell} = typeof(Ferrite.default_interpolation(t)).parameters[1]
 
 end
 
@@ -18,7 +18,7 @@ module FerriteAssemblyHelper
 using Ferrite
 
 # Minimal Ritz-Galerkin type local assembly loop.
-function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues::CellValues{dim,T,refshape}, f_shape, f_test, op) where {dim,T,refshape}
+function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues::CellValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, f_test, op) where {dim}
     n_basefuncs = getnbasefunctions(cellvalues)
 
     Ke = zeros(n_basefuncs, n_basefuncs)
@@ -40,7 +40,7 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
     Ke
 end
 
-function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues::FaceValues{dim,T,refshape}, f_shape, f_test, op) where {dim,T,refshape}
+function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, f_test, op) where {dim}
     n_basefuncs = getnbasefunctions(facevalues)
 
     f = zeros(n_basefuncs)
@@ -66,10 +66,9 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
 end
 
 # Minimal Petrov-Galerkin type local assembly loop. We assume that both function spaces share the same integration rule. Test is applied from the left.
-function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues_shape::CellValues{dim,T,refshape}, f_shape, cellvalues_test::CellValues{dim,T,refshape}, f_test, op) where {dim,T,refshape}
+function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues_shape::CellValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, cellvalues_test::CellValues{<: Ferrite.InterpolationByDim{dim}}, f_test, op) where {dim}
     n_basefuncs_shape = getnbasefunctions(cellvalues_shape)
     n_basefuncs_test = getnbasefunctions(cellvalues_test)
-
     Ke = zeros(n_basefuncs_test, n_basefuncs_shape)
 
     #implicit assumption: Same geometry!
@@ -95,7 +94,7 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     Ke
 end
 
-function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues_shape::FaceValues{dim,T,refshape}, f_shape, facevalues_test::FaceValues{dim,T,refshape}, f_test, op) where {dim,T,refshape}
+function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, facevalues_shape::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_shape, facevalues_test::FaceValues{<: Ferrite.InterpolationByDim{dim}}, f_test, op) where {dim}
     n_basefuncs_shape = getnbasefunctions(facevalues_shape)
     n_basefuncs_test = getnbasefunctions(facevalues_test)
 


### PR DESCRIPTION
Relates to #722
Main changes are:

- `(Cell/Face)(Scalar/Vector)Values` -> `(Cell/Face)Values` 
- Remove `spatial_dim` from interpolations
- Using `FaceQuadratureRule` for `FaceValues`
- `(Cell/Face)Values{dim,T,refshape}` -> `(Cell/Face)Values{<: Ferrite.InterpolationByDim{dim}}`
- FieldHandler -> SubDofHandler