### PR TITLE
pretty print interpolation in SubDofHandler

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -49,16 +49,16 @@ end
 # Shortcut
 @inline getcelltype(grid::AbstractGrid, sdh::SubDofHandler) = getcelltype(grid, first(sdh.cellset))
 
-function Base.show(io::IO, ::MIME"text/plain", sdh::SubDofHandler)
+function Base.show(io::IO, mime::MIME"text/plain", sdh::SubDofHandler)
     println(io, typeof(sdh))
     println(io, "  Cell type: ", getcelltype(sdh.dh.grid, first(sdh.cellset)))
-    _print_field_information(io, sdh)
+    _print_field_information(io, mime, sdh)
 end
 
-function _print_field_information(io::IO, sdh::SubDofHandler)
+function _print_field_information(io::IO, mime::MIME"text/plain", sdh::SubDofHandler)
     println(io, "  Fields:")
     for (i, fieldname) in pairs(sdh.field_names)
-        println(io, "    ", repr(fieldname), ", ", sdh.field_interpolations[i])
+        println(io, "    ", repr(mime, fieldname), ", ", repr(mime, sdh.field_interpolations[i]))
     end
     if !isclosed(sdh.dh)
         print(io, "  Not closed!")
@@ -93,10 +93,10 @@ function DofHandler(grid::G) where {dim, G <: AbstractGrid{dim}}
     DofHandler{dim, G}(sdhs, Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), ScalarWrapper(false), grid, ScalarWrapper(-1))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", dh::DofHandler)
+function Base.show(io::IO, mime::MIME"text/plain", dh::DofHandler)
     println(io, typeof(dh))
     if length(dh.subdofhandlers) == 1
-        _print_field_information(io, dh.subdofhandlers[1])
+        _print_field_information(io, mime, dh.subdofhandlers[1])
     else
         println(io, "  Fields:")
         for fieldname in getfieldnames(dh)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -594,8 +594,8 @@ function test_show()
     add!(dh, :u, Lagrange{RefTriangle, 1}()^2)
     close!(dh)
     @test repr("text/plain", dh) == string(
-        repr(typeof(dh)), "\n  Fields:\n    :u, ",
-        repr(dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 6\n  Total dofs: 8")
+        repr("text/plain", typeof(dh)), "\n  Fields:\n    :u, ",
+        repr("text/plain", dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 6\n  Total dofs: 8")
 
     # multiple SubDofHandlers
     grid = get_2d_grid()
@@ -607,8 +607,8 @@ function test_show()
     close!(dh)
     @test repr("text/plain", dh) == repr(typeof(dh)) * "\n  Fields:\n    :u, dim: 2\n  Total dofs: 10"
     @test repr("text/plain", dh.subdofhandlers[1]) == string(
-        repr(typeof(dh.subdofhandlers[1])), "\n  Cell type: Quadrilateral\n  Fields:\n    :u, ",
-            repr(dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 8\n")
+        repr("text/plain", typeof(dh.subdofhandlers[1])), "\n  Cell type: Quadrilateral\n  Fields:\n    :u, ",
+            repr("text/plain", dh.subdofhandlers[1].field_interpolations[1]), "\n  Dofs per cell: 8\n")
 end
 
 function test_vtk_export()


### PR DESCRIPTION
Vectorized interpolations were not pretty printed in SubDofHandlers.
Ferrite#master:
```julia
julia> sdh
SubDofHandler{DofHandler{2, Grid{2, Ferrite.AbstractCell, Float64}}}
  Cell type: Triangle
  Fields:
    :u, VectorizedInterpolation{2, RefTriangle, 1, Lagrange{RefTriangle, 1, Nothing}}(Lagrange{RefTriangle, 1}())
  Dofs per cell: 6
```
#PR:
```julia
julia> sdh
SubDofHandler{DofHandler{2, Grid{2, Ferrite.AbstractCell, Float64}}}
  Cell type: Triangle
  Fields:
    :u, Lagrange{RefTriangle, 1}()^2
  Dofs per cell: 6
```
