### PR TITLE
Various changes to FaceCache/InterfaceCache/InterfaceIterator

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -197,7 +197,7 @@ end
 function reinit!(cache::InterfaceCache, face_a::FaceIndex, face_b::FaceIndex)
     reinit!(cache.a, face_a)
     reinit!(cache.b, face_b)
-    resize!(cache.dofs, length(cache.a.dofs) + length(cache.b.dofs))
+    resize!(cache.dofs, length(celldofs(cache.a)) + length(celldofs(cache.b)))
     for (i, d) in pairs(cache.a.dofs)
         cache.dofs[i] = d
     end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -132,9 +132,13 @@ See also [`FaceIterator`](@ref).
 """
 struct FaceCache{CC<:CellCache}
     cc::CC  # const for julia > 1.8
+    dofs::Vector{Int} # aliasing cc.dofs
     current_faceid::ScalarWrapper{Int}
 end
-FaceCache(args...) = FaceCache(CellCache(args...), ScalarWrapper(0))
+function FaceCache(args...)
+    cc = CellCache(args...)
+    FaceCache(cc, cc.dofs, ScalarWrapper(0))
+end
 
 function reinit!(fc::FaceCache, face::FaceIndex)
     cellid, faceid = face
@@ -146,8 +150,8 @@ end
 # Delegate methods to the cell cache
 for op = (:getnodes, :get_cell_coordinates, :cellid, :celldofs)
     @eval begin
-        function Ferrite.$op(fc::FaceCache, args...)
-            return Ferrite.$op(fc.cc, args...)
+        function $op(fc::FaceCache, args...)
+            return $op(fc.cc, args...)
         end
     end
 end
@@ -175,7 +179,7 @@ interface. The cache is updated for a new cell by calling `reinit!(cache, face_a
 **Methods with `InterfaceCache`**
  - `reinit!(cache::InterfaceCache, face_a::FaceIndex, face_b::FaceIndex)`: reinitialize the cache for a new interface
  - `interfacedofs(ic)`: get the global dof ids of the interface
- 
+
 See also [`InterfaceIterator`](@ref).
 """
 struct InterfaceCache{FC<:FaceCache}
@@ -193,12 +197,12 @@ end
 function reinit!(cache::InterfaceCache, face_a::FaceIndex, face_b::FaceIndex)
     reinit!(cache.a, face_a)
     reinit!(cache.b, face_b)
-    resize!(cache.dofs, length(cache.a.cc.dofs) + length(cache.b.cc.dofs))
-    for (i, d) in pairs(cache.a.cc.dofs)
+    resize!(cache.dofs, length(cache.a.dofs) + length(cache.b.dofs))
+    for (i, d) in pairs(cache.a.dofs)
         cache.dofs[i] = d
     end
-    for (i, d) in pairs(cache.b.cc.dofs)
-        cache.dofs[i + length(cache.a.cc.dofs)] = d
+    for (i, d) in pairs(cache.b.dofs)
+        cache.dofs[i + length(cache.a.dofs)] = d
     end
     return cache
 end
@@ -313,7 +317,7 @@ end
 """
     InterfaceIterator(grid::Grid, [topology::ExclusiveTopology])
     InterfaceIterator(dh::AbstractDofHandler, [topology::ExclusiveTopology])
-    
+
 Create an `InterfaceIterator` to conveniently iterate over all the interfaces in a
 grid. The elements of the iterator are [`InterfaceCache`](@ref)s which are properly
 `reinit!`ialized. See [`InterfaceCache`](@ref) for more details.
@@ -338,35 +342,35 @@ end
     `InterfaceIterator` is stateful and should not be used for things other than `for`-looping
     (e.g. broadcasting over, or collecting the iterator may yield unexpected results).
 """
-struct InterfaceIterator{Cache<:InterfaceCache}
-    cache::Cache
-    grid::Grid
+struct InterfaceIterator{IC <: InterfaceCache, G <: Grid}
+    cache::IC
+    grid::G
     topology::ExclusiveTopology
 end
 
 function InterfaceIterator(gridordh::Union{Grid,AbstractDofHandler},
-                      topology::ExclusiveTopology = ExclusiveTopology(gridordh))
+        topology::ExclusiveTopology = ExclusiveTopology(gridordh isa Grid ? gridordh : get_grid(gridordh)))
     grid = gridordh isa Grid ? gridordh : get_grid(gridordh)
     return InterfaceIterator(InterfaceCache(gridordh), grid, topology)
 end
 
 # Iterator interface
-function Base.iterate(ii::InterfaceIterator, state_in...)
-    state = state_in
+function Base.iterate(ii::InterfaceIterator, state...)
     grid_dim = getdim(ii.grid)
-    neighborhood = grid_dim == 1 ? ii.topology.vertex_vertex_neighbor : ii.topology.face_face_neighbor 
+    neighborhood = grid_dim == 1 ? ii.topology.vertex_vertex_neighbor : ii.topology.face_face_neighbor
     while true
         it = iterate(faceskeleton(ii.topology, ii.grid), state...)
         it === nothing && return nothing
-        face_a, state_out = it  
+        face_a, state = it
         if isempty(neighborhood[face_a[1], face_a[2]])
-            state = state_out
             continue
         end
-        neighbor = neighborhood[face_a[1], face_a[2]].neighbor_info[]
+        neighbors = neighborhood[face_a[1], face_a[2]].neighbor_info
+        length(neighbors) > 1 && error("multiple neighboring faces not supported yet")
+        neighbor = neighbors[1]
         face_b = grid_dim == 1 ? FaceIndex(neighbor[1], neighbor[2]) : neighbor
         reinit!(ii.cache, face_a, face_b)
-        return (ii.cache, state_out)
+        return (ii.cache, state)
     end
 end
 


### PR DESCRIPTION
In this patch:
 - add a struct field `.dofs` to `FaceCache` that just aliases the underlying `.dofs` field of the `FaceCache`s `CellCache`,
 - fix `InterfaceIterator(::DofHandler)` when not passing the topology,
 - change `iterate(::InterfaceIterator)` to add a check that there is only a single neighboring element.