### PR TITLE
Fix some Documenter link warnings

### DIFF
--- a/docs/src/gallery/index.md
+++ b/docs/src/gallery/index.md
@@ -11,7 +11,7 @@ the wild".
 
 ---
 
-#### [Helmholtz equation](../helmholtz/)
+#### [Helmholtz equation](helmholtz.md)
 
 Solves the Helmholtz equation on the unit square using a combination of Dirichlet and
 Neumann boundary conditions and the method of manufactured solutions.
@@ -20,18 +20,18 @@ Neumann boundary conditions and the method of manufactured solutions.
 
 ---
 
-#### [Nearly incompressible hyperelasticity](../quasi_incompressible_hyperelasticity/)
+#### [Nearly incompressible hyperelasticity](quasi_incompressible_hyperelasticity.md)
 
 This program combines the ideas from [Tutorial 3: Incompressible
-elasticity](../../tutorials/incompressible_elasticity/) and [Tutorial 4:
-Hyperelasticity](../../tutorials/incompressible_elasticity/) to construct a mixed element
+elasticity](../tutorials/incompressible_elasticity.md) and [Tutorial 4:
+Hyperelasticity](../tutorials/incompressible_elasticity.md) to construct a mixed element
 solving three-dimensional displacement-pressure equations.
 
 *Contributed by*: Bhavesh Shrimali ([@bhaveshshrimali](https://github.com/bhaveshshrimali)).
 
 ---
 
-#### [Ginzburg-Landau model energy minimization](../landau/)
+#### [Ginzburg-Landau model energy minimization](landau.md)
 
 A basic Ginzburg-Landau model is solved.
 [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) is used to compute the
@@ -42,7 +42,7 @@ assembly procedure.
 
 ---
 
-#### [Topology optimization](../topology_optimization/)
+#### [Topology optimization](topology_optimization.md)
 
 Topology optimization is shown for the bending problem by using a SIMP material model. To
 avoid numerical instabilities, a regularization scheme requiring the calculation of the

--- a/docs/src/howto/index.md
+++ b/docs/src/howto/index.md
@@ -6,9 +6,9 @@ or build on top of, the tutorials and, therefore, some familiarity with Ferrite 
 
 ---
 
-#### [Post processing and visualization](../postprocessing/)
+#### [Post processing and visualization](postprocessing.md)
 
-This guide builds on top of [Tutorial 1: Heat equation](../../tutorials/heat_equation/) and
+This guide builds on top of [Tutorial 1: Heat equation](../tutorials/heat_equation.md) and
 discusses various post processsing techniques with the goal of visualizing primary fields
 (the finite element solution) and secondary quantities (e.g. fluxes, stresses, etc.).
 Concretely, this guide answers:
@@ -18,9 +18,9 @@ Concretely, this guide answers:
 
 ---
 
-#### [Multi-threaded assembly](../threaded_assembly/)
+#### [Multi-threaded assembly](threaded_assembly.md)
 
-This guide modifies [Tutorial 2: Linear elasticity](../../tutorials/linear_elasticity/) such
+This guide modifies [Tutorial 2: Linear elasticity](../tutorials/linear_elasticity.md) such
 that the program is using multi-threading to parallelize the assembly procedure. Concretely
 this shows how to use grid coloring and "scratch values" in order to use multi-threading
 without running into race-conditions.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,21 +23,22 @@ and iii) to keep mathematical abstractions.
 This high level view of the documentation structure will help you find what you are looking
 for. The document is organized as follows[^1]:
 
- - [**Tutorials**](tutorials/) are thoroughly documented examples which guides you through
-   the process of solving partial differential equations using Ferrite.
- - [**Topic guides**](topics/) contains more in-depth explanations and discussions about
-   finite element programming concepts and ideas, and specifically how these are realized in
-   Ferrite.
- - [**Reference**](reference/) contains the technical API reference of functions and methods
-   (e.g. the documentation strings).
- - [**How-to guides**](howto/) will guide you through the steps involved in addressing
-   common tasks and use-cases. These usually build on top of the tutorials and thus assume
-   basic knowledge of how Ferrite works.
+ - [**Tutorials**](tutorials/index.md) are thoroughly documented examples which guides you
+   through the process of solving partial differential equations using Ferrite.
+ - [**Topic guides**](topics/index.md) contains more in-depth explanations and discussions
+   about finite element programming concepts and ideas, and specifically how these are
+   realized in Ferrite.
+ - [**Reference**](reference/index.md) contains the technical API reference of functions and
+   methods (e.g. the documentation strings).
+ - [**How-to guides**](howto/index.md) will guide you through the steps involved in
+   addressing common tasks and use-cases. These usually build on top of the tutorials and
+   thus assume basic knowledge of how Ferrite works.
 
 [^1]: The organization of the document follows the [Diátaxis Framework](https://diataxis.fr).
 
-In addition there is a [**Code gallery**](gallery/), with user contributed example programs,
-and the [**Developer documentation**](devdocs/), for documentation of Ferrite internal code.
+In addition there is a [**Code gallery**](gallery/index.md), with user contributed example
+programs, and the [**Developer documentation**](devdocs/index.md), for documentation of
+Ferrite internal code.
 
 ## Getting started
 

--- a/docs/src/literate-howto/postprocessing.jl
+++ b/docs/src/literate-howto/postprocessing.jl
@@ -3,7 +3,7 @@
 # ![](heat_square_fluxes.png)
 #
 # *Figure 1*: Heat flux computed from the solution to the heat equation on
-# the unit square, see previous example: [Heat equation](@id tutorial-heat-equation).
+# the unit square, see previous example: [Heat equation](@ref tutorial-heat-equation).
 #
 #-
 #md # !!! tip

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -314,7 +314,9 @@ apply_analytical!(u, dh, :p, x -> ρ * g * x[2])
 See also [Transient heat equation](@ref tutorial-transient-heat-equation) for one example.
 
 !!! note "Consistency"
-    `apply_analytical!` does not enforce consistency of the applied solution with the system of 
-    equations. Some problems, like for example differential-algebraic systems of equations (DAEs)
-    need extra care during initialization. We refer to the paper ["Consistent Initial Condition Calculation for Differential-Algebraic Systems"  by Brown et al.](dx.doi.org/10.1137/S1064827595289996) for more details on this matter.
+    `apply_analytical!` does not enforce consistency of the applied solution with the system
+    of equations. Some problems, like for example differential-algebraic systems of
+    equations (DAEs) need extra care during initialization. We refer to the paper
+    ["Consistent Initial Condition Calculation for Differential-Algebraic Systems" by Brown
+    et al.](https://dx.doi.org/10.1137/S1064827595289996) for more details on this matter.
 

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -2,7 +2,7 @@
 
 On this page you find an overview of Ferrite tutorials. The tutorials explain and show how
 Ferrite can be used to solve a wide range of problems. See also the [Code
-gallery](../../gallery/) for more examples.
+gallery](../gallery/index.md) for more examples.
 
 The tutorials all follow roughly the same structure:
  - **Introduction** introduces the problem to be solved and discusses the learning outcomes
@@ -29,7 +29,7 @@ of the other tutorials. The remaining tutorials discuss more advanced topics.
 
 ---
 
-##### [Tutorial 1: Heat equation](../heat_equation/)
+##### [Tutorial 1: Heat equation](heat_equation.md)
 
 This tutorial guides you through the process of solving the linear stationary heat equation
 (i.e. Poisson's equation) on a unit square with homogeneous Dirichlet boundary conditions.
@@ -42,7 +42,7 @@ complex tutorials.*
 
 ---
 
-##### [Tutorial 2: Linear elasticity](../linear_elasticity/)
+##### [Tutorial 2: Linear elasticity](linear_elasticity.md)
 
 TBW.
 
@@ -50,7 +50,7 @@ TBW.
 
 ---
 
-##### [Tutorial 3: Incompressible elasticity](../incompressible_elasticity/)
+##### [Tutorial 3: Incompressible elasticity](incompressible_elasticity.md)
 
 This tutorial focuses on a mixed formulation of linear elasticity, with (vector)
 displacement and (scalar) pressure as the two unknowns, suitable for incompressibility.
@@ -62,7 +62,7 @@ incompressible limit.
 
 ---
 
-#### [Tutorial 4: Hyperelasticity](../hyperelasticity/)
+#### [Tutorial 4: Hyperelasticity](hyperelasticity.md)
 
 In this tutorial you will learn how to solve a non-linear finite element problem. In
 particular, a hyperelastic material model, in a finite strain setting, is used to solve the
@@ -75,13 +75,14 @@ Newton's method, conjugate gradient (CG).
 
 ---
 
-#### [Tutorial 5: von Mises Plasticity](../plasticity/)
+#### [Tutorial 5: von Mises Plasticity](plasticity.md)
 
-This tutorial revisits the cantilever beam problem from the [Linear elasticity]() tutorial,
-but instead of linear elasticity a plasticity model is used for the constitutive relation.
-You will learn how to solve a problem which require the solution of a local material
-problem, and the storage of material state, in each quadrature point. Newton's method is
-used both locally in the material routine, and globally on the finite element level.
+This tutorial revisits the cantilever beam problem from [Tutorial 2: Linear
+elasticity](linear_elasticity.md), but instead of linear elasticity a plasticity model is
+used for the constitutive relation. You will learn how to solve a problem which require the
+solution of a local material problem, and the storage of material state, in each quadrature
+point. Newton's method is used both locally in the material routine, and globally on the
+finite element level.
 
 **Keywords**: non-linear finite element, plasticity, material modeling, state variables,
 Newton’s method.
@@ -92,7 +93,7 @@ Newton’s method.
 
 In this tutorial the transient heat equation is solved on the unit square. The problem to be
 solved is thus similar to the one solved in the first tutorial, [Heat
-equation](../heat_equation/), but with time-varying boundary conditions. In particular you
+equation](heat_equation.md), but with time-varying boundary conditions. In particular you
 will learn how to solve a time dependent problem with an implicit Euler scheme for the time
 integration.
 
@@ -100,7 +101,7 @@ integration.
 
 ---
 
-#### [Tutorial 7: Computational homogenization](../computational_homogenization/)
+#### [Tutorial 7: Computational homogenization](computational_homogenization.md)
 
 This tutorial guides you through computational homogenization of an representative volume
 element (RVE) consisting of a soft matrix material with stiff inclusions. The computational
@@ -111,7 +112,7 @@ conditions are used.
 
 ---
 
-#### [Tutorial 8: Stokes flow](../stokes-flow/)
+#### [Tutorial 8: Stokes flow](stokes-flow.md)
 
 In this tutorial Stokes flow with (vector) velocity and (scalar) pressure is solved on on a
 quarter circle. Rotationally periodic boundary conditions is used for the inlet/outlet
@@ -123,7 +124,7 @@ Gmsh.
 
 ---
 
-#### [Tutorial 9: Incompressible Navier-Stokes equations](../ns_vs_diffeq/)
+#### [Tutorial 9: Incompressible Navier-Stokes equations](ns_vs_diffeq.md)
 
 In this tutorial the incompressible Navier-Stokes equations are solved. The domain is
 discretized in space with Ferrite as usual, and then forumalated in a way to be compatible


### PR DESCRIPTION
This patch fixes a number of warnings during doc build that will be errors (by default) in future Documenter versions.