### PR TITLE
Convenience constructors CellValues and FaceValues

### DIFF
--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -117,6 +117,7 @@ include("Export/VTK.jl")
 include("PointEval/PointEvalHandler.jl")
 
 # Other
+include("convenience_constructors.jl")
 include("deprecations.jl")
 include("docs.jl")
 

--- a/src/convenience_constructors.jl
+++ b/src/convenience_constructors.jl
@@ -1,0 +1,52 @@
+# Convenience constructors often require multiple types to be defined.
+# Where necessary, these can be put in this file.
+
+_create_qr_rule(qr::QuadratureRule, args...) = qr 
+_create_qr_rule(order::Int, ::Interpolation{RefShape}) where {RefShape} = QuadratureRule{RefShape}(order)
+
+"""
+    CellValues(dh::DofHandler, fieldname::Symbol; qr::Union{Int,QuadratureRule})
+    CellValues(sdh::SubDofHandler, fieldname::Symbol; qr::Union{Int,QuadratureRule})
+
+Create a `CellValues` object by using the interpolation of `fieldname` in `dh` 
+or `sdh`, as well as the default geometric interpolation based on the cell type.
+A `DofHandler` input is only allowed with a single `SubDofHandler` in `dh`.
+The quadrature rule is created automatically as `QuadratureRule{dim,RefShape}(qr)`,
+where `dim` and `RefShape` are taken from `dh` or `sdh`, if `qr::Int` is given.
+"""
+function CellValues(dh::DofHandler, fieldname::Symbol; kwargs...)
+    length(dh.subdofhandlers)==1 || throw(ArgumentError("Multiple SubDofHandlers are not supported, give a single SubDofHandler instead"))
+    return CellValues(first(dh.subdofhandlers), fieldname; kwargs...)
+end
+function CellValues(sdh::SubDofHandler, fieldname::Symbol; qr)
+    CT = getcelltype(get_grid(sdh.dh), sdh)
+    ip_geo = default_interpolation(CT)
+    qr_actual = _create_qr_rule(qr, ip_geo)
+    ip = getfieldinterpolation(sdh, fieldname)
+    return CellValues(qr_actual, ip, ip_geo)
+end
+
+_create_fqr_rule(qr::FaceQuadratureRule, args...) = qr 
+_create_fqr_rule(order::Int, ::Interpolation{RefShape}) where {RefShape} = FaceQuadratureRule{RefShape}(order)
+
+"""
+    CellValues(dh::DofHandler, fieldname::Symbol; qr::Union{Int,QuadratureRule})
+    CellValues(sdh::SubDofHandler, fieldname::Symbol; qr::Union{Int,QuadratureRule})
+
+Create a `CellValues` object by using the interpolation of `fieldname` in `dh` 
+or `sdh`, as well as the default geometric interpolation based on the cell type.
+A `DofHandler` input is only allowed with a single `SubDofHandler` in `dh`.
+The quadrature rule is created automatically as `QuadratureRule{dim,RefShape}(qr)`,
+where `dim` and `RefShape` are taken from `dh` or `sdh`, if `qr::Int` is given.
+"""
+function FaceValues(dh::DofHandler, fieldname::Symbol; kwargs...)
+    length(dh.subdofhandlers)==1 || throw(ArgumentError("Multiple SubDofHandlers are not supported, give a single SubDofHandler instead"))
+    return FaceValues(first(dh.subdofhandlers), fieldname; kwargs...)
+end
+function FaceValues(sdh::SubDofHandler, fieldname::Symbol; qr)
+    CT = getcelltype(get_grid(sdh.dh), sdh)
+    ip_geo = default_interpolation(CT)
+    qr_actual = _create_fqr_rule(qr, ip_geo)
+    ip = getfieldinterpolation(sdh, fieldname)
+    return FaceValues(qr_actual, ip, ip_geo)
+end


### PR DESCRIPTION
(Taken out and extended from #680)

With the new distinction between vector and scalar interpolations since #694, 
it is possible to make a convenience constructor of cell and face values, given a 
`SubDofHandler` (or `DofHandler` with a single `SubDofHandler`). 

Happy to hear feedback on this idea!

**Proposed syntax**
```julia
cv = CellValues(dh, fieldname; qr)
fv = FaceValues(dh, fieldname; qr)
```
where `qr::Union{Int,[Face]QuadratureRule}`. For standard quadrature rules, the syntax now allows e.g.,
```julia
cv = CellValues(dh, :u; qr=2)
fv = FaceValues(dh, :u, qr=1)
```
for single subdofhandler problems, and just replace `dh::DofHandler` with `sdh::SubDofHandler` for cases with multiple subdofhandlers. 

**Motivation**
The geometric interpolation matches the grid, without having to extract information by using e.g. `Ferrite.default_interpolation` on the user-side
Less verbose by not requiring the quadrature rule constructor when the standard quadrature points should be used. 