### PR TITLE
use replace! instead of aliased map!

### DIFF
--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -451,7 +451,7 @@ n_faces_per_cell(grid::Grid) = nfaces(getcelltype(grid))
 Transform all nodes of the `grid` based on some transformation function `f`.
 """
 function transform_coordinates!(g::Grid, f::Function)
-    map!(n -> Node(f(get_node_coordinate(n))), g.nodes, g.nodes)
+    replace!(n -> Node(f(get_node_coordinate(n))), g.nodes)
     return g
 end
 


### PR DESCRIPTION
I learned on [Slack](https://julialang.slack.com/archives/C6A044SQH/p1691785439327919?thread_ts=1691784875.039309&cid=C6A044SQH) yesterday that `map!(f, x, x)` isn't guaranteed safe due to aliasing, and just happens to work at the moment. 

My quick benchmarks show no measurable difference in performance. 
