### PR TITLE
Batch evaluations

### DIFF
--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -15,6 +15,9 @@ Ferrite.shape_gradient(::Interpolation, ::Vec, ::Int)
 Ferrite.shape_gradient_and_value
 Ferrite.boundarydof_indices
 Ferrite.dirichlet_boundarydof_indices
+Ferrite.shape_values!
+Ferrite.shape_gradients!
+Ferrite.shape_gradients_and_values!
 ```
 
 ### Required methods to implement for all subtypes of `Interpolation` to define a new finite element

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -68,12 +68,13 @@ function CellValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, GIP}(qr::QR, ip::I
     dMdξ = fill(zero(dMdξ_t) * T(NaN), n_geom_basefuncs, n_qpoints)
 
     for (qp, ξ) in pairs(getpoints(qr))
-        for basefunc in 1:n_func_basefuncs
-            dNdξ[basefunc, qp], N[basefunc, qp] = shape_gradient_and_value(ip, ξ, basefunc)
-        end
-        for basefunc in 1:n_geom_basefuncs
-            dMdξ[basefunc, qp], M[basefunc, qp] = shape_gradient_and_value(gip, ξ, basefunc)
-        end
+        Nqp = @view N[:, qp]
+        dNdξqp = @view dNdξ[:, qp]
+        shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
+        
+        Mqp = @view M[:, qp]
+        dMdξqp = @view dMdξ[:, qp]
+        shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)
     end
 
     detJdV = fill(T(NaN), n_qpoints)

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -71,7 +71,7 @@ function CellValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, GIP}(qr::QR, ip::I
         Nqp = @view N[:, qp]
         dNdξqp = @view dNdξ[:, qp]
         shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
-        
+
         Mqp = @view M[:, qp]
         dMdξqp = @view dMdξ[:, qp]
         shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -68,13 +68,8 @@ function CellValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, GIP}(qr::QR, ip::I
     dMdξ = fill(zero(dMdξ_t) * T(NaN), n_geom_basefuncs, n_qpoints)
 
     for (qp, ξ) in pairs(getpoints(qr))
-        Nqp = @view N[:, qp]
-        dNdξqp = @view dNdξ[:, qp]
-        shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
-
-        Mqp = @view M[:, qp]
-        dMdξqp = @view dMdξ[:, qp]
-        shape_gradients_and_values!(dMdξqp, Mqp, gip, ξ)
+        shape_gradients_and_values!(@view(dNdξ[:, qp]), @view(N[:, qp]), ip, ξ)
+        shape_gradients_and_values!(@view(dMdξ[:, qp]), @view(M[:, qp]), gip, ξ)
     end
 
     detJdV = fill(T(NaN), n_qpoints)

--- a/src/FEValues/cell_values.jl
+++ b/src/FEValues/cell_values.jl
@@ -74,7 +74,7 @@ function CellValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, GIP}(qr::QR, ip::I
 
         Mqp = @view M[:, qp]
         dMdξqp = @view dMdξ[:, qp]
-        shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)
+        shape_gradients_and_values!(dMdξqp, Mqp, gip, ξ)
     end
 
     detJdV = fill(T(NaN), n_qpoints)

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -71,12 +71,12 @@ function FaceValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, Normal_t, GIP}(qr:
     dMdξ = fill(zero(dMdξ_t) * T(NaN), n_geom_basefuncs, max_n_qpoints, n_faces)
 
     for face in 1:n_faces, (qp, ξ) in pairs(getpoints(qr, face))
-        Nqp = @view N[:, qp]
-        dNdξqp = @view dNdξ[:, qp]
+        Nqp = @view N[:, qp, face]
+        dNdξqp = @view dNdξ[:, qp, face]
         shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
 
-        Mqp = @view M[:, qp]
-        dMdξqp = @view dMdξ[:, qp]
+        Mqp = @view M[:, qp, face]
+        dMdξqp = @view dMdξ[:, qp, face]
         shape_gradients_and_values!(dMdξqp, Mqp, gip, ξ)
     end
 

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -74,7 +74,7 @@ function FaceValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, Normal_t, GIP}(qr:
         Nqp = @view N[:, qp]
         dNdξqp = @view dNdξ[:, qp]
         shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
-        
+
         Mqp = @view M[:, qp]
         dMdξqp = @view dMdξ[:, qp]
         shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)
@@ -223,7 +223,7 @@ function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interp
     M   = fill(zero(T) * T(NaN), n_geom_basefuncs, n_qpoints, n_boundary_entities)
     nqp = zeros(Int,n_boundary_entities)
 
-    for n_boundary_entity in 1:n_boundary_entities        
+    for n_boundary_entity in 1:n_boundary_entities
         for (qp, ξ) in enumerate(qrs[n_boundary_entity].points)
             Mqp = @view M[:, qp, n_boundary_entity]
             shape_values!(Mqp, geom_interpol, ξ)

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -71,12 +71,13 @@ function FaceValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, Normal_t, GIP}(qr:
     dMdξ = fill(zero(dMdξ_t) * T(NaN), n_geom_basefuncs, max_n_qpoints, n_faces)
 
     for face in 1:n_faces, (qp, ξ) in pairs(getpoints(qr, face))
-        for basefunc in 1:n_func_basefuncs
-            dNdξ[basefunc, qp, face], N[basefunc, qp, face] = shape_gradient_and_value(ip, ξ, basefunc)
-        end
-        for basefunc in 1:n_geom_basefuncs
-            dMdξ[basefunc, qp, face], M[basefunc, qp, face] = shape_gradient_and_value(gip, ξ, basefunc)
-        end
+        Nqp = @view N[:, qp]
+        dNdξqp = @view dNdξ[:, qp]
+        shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
+        
+        Mqp = @view M[:, qp]
+        dMdξqp = @view dMdξ[:, qp]
+        shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)
     end
 
     detJdV = fill(T(NaN), max_n_qpoints, n_faces)
@@ -222,9 +223,10 @@ function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interp
     M   = fill(zero(T) * T(NaN), n_geom_basefuncs, n_qpoints, n_boundary_entities)
     nqp = zeros(Int,n_boundary_entities)
 
-    for n_boundary_entity in 1:n_boundary_entities
-        for (qp, ξ) in enumerate(qrs[n_boundary_entity].points), i in 1:n_geom_basefuncs
-            M[i, qp, n_boundary_entity] = shape_value(geom_interpol, ξ, i)
+    for n_boundary_entity in 1:n_boundary_entities        
+        for (qp, ξ) in enumerate(qrs[n_boundary_entity].points)
+            Mqp = @view M[:, qp, n_boundary_entity]
+            shape_values!(Mqp, geom_interpol, ξ)
         end
         nqp[n_boundary_entity] = length(qrs[n_boundary_entity].points)
     end

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -77,7 +77,7 @@ function FaceValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, Normal_t, GIP}(qr:
 
         Mqp = @view M[:, qp]
         dMdξqp = @view dMdξ[:, qp]
-        shape_gradients_and_values!(dMdξqp, Mqp, ip, ξ)
+        shape_gradients_and_values!(dMdξqp, Mqp, gip, ξ)
     end
 
     detJdV = fill(T(NaN), max_n_qpoints, n_faces)

--- a/src/FEValues/face_values.jl
+++ b/src/FEValues/face_values.jl
@@ -71,13 +71,8 @@ function FaceValues{IP, N_t, dNdx_t, dNdξ_t, T, dMdξ_t, QR, Normal_t, GIP}(qr:
     dMdξ = fill(zero(dMdξ_t) * T(NaN), n_geom_basefuncs, max_n_qpoints, n_faces)
 
     for face in 1:n_faces, (qp, ξ) in pairs(getpoints(qr, face))
-        Nqp = @view N[:, qp, face]
-        dNdξqp = @view dNdξ[:, qp, face]
-        shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
-
-        Mqp = @view M[:, qp, face]
-        dMdξqp = @view dMdξ[:, qp, face]
-        shape_gradients_and_values!(dMdξqp, Mqp, gip, ξ)
+        shape_gradients_and_values!(@view(dNdξ[:, qp, face]), @view(N[:, qp, face]), ip, ξ)
+        shape_gradients_and_values!(@view(dMdξ[:, qp, face]), @view(M[:, qp, face]), gip, ξ)
     end
 
     detJdV = fill(T(NaN), max_n_qpoints, n_faces)
@@ -224,9 +219,8 @@ function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interp
     nqp = zeros(Int,n_boundary_entities)
 
     for n_boundary_entity in 1:n_boundary_entities
-        for (qp, ξ) in enumerate(qrs[n_boundary_entity].points)
-            Mqp = @view M[:, qp, n_boundary_entity]
-            shape_values!(Mqp, geom_interpol, ξ)
+        for (qp, ξ) in pairs(qrs[n_boundary_entity].points)
+            shape_values!(@view(M[:, qp, n_boundary_entity]), geom_interpol, ξ)
         end
         nqp[n_boundary_entity] = length(qrs[n_boundary_entity].points)
     end

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -125,6 +125,7 @@ function find_local_coordinate(interpolation, cell_coordinates::Vector{V}, globa
     for _ in 1:max_iters
         global_guess = zero(V)
         J = zero(Tensor{2, dim, T})
+        # TODO batched eval after 764 is merged.
         for j in 1:n_basefuncs
             dNdξ, N = shape_gradient_and_value(interpolation, local_guess, j)
             global_guess += N * cell_coordinates[j]

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -76,7 +76,7 @@ end
 
 function PointValuesInternal(ξ::Vec{dim, T}, ip::IP) where {dim, T, shape <: AbstractRefShape{dim}, IP <: Interpolation{shape}}
     n_func_basefuncs = getnbasefunctions(ip)
-    N = [shape_value(ip, ξ, i) for i in 1:n_func_basefuncs]
+    N = @SVector [shape_value(ip, ξ, i) for i in 1:n_func_basefuncs]
     return PointValuesInternal{IP, eltype(N)}(N, ip)
 end
 

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -61,7 +61,7 @@ function reinit!(pv::PointValues, x::AbstractVector{<:Vec{D}}, ξ::Vec{D}) where
     # TODO: Does M need to be updated too?
     Nqp = @view pv.cv.N[:, qp]
     dNdξqp = @view pv.cv.dNdξ[:, qp]
-    shape_gradients_and_values!(dNdξqp, Nqp, ip, ξ)
+    shape_gradients_and_values!(dNdξqp, Nqp, pv.cv.ip, ξ)
     reinit!(pv.cv, x)
     return nothing
 end
@@ -77,7 +77,7 @@ end
 function PointValuesInternal(ξ::Vec{dim, T}, ip::IP) where {dim, T, shape <: AbstractRefShape{dim}, IP <: Interpolation{shape}}
     n_func_basefuncs = getnbasefunctions(ip)
     N = MVector(ntuple(i->shape_value(ip, ξ, i), n_func_basefuncs))
-    return PointValuesInternal{IP, eltype(N)}(N, ip)
+    return PointValuesInternal{IP, eltype(N), typeof(N)}(N, ip)
 end
 
 getnquadpoints(pv::PointValuesInternal) = 1
@@ -86,6 +86,6 @@ shape_value(pv::PointValuesInternal, qp::Int, i::Int) = (@assert qp == 1; pv.N[i
 
 # allow on-the-fly updating
 function reinit!(pv::PointValuesInternal{IP}, ξ::Vec{dim}) where {dim, shape <: AbstractRefShape{dim}, IP <: Interpolation{shape}}
-    shape_values!(pv.N, ip, ξ)
+    shape_values!(pv.N, pv.ip, ξ)
     return nothing
 end

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -76,7 +76,7 @@ end
 
 function PointValuesInternal(ξ::Vec{dim, T}, ip::IP) where {dim, T, shape <: AbstractRefShape{dim}, IP <: Interpolation{shape}}
     n_func_basefuncs = getnbasefunctions(ip)
-    N = @SVector [shape_value(ip, ξ, i) for i in 1:n_func_basefuncs]
+    N = MVector(ntuple(i->shape_value(ip, ξ, i), n_func_basefuncs))
     return PointValuesInternal{IP, eltype(N)}(N, ip)
 end
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -207,9 +207,11 @@ getnbasefunctions(::Interpolation)
 """
     shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec)
 
-Evaluate all shape functions of `ip` at once at the reference point `ξ` and store them in `values`.
+Evaluate all shape functions of `ip` at once at the reference point `ξ` and store them in
+`values`.
 """
-function shape_values!(values::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
+@propagate_inbounds function shape_values!(values::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
+    @boundscheck checkbounds(values, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
         values[i] = shape_value(ip, ξ, i)
     end
@@ -218,22 +220,27 @@ end
 """
     shape_gradients!(gradients::AbstractArray, ip::Interpolation, ξ::Vec)
 
-Evaluate all shape function gradients of `ip` at once at the reference point `ξ` and store them in `values`.
+Evaluate all shape function gradients of `ip` at once at the reference point `ξ` and store
+them in `gradients`.
 """
 function shape_gradients!(gradients::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
+    @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        values[i] = shape_gradient(ip, ξ, i)
+        gradients[i] = shape_gradient(ip, ξ, i)
     end
 end
 
 """
-    shape_gradients_and_values!(gradients::AbstractArray, shapes::AbstractArray, ip::Interpolation, ξ::Vec)
+    shape_gradients_and_values!(gradients::AbstractArray, values::AbstractArray, ip::Interpolation, ξ::Vec)
 
-Evaluate all shape functions and their gradients of `ip` at once at the reference point `ξ` and store them in `values`.
+Evaluate all shape function gradients and values of `ip` at once at the reference point `ξ`
+and store them in `values`.
 """
-function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray}
+function shape_gradients_and_values!(gradients::GAT, values::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray}
+    @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
+    @boundscheck checkbounds(values, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        gradients[i], shapes[i] = shape_gradient_and_value(ip, ξ, i)
+        gradients[i], values[i] = shape_gradient_and_value(ip, ξ, i)
     end
 end
 
@@ -490,75 +497,6 @@ is_discontinuous(::Type{<:DiscontinuousLagrange}) = true
 ############
 # Lagrange #
 ############
-# struct TensorProductLagrange{shape, order} <: ScalarInterpolation{shape, order}
-# end
-
-# adjust_dofs_during_distribution(::TensorProductLagrange) = true
-# adjust_dofs_during_distribution(::TensorProductLagrange{<:Any, 2}) = false
-# adjust_dofs_during_distribution(::TensorProductLagrange{<:Any, 1}) = false
-
-# TODO support these orderings in the dof handler close
-# vertexdof_indices(::TensorProductLagrange{RefLine,order}) where {order} = ((1,),(order+1,))
-# vertexdof_indices(::TensorProductLagrange{RefQuadrilateral,order}) where {order} = ((1,),(order+1,), (order*(order+1),), ((order+1)*(order+1),))
-# ...
-
-# Sum factorized eval for tensor product elements
-# function shape_values!(values::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray, order}
-#     # Auxillary 1D interpolation
-#     ip_1d = Lagrange{RefLine,order}()
-#     n_basefunctions_1d = getnbasefunctions(ip_1d)
-#     # Evaluate 1D
-#     evals_x_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[1],)), i), order+1)
-#     evals_y_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[2],)), i), order+1)
-#     # Sum factorization
-#     values_2d = reshape(values, (n_basefunctions_1d, n_basefunctions_1d))
-#     for ix in 1:n_basefunctions_1d, iy in 1:n_basefunctions_1d
-#         values_2d[ix, iy] = evals_x_1d[ix] * evals_y_1d[iy]
-#     end
-#     TODO permutate values_2d
-# end
-
-# function shape_values!(gradients_2d::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray, order}
-#     # Auxillary 1D interpolation
-#     ip_1d = Lagrange{RefLine,order}()
-#     n_basefunctions_1d = getnbasefunctions(ip_1d)
-#     # Evaluate 1D
-#     evals_x_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[1],)), i), order+1)
-#     evals_y_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[2],)), i), order+1)
-#     evals_dx_1d = ntuple(i->shape_gradient(ip_1d, Vec{1,T}((ξ[1],)), i), order+1)
-#     evals_dy_1d = ntuple(i->shape_gradient(ip_1d, Vec{1,T}((ξ[2],)), i), order+1)
-#     # Sum factorization
-#     gradients_2d_2d = reshape(gradients_2d, (n_basefunctions_1d, n_basefunctions_1d))
-#     for ix in 1:n_basefunctions_1d, iy in 1:n_basefunctions_1d
-#         gradients_2d_2d[ix, iy, 1] = ...
-#         gradients_2d_2d[ix, iy, 2] = ...
-#     end
-#     TODO permutate gradients_2d_2d
-# end
-
-# function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec ) where {T, SAT <: AbstractArray, GAT <: AbstractArray, dim, order}
-#     # Auxillary 1D interpolation
-#     ip_1d = Lagrange{RefLine,order}()
-#     n_basefunctions_1d = getnbasefunctions(ip_1d)
-#     # Evaluate 1D
-#     evals_x_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[1],)), i), order+1)
-#     evals_y_1d = ntuple(i->shape_value(ip_1d, Vec{1,T}((ξ[2],)), i), order+1)
-#     evals_dx_1d = ntuple(i->shape_gradient(ip_1d, Vec{1,T}((ξ[1],)), i), order+1)
-#     evals_dy_1d = ntuple(i->shape_gradient(ip_1d, Vec{1,T}((ξ[2],)), i), order+1)
-#     # Sum factorization
-#     values_2d    = reshape(values, (n_basefunctions_1d, n_basefunctions_1d))
-#     gradients_2d = reshape(gradients, (n_basefunctions_1d, n_basefunctions_1d))
-#     for ix in 1:n_basefunctions_1d, iy in 1:n_basefunctions_1d
-#         values_2d[ix, iy, 1] = ...
-#         values_2d[ix, iy, 2] = ...
-#     end
-#     TODO permutate values_2d
-#     TODO permutate gradients_2d_2d
-# end
-
-# TODO implement kernels above for 3D
-# TODO implement vectorized interpolation case
-
 struct Lagrange{shape, order, unused} <: ScalarInterpolation{shape, order}
     function Lagrange{shape, order}() where {shape <: AbstractRefShape, order}
         new{shape, order, Nothing}()

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -205,35 +205,35 @@ getnbasefunctions(::Interpolation)
 #   celldof: dof that is local to the element
 
 """
-    shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+    shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape functions of `ip` at once at the reference point `ξ` and store them in `values`.
 """
-function shape_values!(values::AT, ip::IP, ξ::Vec{T}) where {T, IP <: Interpolation, AT <: AbstractArray{T}}
+function shape_values!(values::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
     @inbounds for i in 1:getnbasefunctions(ip)
         values[i] = shape_value(ip, ξ, i)
     end
 end
 
 """
-    shape_gradients!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+    shape_gradients!(gradients::AbstractArray, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape function gradients of `ip` at once at the reference point `ξ` and store them in `values`.
 """
-function shape_gradients!(values::AT, ip::IP, ξ::Vec{T}) where {T, IP <: Interpolation, AT <: AbstractArray{T}}
+function shape_gradients!(gradients::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
     @inbounds for i in 1:getnbasefunctions(ip)
         values[i] = shape_gradient(ip, ξ, i)
     end
 end
 
 """
-    shape_gradients_and_values!(gradients::AbstractArray{T}, shapes::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+    shape_gradients_and_values!(gradients::AbstractArray, shapes::AbstractArray, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape functions and their gradients of `ip` at once at the reference point `ξ` and store them in `values`.
 """
-function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::IP, ξ::Vec{T}) where {T, IP <: Interpolation, SAT <: AbstractArray{T}, GAT <: AbstractArray{T}}
+function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray}
     @inbounds for i in 1:getnbasefunctions(ip)
-        gradients[i], shapes[i] = shape_gradient_and_value(ip, ξ, basefunc)
+        gradients[i], shapes[i] = shape_gradient_and_value(ip, ξ, i)
     end
 end
 
@@ -503,7 +503,7 @@ is_discontinuous(::Type{<:DiscontinuousLagrange}) = true
 # ...
 
 # Sum factorized eval for tensor product elements
-# function shape_values!(values::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray{T}, order}
+# function shape_values!(values::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray, order}
 #     # Auxillary 1D interpolation
 #     ip_1d = Lagrange{RefLine,order}()
 #     n_basefunctions_1d = getnbasefunctions(ip_1d)
@@ -518,7 +518,7 @@ is_discontinuous(::Type{<:DiscontinuousLagrange}) = true
 #     TODO permutate values_2d
 # end
 
-# function shape_values!(gradients_2d::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray{T}, order}
+# function shape_values!(gradients_2d::AT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec{2,T}) where {T, AT <: AbstractArray, order}
 #     # Auxillary 1D interpolation
 #     ip_1d = Lagrange{RefLine,order}()
 #     n_basefunctions_1d = getnbasefunctions(ip_1d)
@@ -536,7 +536,7 @@ is_discontinuous(::Type{<:DiscontinuousLagrange}) = true
 #     TODO permutate gradients_2d_2d
 # end
 
-# function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec {T}) where {T, SAT <: AbstractArray{T}, GAT <: AbstractArray{T}, dim, order}
+# function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::Lagrange{RefHypercube{2},order}, ξ::Vec ) where {T, SAT <: AbstractArray, GAT <: AbstractArray, dim, order}
 #     # Auxillary 1D interpolation
 #     ip_1d = Lagrange{RefLine,order}()
 #     n_basefunctions_1d = getnbasefunctions(ip_1d)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -205,6 +205,39 @@ getnbasefunctions(::Interpolation)
 #   celldof: dof that is local to the element
 
 """
+    shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+
+Evaluate all shape functions of `ip` at once at the reference point `ξ` and store them in `values`.
+"""
+function shape_values!(values::AT, ip::IP, ξ::Vec{T}) where {T, AT <: AbstractArray{T}, IP <: Interpolation}
+    @inbounds for i in 1:getnbasefunctions(ip)
+        values[i] = shape_value(ip, ξ, i)
+    end
+end
+
+"""
+    shape_gradients!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+
+Evaluate all shape function gradients of `ip` at once at the reference point `ξ` and store them in `values`.
+"""
+function shape_gradients!(values::AT, ip::IP, ξ::Vec{T}) where {T, AT <: AbstractArray{T}, IP <: Interpolation}
+    @inbounds for i in 1:getnbasefunctions(ip)
+        values[i] = shape_gradient(ip, ξ, i)
+    end
+end
+
+"""
+    shape_gradients_and_values!(gradients::AbstractArray{T}, shapes::AbstractArray{T}, ip::Interpolation, ξ::Vec{T})
+
+Evaluate all shape functions and their gradients of `ip` at once at the reference point `ξ` and store them in `values`.
+"""
+function shape_gradients_and_values!(gradients::GAT, shapes::SAT, ip::IP, ξ::Vec {T}) where {T, IP <: Interpolation, SAT <: AbstractArray{T}, GAT <: AbstractArray{T}}
+    @inbounds for i in 1:getnbasefunctions(ip)
+        gradients[i], shapes[i] = shape_gradient_and_value(ip, ξ, basefunc)
+    end
+end
+
+"""
     shape_value(ip::Interpolation, ξ::Vec, i::Int)
 
 Evaluate the value of the `i`th shape function of the interpolation `ip`

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -1,5 +1,4 @@
-@testset "CellValues" begin
-for (scalar_interpol, quad_rule) in  (
+@testset "CellValues" for (scalar_interpol, quad_rule) in  (
                                     (Lagrange{RefLine, 1}(), QuadratureRule{RefLine}(2)),
                                     (Lagrange{RefLine, 2}(), QuadratureRule{RefLine}(2)),
                                     (Lagrange{RefQuadrilateral, 1}(), QuadratureRule{RefQuadrilateral}(2)),

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -1,4 +1,5 @@
-@testset "CellValues" for (scalar_interpol, quad_rule) in  (
+@testset "CellValues" begin
+@testset "ip=$scalar_interpol quad_rule=$(typeof(quad_rule))" for (scalar_interpol, quad_rule) in  (
                                     (Lagrange{RefLine, 1}(), QuadratureRule{RefLine}(2)),
                                     (Lagrange{RefLine, 2}(), QuadratureRule{RefLine}(2)),
                                     (Lagrange{RefQuadrilateral, 1}(), QuadratureRule{RefQuadrilateral}(2)),
@@ -99,6 +100,7 @@
             @test v == vc
         end
     end
+end
 end
 
 @testset "#265: error message for incompatible geometric interpolation" begin

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -101,7 +101,6 @@
         end
     end
 end
-end
 
 @testset "#265: error message for incompatible geometric interpolation" begin
     dim = 1


### PR DESCRIPTION
This PR introduces internal batched evaluations where possible, which is interesting for matrix-free and high order stuff (and maybe threading?). We might want to expose the functionality to the users in #766 . It should also help with eval times in #790 . In interpolations.jl there is an outline for #389 .

Due to the interaction this PR might precede #790 and #798 . Further is part of the infrastructure for #766 .

## TODOs

* [ ] exports for new functions
* [ ] better docs