### PR TITLE
Fix show of Face and Cell values

### DIFF
--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -285,3 +285,11 @@ function reinit!(cv::CellValues{<:Any, N_t, dNdx_t, dNdξ_t}, x::AbstractVector{
     end
     return nothing
 end
+
+function Base.show(io::IO, m::MIME"text/plain", cv::CellValues)
+    println(io, "CellValues with")
+    println(io, "- Quadrature rule with ", getnquadpoints(cv), " points")
+    print(io, "- Function interpolation: "); show(io, m, cv.ip)
+    println(io)
+    print(io, "- Geometric interpolation: "); show(io, m, cv.gip)
+end

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -250,3 +250,16 @@ function checkface(fv::FaceValues, face::Int)
     0 < face <= nfaces(fv) || error("Face index out of range.")
     return nothing
 end
+
+function Base.show(io::IO, m::MIME"text/plain", fv::FaceValues)
+    println(io, "FaceValues with")
+    nqp = getnquadpoints.(fv.qr.face_rules)
+    if all(n==first(nqp) for n in nqp)
+        println(io, "- Quadrature rule with ", first(nqp), " points per face")
+    else
+        println(io, "- Quadrature rule with ", tuple(nqp...), " points on each face")
+    end
+    print(io, "- Function interpolation: "); show(io, m, fv.func_interp)
+    println(io)
+    print(io, "- Geometric interpolation: "); show(io, m, fv.geo_interp)
+end

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -310,7 +310,7 @@ end
 
 @testset "show" begin
     # Just smoke test
-    cv_quad = CellValues(QuadratureRule{RefQuadrilateral}(2)^2, Lagrange{RefQuadrilateral,2}())
+    cv_quad = CellValues(QuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}()^2)
     cv_wedge = CellValues(QuadratureRule{RefPrism}(2), Lagrange{RefPrism,2}())
     show(stdout, MIME"text/plain"(), cv_quad)
     show(stdout, MIME"text/plain"(), cv_wedge)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -310,8 +310,10 @@ end
 
 @testset "show" begin
     # Just smoke test
-    cv = CellValues(QuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}())
-    show(stdout, MIME"text/plain"(), cv)
+    cv_quad = CellValues(QuadratureRule{RefQuadrilateral}(2)^2, Lagrange{RefQuadrilateral,2}())
+    cv_wedge = CellValues(QuadratureRule{RefPrism}(2), Lagrange{RefPrism,2}())
+    show(stdout, MIME"text/plain"(), cv_quad)
+    show(stdout, MIME"text/plain"(), cv_wedge)
 end
 
 end # of testset

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -308,4 +308,10 @@ end
     end
 end
 
+@testset "show" begin
+    # Just smoke test
+    cv = CellValues(QuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}())
+    show(stdout, MIME"text/plain"(), cv)
+end
+
 end # of testset

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -107,4 +107,13 @@ for (scalar_interpol, quad_rule) in (
     end
 end
 
+@testset "show" begin
+    # Just smoke test to make sure show doesn't error. 
+    fv = FaceValues(FaceQuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}())
+    show(stdout, MIME"text/plain"(), fv)
+    fv.qr.face_rules[1] = deepcopy(fv.qr.face_rules[1])
+    push!(Ferrite.getweights(fv.qr.face_rules[1]), 1)
+    show(stdout, MIME"text/plain"(), fv)
+end
+
 end # of testset


### PR DESCRIPTION
For upcoming 1.0, make sure show doesn't fail for face values (closes #752)
Makes output for CellValues consistent with FaceValues. 

Note: Exact output may change later (e.g. if/when we split #764 or similar), this is just to remove bug for the upcoming release. 

Output:
```julia
# Scalar
CellValues with
- Quadrature rule with 4 points
- Function interpolation: Lagrange{RefQuadrilateral, 2}()
- Geometric interpolation: Lagrange{RefQuadrilateral, 1}()

# Vector 
CellValues with
- Quadrature rule with 4 points
- Function interpolation: Lagrange{RefQuadrilateral, 2}()^2
- Geometric interpolation: Lagrange{RefQuadrilateral, 1}()

FaceValues with
- Quadrature rule with 2 points per face
- Function interpolation: Lagrange{RefQuadrilateral, 2}()
- Geometric interpolation: Lagrange{RefQuadrilateral, 1}()

# Different number of quadrature points on each face:
FaceValues with
- Quadrature rule with (3, 2, 2, 2) points on each face
- Function interpolation: Lagrange{RefQuadrilateral, 2}()
- Geometric interpolation: Lagrange{RefQuadrilateral, 1}()
```