### PR TITLE
Fix CellIterator for subdomains

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -132,6 +132,7 @@ function ndofs_per_cell(dh::DofHandler, cell::Int=1)
     return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end
 ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
+ndofs_per_cell(sdh::SubDofHandler, _) = sdh.ndofs_per_cell[] # allow handing in a cellid for compatibility with DofHandler
 
 """
     celldofs!(global_dofs::Vector{Int}, dh::AbstractDofHandler, i::Int)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -132,7 +132,7 @@ function ndofs_per_cell(dh::DofHandler, cell::Int=1)
     return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end
 ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
-ndofs_per_cell(sdh::SubDofHandler, _) = sdh.ndofs_per_cell[] # allow handing in a cellid for compatibility with DofHandler
+ndofs_per_cell(sdh::SubDofHandler, ::Int) = sdh.ndofs_per_cell[] # for compatibility with DofHandler
 
 """
     celldofs!(global_dofs::Vector{Int}, dh::AbstractDofHandler, i::Int)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -67,7 +67,8 @@ function CellCache(dh::DofHandler{dim}, flags::UpdateFlags=UpdateFlags()) where 
 end
 
 function CellCache(sdh::SubDofHandler, flags::UpdateFlags=UpdateFlags())
-    CellCache(flags, sdh.dh.grid, ScalarWrapper(-1), Int[], Vec{2,Float64}[], sdh, Int[])
+    dim = getdim(sdh.dh.grid)
+    CellCache(flags, sdh.dh.grid, ScalarWrapper(-1), Int[], Vec{dim,Float64}[], sdh, Int[])
 end
 
 function reinit!(cc::CellCache, i::Int)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -266,7 +266,7 @@ function CellIterator(gridordh::Union{Grid,DofHandler}, flags::UpdateFlags)
     return CellIterator(gridordh, nothing, flags)
 end
 function CellIterator(sdh::SubDofHandler, flags::UpdateFlags=UpdateFlags())
-    CellIterator(sdh.dh, sdh.cellset, flags)
+    CellIterator(CellCache(sdh, flags), sdh.cellset)
 end
 
 @inline _getset(ci::CellIterator) = ci.set

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -517,6 +517,18 @@ function test_subparametric_triangle()
     @test celldofs(dh, 1) == [i for i in 1:12]
 end
 
+function test_celliterator_subdomain()
+    grid = generate_grid(Quadrilateral, (2,1)) # 2 cells
+    dh = DofHandler(grid)
+    sdh = SubDofHandler(dh, Set(2)) # only cell 2, cell 1 is not part of dh at all
+    add!(sdh, :u, Lagrange{RefQuadrilateral, 1}())
+    close!(dh)
+
+    ci = CellIterator(sdh)
+    reinit!(ci.cc, 2)
+    @test celldofs(ci.cc) == collect(1:4)
+end
+
 function test_separate_fields_on_separate_domains()
     # 5_______6
     # |\      | 
@@ -619,5 +631,6 @@ end
     test_mixed_grid_show()
     test_separate_fields_on_separate_domains();
     test_unique_cellsets()
+    test_celliterator_subdomain()
     test_show()
 end


### PR DESCRIPTION
Fixes the `CellIterator` for the case where only a subset of cells is part of the `DofHandler`. In particular this was problematic when cell 1 was not part of any `SubDofHandler`. 

Bugfix for bug in vtk export of L2-Projection on subdomain that was reported on Slack last week.

