### PR TITLE
Add changelog entries for the upcoming release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docs/src/examples/
 docs/src/tutorials/
 docs/src/howto/
 docs/src/gallery/
+docs/src/changelog.md
 *.DS_Store
 /Manifest.toml
 /test/coverage/Manifest.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,389 @@
-# Ferrite.jl changelog
+# Ferrite changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - Work in progress, release date TBD
+
+Ferrite version 1.0 is a relatively large release, with a lot of new features, improvements,
+deprecations and some removals. These changes are made to make the code base more consistent
+and more suitable for future improvements. With this 1.0 release we are aiming for long time
+stability, and there is no breaking release 2.0 on the horizon.
+
+Unfortunately this means that code written for Ferrite version 0.3 will have to be updated.
+All changes, with upgrade paths, are listed in the sections below. Since these sections
+include a lot of other information as well (new features, internal changes, ...) there is
+also a dedicated section about [Upgrading code from Ferrite 0.3 to
+1.0](#upgrading-code-from-ferrite-03-to-10) which include the most common changes that are
+required. In addition, in all cases where possible, you will be presented with a descriptive
+error message telling you what needs to change.
+
+### Upgrading code from Ferrite 0.3 to 1.0
+
+This section give a short overview of the most common required changes. More details and
+motivation are included in the following sections (with links to issues/pull request for
+more discussion).
+
+- **Interpolations**: remove the first parameter (the reference dimension) and use new
+  reference shapes.
+
+  Examples:
+  ```diff
+  # Linear Lagrange interpolation for a line
+  - Lagrange{1, RefCube, 1}()
+  + Lagrange{RefLine, 1}()
+
+  # Linear Lagrange interpolation for a quadrilateral
+  - Lagrange{2, RefCube, 1}()
+  + Lagrange{RefQuadrilateral, 1}()
+
+  # Quadratic Lagrange interpolation for a triangle
+  - Lagrange{2, RefTetrahedron, 2}()
+  + Lagrange{RefTriangle, 2}()
+  ```
+
+  For vector valued problems it is now required to explicitly vectorize the interpolation
+  using the new `VectorizedInterpolation`. This is required when passing the interpolation
+  to `CellValues` and when adding fields to the `DofHandler` using `add!`. In both of these
+  places the interpolation was implicitly vectorized in Ferrite 0.3.
+
+  Examples:
+  ```julia
+  # Linear Lagrange interpolation for a vector problem on the triangle (vector dimension
+  # same as the reference dimension)
+  ip_scalar = Lagrange{RefTriangle, 1}()
+  ip_vector = ip_scalar ^ 2 # or VectorizedInterpolation{2}(ip_scalar)
+  ```
+
+- **Quadrature**: remove the first parameter (the reference dimension) and use new reference
+  shapes.
+
+  Examples:
+  ```diff
+  # Quadrature for a line
+  - QuadratureRule{1, RefCube}(quadrature_order)
+  + QuadratureRule{RefLine}(quadrature_order)
+
+  # Quadrature for a quadrilateral
+  - QuadratureRule{2, RefCube}(quadrature_order)
+  + QuadratureRule{RefQuadrilateral}(quadrature_order)
+
+  # Quadrature for a tetrahedron
+  - QuadratureRule{3, RefTetrahedron}(quadrature_order)
+  + QuadratureRule{RefTetrahedron}(quadrature_order)
+  ```
+
+- **Quadrature for face integration (FaceValues)**: replace `QuadratureRule{dim-1,
+  reference_shape}(quadrature_order)` with
+  `FaceQuadratureRule{reference_shape}(quadrature_order)`.
+
+  Examples:
+  ```diff
+  # Quadrature for the faces of a quadrilateral
+  - QuadratureRule{1, RefCube}(quadrature_order)
+  + FaceQuadratureRule{RefQuadrilateral}(quadrature_order)
+
+  # Quadrature for the faces of a triangle
+  - QuadratureRule{1, RefTetrahedron}(quadrature_order)
+  + FaceQuadratureRule{RefTriangle}(quadrature_order)
+
+  # Quadrature for the faces of a hexhedron
+  - QuadratureRule{2, RefCube}(quadrature_order)
+  + FaceQuadratureRule{RefHexahedron}(quadrature_order)
+  ```
+
+- **CellValues**: replace usage of `CellScalarValues` *and* `CellVectorValues` with
+  `CellValues`. For vector valued problems the interpolation passed to `CellValues` should
+  be vectorized to a `VectorizedInterpolation` (see above).
+
+  Examples:
+  ```diff
+  # CellValues for a scalar problem with triangle elements
+  - qr = QuadratureRule{2, RefTetrahedron}(quadrature_order)
+  - ip = Lagrange{2, RefTetrahedron, 1}()
+  - cv = CellScalarValues(qr, ip)
+  + qr = QuadratureRule{RefTriangle}(quadrature_order)
+  + ip = Lagrange{RefTriangle, 1}()
+  + cv = CellValues(qr, ip)
+
+  # CellValues for a vector problem with hexahedronal elements
+  - qr = QuadratureRule{3, RefCube}(quadrature_order)
+  - ip = Lagrange{3, RefCube, 1}()
+  - cv = CellVectorValues(qr, ip)
+  + qr = QuadratureRule{RefHexahedron}(quadrature_order)
+  + ip = Lagrange{RefHexahedron, 1}() ^ 3
+  + cv = CellValues(qr, ip)
+  ```
+
+  If you use `CellScalarValues` or `CellVectorValues` in method signature you must replace
+  them with `CellValues`. Note that the type parameters are different.
+
+  Examples:
+  ```diff
+  - function do_something(cvs::CellScalarValues, cvv::CellVectorValues)
+  + function do_something(cvs::CellValues, cvv::CellValues)
+  ```
+
+  The default geometric interpolation have changed from the function interpolation to always
+  use linear Lagrange interpolation. If you use linear elements in the grid, and a higher
+  order interpolation for the function you can now rely on the new default:
+  ```diff
+  qr = QuadratureRule(...)
+  - ip_function = Lagrange{2, RefTetrahedron, 2}()
+  - ip_geometry = Lagrange{2, RefTetrahedron, 1}()
+  - cv = CellScalarValues(qr, ip_function, ip_geometry)
+  + ip_function = Lagrange{2, RefTetrahedron, 2}()
+  + cv = CellValues(qr, ip_function)
+  ```
+  and if you have quadratic (or higher order) elements in the grid you must now pass the
+  corresponding interpolation to the constructor:
+  ```diff
+  qr = QuadratureRule(...)
+  - ip_function = Lagrange{2, RefTetrahedron, 2}()
+  - cv = CellScalarValues(qr, ip_function)
+  + ip_function = Lagrange{2, RefTetrahedron, 2}()
+  + ip_geometry = Lagrange{2, RefTetrahedron, 1}()
+  + cv = CellValues(qr, ip_function, ip_geometry)
+  ```
+
+- **FaceValues**: replace usage of `FaceScalarValues` *and* `FaceVectorValues` with
+  `FaceValues`. For vector valued problems the interpolation passed to `CellValues` should
+  be vectorized to a `VectorizedInterpolation` (see above). The input quadrature rule should
+  be a `FaceQuadratureRule` instead of a `QuadratureRule`.
+
+  Examples:
+  ```diff
+  # FaceValues for a scalar problem with triangle elements
+  - qr = QuadratureRule{1, RefTetrahedron}(quadrature_order)
+  - ip = Lagrange{2, RefTetrahedron, 1}()
+  - cv = FaceScalarValues(qr, ip)
+  + qr = FaceQuadratureRule{RefTriangle}(quadrature_order)
+  + ip = Lagrange{RefTriangle, 1}()
+  + cv = FaceValues(qr, ip)
+
+  # FaceValues for a vector problem with hexahedronal elements
+  - qr = QuadratureRule{2, RefCube}(quadrature_order)
+  - ip = Lagrange{3, RefCube, 1}()
+  - cv = FaceVectorValues(qr, ip)
+  + qr = FaceQuadratureRule{RefHexahedron}(quadrature_order)
+  + ip = Lagrange{RefHexahedron, 1}() ^ 3
+  + cv = FaceValues(qr, ip)
+  ```
+
+- **DofHandler construction**: it is now required to pass the interpolation explicitly when
+  adding new fields using `add!` (previously it was optional, defaulting to the default
+  interpolation of the elements in the grid). For vector-valued fields the interpolation
+  should be vectorized, instead of passing the number of components to `add!` as an integer.
+
+  Examples:
+  ```diff
+  dh = DofHandler(grid) # grid with triangles
+
+  # Vector field :u
+  - add!(dh, :u, 2)
+  + add!(dh, :u, Lagrange{RefTriangle, 1}()^2)
+
+  # Scalar field :p
+  - add!(dh, :u, 1)
+  + add!(dh, :u, Lagrange{RefTriangle, 1}())
+  ```
+
 ### Added
-- `DofHandler` now supports fields on subdomains and mixed grids. ([#667][github-667])
-- Support for embedded elements in `CellValues`. ([#651][github-651])
-- Support for vectorized interpolations with dimension different from the spatial 
-  dimension in `CellValues`. ([#651][github-651])
-- All keyword arguments supported by `WriteVTK.jl` can be given to `vtk_grid` (only `compress` earlier) ([#687][github-687])
+
+- The `DofHandler` now support selectively adding fields on sub-domains (rather than the
+  full domain). This new functionality is included with the new `SubDofHandler` struct,
+  which, as the name suggest, is a `DofHandler` for a subdomain. ([#624][github-624],
+  [#667][github-667], [#735][github-735])
+
+- New reference shape structs `RefLine`, `RefTriangle`, `RefQuadrilateral`,
+  `RefTetrahedron`, `RefHexahedron`, and `RefPrism` have been added. These encode the
+  reference dimension, and will thus replace the old reference shapes for which it was
+  necessary to always pair with an explicit dimension (i.e. `RefLine` replaces `(RefCube,
+  1)`, `RefTriangle` replaces `(RefTetrahedron, 2)`, etc.). For writing "dimension
+  independent code" it is possible to use `Ferrite.RefHypercube{dim}` and
+  `Ferrite.RefSimplex{dim}`. ([#679][github-679])
+
+- New methods for adding entitysets that are located on the boundary of the grid:
+  `addboundaryfaceset!`, `addboundaryedgeset!`, and `addboundaryvertexset!`. These work
+  similar to `addfaceset!`, `addedgeset!`, and `addvertexset!`, but filters out all
+  instances not on the boundary (this can be used to avoid accidental inclusion of internal
+  entities in sets used for boundary conditions, for example). ([#606][github-606])
+
+- New interpolation `VectorizedInterpolation` which vectorizes scalar interpolations for
+  vector-valued problems. A `VectorizedInterpolation` is created from a (scalar)
+  interpolation `ip` using either `ip ^ dim` or `VectorizedInterpolation{dim}(ip)`. For
+  convenience, the method `VectorizedInterpolation(ip)` vectorizes the interpolation to the
+  reference dimension of the interpolation. ([#694][github-694], [#736][github-736])
+
+- New (scalar) interpolation `Lagrange{RefQuadrilateral, 3}()`, i.e. third order Lagrange
+  interpolation for 2D quadrilaterals. ([#701][github-701], [#731][github-731])
+
+- `CellValues` now support embedded elements. Specifically you can now embed elements with
+  reference dimension 1 into spatial dimension 2 or 3, and elements with reference dimension
+  2 in to spatial dimension 3. ([#651][github-651])
+
+- `CellValues` now support (vector) interpolations with dimension different from the spatial
+  dimension. ([#651][github-651])
+
+- `FaceQuadratureRule` have been added and should be used for `FaceValues`. A
+  `FaceQuadratureRule` for integration of the faces of e.g. a triangle can be constructed by
+  `FaceQuadratureRule{RefTriangle}(order)` (similar to how `QuadratureRule` is constructed).
+  ([#716][github-716])
+
+- New methods `shape_value(::Interpolation, ξ::Vec, i::Int)` and
+  `shape_gradient(::Interpolation, ξ::Vec, i::Int)` for evaluating the value/gradient of the
+  `i`th shape function of an interpolation in local reference coordinate `ξ`. Note that
+  these methods return the value/gradient wrt. the reference coordinate `ξ`, whereas the
+  corresponding methods for `CellValues` etc return the value/gradient wrt the spatial
+  coordinate `x`. ([#721][github-721])
+
+- `FaceIterator` and `FaceCache` have been added. These work similarly to `CellIterator` and
+  `CellCache` but are used to iterate over (boundary) face sets instead. These simplify
+  boundary integrals in general, and in particular Neumann boundary conditions are more
+  convenient to implement now that you can loop directly over the face set instead of
+  checking all faces of a cell inside the element routine. ([#495][github-495])
+
+- The `ConstraintHandler` now support adding Dirichlet boundary conditions on discontinuous
+  interpolations. ([#729][github-729])
+
+- All keyword arguments to `vtk_grid` are now passed on to `WriteVTK.vtk_grid` (only
+  `compress` was supported earlier). ([#687][github-687])
+
+- `collect_periodic_faces` now have a keyword argument `tol` that can be used to relax the
+  default tolerance when necessary. ([#749][github-749])
+
+- VTK export now work with `QuadraticHexahedron` elements. ([#714][github-714])
+
+### Changed
+
+- The `AbstractCell` interface has been reworked. This change should not affect user code,
+  but may in some cases be relevant for code parsing external mesh files. In particular, the
+  generic `Cell` struct have been removed in favor of concrete cell implementations (`Line`,
+  `Triangle`, ...). ([#679][github-679], [#712][github-712])
+
+  **To upgrade** replace any usage of `Cell{...}(...)` with calls to the concrete
+  implementations.
+
+- The default geometric mapping in `CellValues` and `FaceValues` have changed. The new
+  default is to always use `Lagrange{refshape, 1}()`, i.e. linear Lagrange polynomials, for
+  the geometric interpolation. Previously, the function interpolation was (re) used also for
+  the geometry interpolation. ([#695][github-695])
+
+  **To upgrade**, if you relied on the previous default, simply pass the function
+  interpolation also as the third argument (the geometric interpolation).
+
+- All interpolations are now categorized as either scalar or vector interpolations. All
+  (previously) existing interpolations are scalar. (Scalar) interpolations must now be
+  explicitly vectorized, using the new `VectorizedInterpolation`, when used for vector
+  problems. (Previously implicit vectorization happened in the `CellValues` constructor, and
+  when adding fields to the `DofHandler`). ([#694][github-694])
+
+- It is now required to explicitly pass the interpolation to the `DofHandler` when adding a
+  new field using `add!`. For vector fields the interpolation should be vectorized, instead
+  of passing number of components as an integer. ([#694][github-694])
+
+  **To upgrade** don't pass the dimension as an integer, and pass the interpolation
+  explicitly. See more details in [Upgrading code from Ferrite 0.3 to
+  1.0](#upgrading-code-from-ferrite-03-to-10).
+
+- `Interpolation`s should now be constructed using the new reference shapes. Since the new
+  reference shapes encode the reference dimension the first type parameter of interpolations
+  have been removed. ([#711][github-711])
+  **To upgrade** replace e.g. `Lagrange{1, RefCube, 1}()` with `Lagrange{RefLine, 1}()`, and
+  `Lagrange{2, RefTetrahedron, 1}()` with `Lagrange{RefTriangle, 1}()`, etc.
+
+- `QuadratureRule`s should now be constructed using the new reference shapes. Since the new
+  reference shapes encode the reference dimension the first type parameter of
+  `QuadratureRule` have been removed. ([#711][github-711], [#716][github-716])
+  **To upgrade** replace e.g. `QuadratureRule{1, RefCube}(order)` with
+  `QuadratureRule{RefLine}(order)`, and `QuadratureRule{2, RefTetrahedron}(1)` with
+  `Lagrange{RefTriangle}(order)`, etc.
+
+- `CellScalarValues` and `CellVectorValues` have been merged into `CellValues`,
+  `FaceScalarValues` and `FaceVectorValues` have been merged into `FaceValues`, and
+  `PointScalarValues` and `PointVectorValues` have been merged into `PointValues`. The
+  differentiation between scalar and vector have thus been moved to the interpolation (see
+  above). Note that previously `CellValues`, `FaceValues`, and `PointValues` where abstract
+  types, but they are now concrete implementations with *different type parameters*.
+  ([#708][github-708])
+  **To upgrade**, for scalar problems, it is enough to replace `CellScalarValues` with
+  `CellValues`, `FaceScalarValues` with `FaceValues` and `PointScalarValues` with
+  `PointValues`, respectively. For vector problems, make sure to vectorize the interpolation
+  (see above) and then replace `CellVectorValues` with `CellValues`, `FaceVectorValues` with
+  `FaceValues`, and `PointVectorValues` with `PointValues`.
+
+- The quadrature rule passed to `FaceValues` should now be of type `FaceQuadratureRule`
+  rather than of type `QuadratureRule`. ([#716][github-716])
+  **To upgrade** replace the quadrature rule passed to `FaceValues` with a
+  `FaceQuadratureRule`.
+
+### Deprecated
+
+- The rarely (if ever) used methods of `function_value`, `function_gradient`,
+  `function_divergence`, and `function_curl` taking *vectorized dof values* as in put have
+  been deprecated. ([#698][github-698])
+
+- The function `reshape_to_nodes` have been deprecated in favor of `evaluate_at_grid_nodes`.
+  ([#703][github-703])
+
+- `start_assemble(f, K)` have been deprecated in favor of the "canonical" `start_assemble(K,
+  f)`. ([#707][github-707])
 
 ### Removed
-- **BREAKING**: `MixedDofHandler` has been renamed to `DofHandler`. Update by replacing 
-`MixedDofHandler` to `DofHandler`. ([#667][github-667])
+
+- `MixedDofHandler` + `FieldHandler` have been removed in favor of `DofHandler` +
+  `SubDofHandler`. Note that the syntax has changed, and note that `SubDofHandler` is much
+  more capable compared to `FieldHandler`. Previously it was often required to pass both the
+  `MixedDofHandler` and the `FieldHandler` to e.g. the assembly routine, but now it is
+  enough to pass the `SubDofHandler` since it can be used for e.g. DoF queries etc.
+  ([#624][github-624], [#667][github-667], [#735][github-735])
+
+- Some old methods to construct the `L2Projector` have been removed after being deprecated
+  for several releases. ([#697][github-697])
+
+- The option `project_to_nodes` have been removed from `project(::L2Projector, ...)`. The
+  returned values are now always ordered according to the projectors internal `DofHandler`.
+  ([#699][github-699])
+
+- The function `compute_vertex_values` have been removed. ([#700][github-700])
+
+### Fixed
+
+- Topology construction have been generalized to, in particular, fix construction for 1D and
+  for wedge elements. ([#641][github-641], [#670][github-670], [#684][github-684])
 
 ### Other improvements
-- **BREAKING**: All `CellValues` have a finer granularity on the different types of
-  dimensions used. Custom `CellValues` and dispatches on their type parameters must be 
-  updated to respect the new type. ([#651][github-651])
+
+- Documentation:
+  - The documentation is now structured according to the Diataxis framework. There is now
+    also clear separation between tutorials (for teaching) and code gallery (for showing
+    off). ([#737][github-737], [#756][github-756])
+  - New section in the developer documentation that describes the (new) reference shapes and
+    their numbering scheme. ([#688][github-688])
+
+- Performance:
+  - `Ferrite.transform!(grid, f)` (for transforming the node coordinates in the `grid`
+    according to a function `f`) is now faster and allocates less. ([#675][github-675])
+  - Slight performance improvement in construction of `PointEvalHandler` (faster reverse
+    coordinate lookup). ([#719][github-719])
+  - Various performance improvements to topology construction. ([#753][github-753])
+
+- Internal improvements:
+  - The dof distribution interface have been updated to support higher order elements
+    (future work). ([#627][github-627], [#732][github-732], [#733][github-733])
+  - The `AbstractGrid` and `AbstractDofHandler` interfaces are now used more consistently
+    internally. This will help with the implementation of distributed grids and DofHandlers.
+    ([#655][github-655])
+  - VTK export now uses the (geometric) interpolation directly when evaluating the finite
+    element field instead of trying to work backwards how DoFs map to nodes.
+    ([#703][github-703])
+  - Improved bounds checking in `assemble!`. ([#706][github-706])
+  - Internal methods `Ferrite.value` and `Ferrite.derivative` for computing the
+    value/gradient of *all* shape functions have been removed. ([#720][github-720])
+  - `Ferrite.create_incidence_matrix` now work with any `AbstractGrid` (not just `Grid`).
+    ([#726][github-726])
 
 ## [0.3.14] - 2023-04-03
 ### Added
@@ -294,8 +657,8 @@ poking into Ferrite internals:
 - Support for new interpolation types: `DiscontinuousLagrange`, `BubbleEnrichedLagrange`,
   and `CrouzeixRaviart`. ([#352][github-352], [#392][github-392])
 ### Changed
-- Julia version 1.0 is no longer supported for Ferrite versions >= 0.3.2. Use Julia version
-  >= 1.6. ([#385][github-385])
+- Julia version 1.0 is no longer supported for Ferrite versions >= 0.3.2.
+  Use Julia version >= 1.6. ([#385][github-385])
 - Quadrature data for L2 projection can now be given as a matrix of size "number of
   elements" x "number of quadrature points per element". ([#386][github-386])
 - Projected values from L2 projection can now be exported directly to VTK.
@@ -307,15 +670,36 @@ poking into Ferrite internals:
 - Exporting tensors to VTK now use correct names for the components. ([#406][github-406])
 
 
-[github-352]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/352
+<!-- Release links -->
+
+[Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v1.3.14...HEAD
+[1.0.0]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.14...HEAD
+[0.3.14]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.13...v0.3.14
+[0.3.13]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.12...v0.3.13
+[0.3.12]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.11...v0.3.12
+[0.3.11]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.10...v0.3.11
+[0.3.10]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.9...v0.3.10
+[0.3.9]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.8...v0.3.9
+[0.3.8]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.7...v0.3.8
+[0.3.7]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.6...v0.3.7
+[0.3.6]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.5...v0.3.6
+[0.3.5]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.1...v0.3.2
+
+
+<!-- GitHub pull request/issue links -->
+
+[github-352]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/352
 [github-363]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/363
-[github-378]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/378
+[github-378]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/378
 [github-385]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/385
 [github-386]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/386
 [github-388]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/388
 [github-390]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/390
 [github-392]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/392
-[github-393]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/393
+[github-393]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/393
 [github-401]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/401
 [github-402]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/402
 [github-404]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/404
@@ -327,8 +711,8 @@ poking into Ferrite internals:
 [github-428]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/428
 [github-431]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/431
 [github-436]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/436
-[github-444]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/444
-[github-453]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/453
+[github-444]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/444
+[github-453]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/453
 [github-455]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/455
 [github-456]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/456
 [github-458]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/458
@@ -338,7 +722,6 @@ poking into Ferrite internals:
 [github-462]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/462
 [github-464]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/464
 [github-465]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/465
-[github-466]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/466
 [github-466]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/466
 [github-467]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/467
 [github-469]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/469
@@ -351,6 +734,7 @@ poking into Ferrite internals:
 [github-487]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/487
 [github-489]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/489
 [github-494]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/494
+[github-495]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/495
 [github-496]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/496
 [github-500]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/500
 [github-501]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/501
@@ -360,13 +744,13 @@ poking into Ferrite internals:
 [github-509]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/509
 [github-512]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/512
 [github-514]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/514
-[github-518]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/518
-[github-520]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/520
+[github-518]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/518
+[github-520]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/520
 [github-523]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/523
 [github-524]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/524
 [github-528]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/528
 [github-529]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/529
-[github-530]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/530
+[github-530]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/530
 [github-531]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/531
 [github-532]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/532
 [github-533]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/533
@@ -398,12 +782,12 @@ poking into Ferrite internals:
 [github-577]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/577
 [github-578]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/578
 [github-581]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/581
-[github-582]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/582
+[github-582]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/582
 [github-583]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/583
 [github-588]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/588
 [github-591]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/591
 [github-592]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/592
-[github-593]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/593
+[github-593]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/593
 [github-594]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/594
 [github-598]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/598
 [github-599]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/599
@@ -411,13 +795,17 @@ poking into Ferrite internals:
 [github-601]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/601
 [github-602]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/602
 [github-604]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/604
+[github-606]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/606
 [github-611]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/611
 [github-614]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/614
 [github-621]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/621
-[github-629]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/629
+[github-624]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/624
+[github-627]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/627
+[github-629]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/629
 [github-633]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/633
 [github-637]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/637
 [github-639]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/639
+[github-641]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/641
 [github-642]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/642
 [github-643]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/643
 [github-645]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/645
@@ -425,24 +813,44 @@ poking into Ferrite internals:
 [github-650]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/650
 [github-651]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/651
 [github-653]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/653
+[github-655]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/655
 [github-656]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/656
 [github-658]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/658
 [github-659]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/659
 [github-660]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/660
 [github-667]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/667
+[github-670]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/670
+[github-675]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/675
+[github-679]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/679
+[github-684]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/684
 [github-687]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/687
-
-[Unreleased]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.14...HEAD
-[0.3.14]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.13...v0.3.14
-[0.3.13]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.12...v0.3.13
-[0.3.12]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.11...v0.3.12
-[0.3.11]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.10...v0.3.11
-[0.3.10]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.9...v0.3.10
-[0.3.9]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.8...v0.3.9
-[0.3.8]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.7...v0.3.8
-[0.3.7]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.6...v0.3.7
-[0.3.6]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.5...v0.3.6
-[0.3.5]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.4...v0.3.5
-[0.3.4]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.3...v0.3.4
-[0.3.3]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.2...v0.3.3
-[0.3.2]: https://github.com/Ferrite-FEM/Ferrite.jl/compare/v0.3.1...v0.3.2
+[github-688]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/688
+[github-694]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/694
+[github-695]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/695
+[github-697]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/697
+[github-698]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/698
+[github-699]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/699
+[github-700]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/700
+[github-701]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/701
+[github-703]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/703
+[github-706]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/706
+[github-707]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/707
+[github-708]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/708
+[github-711]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/711
+[github-712]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/712
+[github-714]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/714
+[github-716]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/716
+[github-719]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/719
+[github-720]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/720
+[github-721]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/721
+[github-726]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/726
+[github-729]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/729
+[github-731]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/731
+[github-732]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/732
+[github-733]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/733
+[github-735]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/735
+[github-736]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/736
+[github-737]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/737
+[github-749]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/749
+[github-753]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/753
+[github-756]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/756

--- a/docs/changelog.jl
+++ b/docs/changelog.jl
@@ -1,0 +1,53 @@
+const changelogfile = joinpath(@__DIR__, "../CHANGELOG.md")
+
+function create_documenter_changelog()
+    content = read(changelogfile, String)
+    # Replace release headers
+    content = replace(content, "## [Unreleased]" => "## Changes yet to be released")
+    content = replace(content, r"## \[(\d+\.\d+\.\d+)\]" => s"## Version \1")
+    # Replace [#XXX][github-XXX] with the proper links
+    content = replace(content, r"(\[#(\d+)\])\[github-\d+\]" => s"\1(https://github.com/Ferrite-FEM/Ferrite.jl/pull/\2)")
+    # Remove all links at the bottom
+    content = replace(content, r"^<!-- Release links -->.*$"ms => "")
+    # Change some GitHub in-readme links to documenter links
+    content = replace(content, "(#upgrading-code-from-ferrite-03-to-10)" => "(@ref)")
+    # Add a contents block
+    last_sentence_before_content = "adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
+    contents_block = """
+    ```@contents
+    Pages = ["changelog.md"]
+    Depth = 2:2
+    ```
+    """
+    content = replace(content, last_sentence_before_content => last_sentence_before_content * "\n\n" * contents_block)
+    # Remove trailing lines
+    content = strip(content) * "\n"
+    # Write out the content
+    write(joinpath(@__DIR__, "src/changelog.md"), content)
+    return nothing
+end
+
+function fix_links()
+    content = read(changelogfile, String)
+    text = split(content, "<!-- Release links -->")[1]
+    # Look for links of the form: [#XXX][github-XXX]
+    github_links = Dict{String, String}()
+    r = r"\[#(\d+)\](\[github-(\d+)\])"
+    for m in eachmatch(r, text)
+        @assert m[1] == m[3]
+        # Always use /pull/ since it will redirect to /issues/ if it is an issue
+        url = "https://github.com/Ferrite-FEM/Ferrite.jl/pull/$(m[1])"
+        github_links[m[2]] = url
+    end
+    io = IOBuffer()
+    print(io, "<!-- GitHub pull request/issue links -->\n\n")
+    for l in sort!(collect(github_links); by = first)
+        println(io, l[1], ": ", l[2])
+    end
+    content = replace(content, r"<!-- GitHub pull request/issue links -->.*$"ms => String(take!(io)))
+    write(changelogfile, content)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    fix_links()
+end

--- a/docs/liveserver.jl
+++ b/docs/liveserver.jl
@@ -31,9 +31,14 @@ LiveServer.servedocs(;
     ],
     include_files = [
         joinpath(repo_root, "docs/generate.jl"),
+        joinpath(repo_root, "docs/changelog.jl"),
+        joinpath(repo_root, "CHANGELOG.md"),
         # Watch the index files in the skip_dirs folders
         joinpath(repo_root, "docs/src/tutorials/index.md"),
         joinpath(repo_root, "docs/src/howto/index.md"),
         joinpath(repo_root, "docs/src/gallery/index.md"),
+    ],
+    skip_files = [
+        joinpath(repo_root, "docs/src/changelog.md"),
     ],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,10 @@ const is_ci = haskey(ENV, "GITHUB_ACTIONS")
 # Generate tutorials and how-to guides
 include("generate.jl")
 
+# Changelog
+include("changelog.jl")
+create_documenter_changelog()
+
 # Build documentation.
 @timeit dto "makedocs" makedocs(
     format = Documenter.HTML(
@@ -31,6 +35,7 @@ include("generate.jl")
     draft = liveserver,
     pages = Any[
         "Home" => "index.md",
+        # hide("Changelog" => "changelog.md"),
         "Tutorials" => [
             "Tutorials overview" => "tutorials/index.md",
             "tutorials/heat_equation.md",


### PR DESCRIPTION
This patch adds changelogs for everything that was missing. This patch also adds infrastructure to build a Documenter-friendly version of the changelog that is rendered in the HTML output.