### PR TITLE
Support saving no, or first order, derivatives in FEValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,10 @@ more discussion).
   **To upgrade** replace the quadrature rule passed to `FaceValues` with a
   `FaceQuadratureRule`.
 
+- Checking if a face `(ele_id, local_face_id) ∈ faceset` has been previously implemented
+  by type piracy. In order to be invariant to the underlying `Set` datatype as well as
+  omitting type piracy, ([#835][github-835]) implemented `isequal` and `hash` for `BoundaryIndex` datatypes.
+
 ### Deprecated
 
 - The rarely (if ever) used methods of `function_value`, `function_gradient`,
@@ -867,3 +871,4 @@ poking into Ferrite internals:
 [github-749]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/749
 [github-753]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/753
 [github-756]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/756
+[github-835]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/835

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Metis = "1.3"
 NearestNeighbors = "0.4"
 Preferences = "1"
 Reexport = "1"
-Tensors = "1"
+Tensors = "1.14"
 WriteVTK = "1.13"
 julia = "1.6"
 

--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -12,7 +12,8 @@ for spatial_dim ∈ 1:3
     for geo_type ∈ FerriteBenchmarkHelper.geo_types_for_spatial_dim(spatial_dim)
         COMMON_LOCAL_ASSEMBLY["spatial-dim",spatial_dim][string(geo_type)] = BenchmarkGroup()
 
-        grid = generate_grid(geo_type, tuple(repeat([1], spatial_dim)...));
+        grid = generate_grid(geo_type, tuple(repeat([2], spatial_dim)...));
+        topology = ExclusiveTopology(grid)
         ip_geo = Ferrite.default_interpolation(geo_type)
         ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
 
@@ -66,6 +67,20 @@ for spatial_dim ∈ 1:3
 
                 LAGRANGE_SUITE["ritz-galerkin"]["face-flux"] = @benchmarkable FerriteAssemblyHelper._generalized_ritz_galerkin_assemble_local_matrix($grid, $fsv, shape_gradient, shape_value, *)
                 LAGRANGE_SUITE["petrov-galerkin"]["face-flux"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_local_matrix($grid, $fsv, shape_gradient, $fsv2, shape_value, *)
+                
+                ip = DiscontinuousLagrange{ref_type, order}()
+                isv = InterfaceValues(qr_face, ip, ip_geo; geom_interpol_b = ip_geo);
+                isv2 = InterfaceValues(qr_face, ip, ip_geo; geom_interpol_b = ip_geo);
+                dh = DofHandler(grid)
+                add!(dh, :u, ip)
+                close!(dh)
+
+                LAGRANGE_SUITE["ritz-galerkin"]["interface-{grad}⋅[[val]]"] = @benchmarkable FerriteAssemblyHelper._generalized_ritz_galerkin_assemble_interfaces($dh, $isv, shape_gradient_average, shape_value_jump, ⋅)
+                LAGRANGE_SUITE["petrov-galerkin"]["interface-{grad}⋅[[val]]"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_interfaces($dh, $isv, shape_gradient_average, $isv2, shape_value_jump, ⋅)
+    
+                LAGRANGE_SUITE["ritz-galerkin"]["interface-interior-penalty"] = @benchmarkable FerriteAssemblyHelper._generalized_ritz_galerkin_assemble_interfaces($dh, $isv, shape_value_jump, shape_value_jump, ⋅)
+                LAGRANGE_SUITE["petrov-galerkin"]["interface-interior-penalty"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_interfaces($dh, $isv, shape_value_jump, $isv2, shape_value_jump, ⋅)
+    
             end
         end
     end

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -65,6 +65,30 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
     f
 end
 
+function _generalized_ritz_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_shape, f_test, op) where {dim}
+    n_basefuncs = getnbasefunctions(interfacevalues)
+
+    K = zeros(ndofs(dh), ndofs(dh))
+
+    for ic in InterfaceIterator(dh)
+        reinit!(interfacevalues, ic)
+        for q_point in 1:getnquadpoints(interfacevalues)
+            dΓ = getdetJdV(interfacevalues, q_point)
+            for i in 1:n_basefuncs
+                test = f_test(interfacevalues, q_point, i)
+                f_test == shape_value_jump && (test *= getnormal(interfacevalues, q_point))
+                for j in 1:n_basefuncs
+                    shape = f_shape(interfacevalues, q_point, j)
+                    f_shape == shape_value_jump && (shape *= getnormal(interfacevalues, q_point))
+                    K[interfacedofs(ic)[i], interfacedofs(ic)[j]] += op(test, shape) * dΓ
+                end
+            end
+        end
+    end
+
+    K
+end
+
 # Minimal Petrov-Galerkin type local assembly loop. We assume that both function spaces share the same integration rule. Test is applied from the left.
 function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.AbstractGrid, cellvalues_shape::CellValues, f_shape, cellvalues_test::CellValues, f_test, op)
     n_basefuncs_shape = getnbasefunctions(cellvalues_shape)
@@ -120,6 +144,32 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     end
 
     f
+end
+
+function _generalized_petrov_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues_shape::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_shape, interfacevalues_test::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_test, op) where {dim}
+    n_basefuncs_shape = getnbasefunctions(interfacevalues_shape)
+    n_basefuncs_test = getnbasefunctions(interfacevalues_test)
+
+    K = zeros(ndofs(dh), ndofs(dh))
+
+    for ic in InterfaceIterator(dh)
+        reinit!(interfacevalues_shape, ic)
+        reinit!(interfacevalues_test, ic)
+        for q_point in 1:getnquadpoints(interfacevalues_shape)
+            dΓ = getdetJdV(interfacevalues_test, q_point)
+            for i in 1:n_basefuncs_test
+                test = f_test(interfacevalues_test, q_point, i)
+                f_test == shape_value_jump && (test *= getnormal(interfacevalues_test, q_point))
+                for j in 1:n_basefuncs_shape
+                    shape = f_shape(interfacevalues_shape, q_point, j)
+                    f_shape == shape_value_jump && (shape *= getnormal(interfacevalues_shape, q_point))
+                    K[interfacedofs(ic)[i], interfacedofs(ic)[j]] += op(test, shape) * dΓ
+                end
+            end
+        end
+    end
+
+    K
 end
 
 function _assemble_mass(dh, cellvalues, sym)

--- a/docs/src/assets/references.bib
+++ b/docs/src/assets/references.bib
@@ -61,7 +61,7 @@ keywords = {Finite element methods, polyhedral cells, degrees-of-freedom}
   author={Mirza Cenanovic},
   title={Finite element methods for surface problems},
   school={Jönköping University, School of Engineering},
-  year=2017
+  year={2017},
 }
 @misc{Kirby2017,
       title={A general approach to transforming finite elements}, 
@@ -70,5 +70,29 @@ keywords = {Finite element methods, polyhedral cells, degrees-of-freedom}
       eprint={1706.09017},
       doi={10.48550/arXiv.1706.09017},
       archivePrefix={arXiv},
-      primaryClass={math.NA}
+      primaryClass={math.NA},
+}
+@article{SimMie:1992:act,
+title = {Associative coupled thermoplasticity at finite strains: Formulation, numerical analysis and implementation},
+journal = {Computer Methods in Applied Mechanics and Engineering},
+volume = {98},
+number = {1},
+pages = {41-104},
+year = {1992},
+issn = {0045-7825},
+doi = {https://doi.org/10.1016/0045-7825(92)90170-O},
+url = {https://www.sciencedirect.com/science/article/pii/004578259290170O},
+author = {J.C. Simo and C. Miehe},
+}
+@book{Hol:2000:nsm,
+  title = {Nonlinear Solid Mechanics: A Continuum Approach for Engineering},
+  shorttitle = {Nonlinear Solid Mechanics},
+  author = {Holzapfel, Gerhard A.},
+  year = {2000},
+  publisher = {{Wiley}},
+  address = {{Chichester ; New York}},
+  isbn = {978-0-471-82304-9 978-0-471-82319-3},
+  langid = {english},
+  lccn = {QA808.2 .H655 2000},
+  keywords = {Continuum mechanics}
 }

--- a/docs/src/devdocs/elements.md
+++ b/docs/src/devdocs/elements.md
@@ -35,5 +35,7 @@ Ferrite.getvertexinstances
 Ferrite.filterfaces
 Ferrite.filteredges
 Ferrite.filtervertices
+Ferrite.element_to_face_transformation
+Ferrite.face_to_element_transformation
+Ferrite.InterfaceTransformation
 ```
-

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -37,7 +37,6 @@ Ferrite.edgedof_interior_indices(::Interpolation)
 Ferrite.celldof_interior_indices(::Interpolation)
 Ferrite.getnbasefunctions(::Interpolation)
 Ferrite.reference_coordinates(::Interpolation)
-Ferrite.face_to_element_transformation
 Ferrite.is_discontinuous(::Interpolation)
 Ferrite.adjust_dofs_during_distribution(::Interpolation)
 Ferrite.get_mapping_type

--- a/docs/src/reference/fevalues.md
+++ b/docs/src/reference/fevalues.md
@@ -42,3 +42,21 @@ In addition, there are some methods that are unique for `FaceValues`.
 Ferrite.getcurrentface
 getnormal
 ```
+
+## [InterfaceValues](@id reference-interfacevalues)
+
+All of the methods for [`FaceValues`](@ref) apply for `InterfaceValues` as well.
+In addition, there are some methods that are unique for `InterfaceValues`:
+
+```@docs
+InterfaceValues
+shape_value_average
+shape_value_jump
+shape_gradient_average
+shape_gradient_jump
+function_value_average
+function_value_jump
+function_gradient_average
+function_gradient_jump
+transform_interface_points!
+```

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -41,12 +41,11 @@ struct CellValues{FV, GM, QR, detT} <: AbstractCellValues
     qr::QR         # QuadratureRule
     detJdV::detT   # AbstractVector{<:Number}
 end
-function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation; difforder=Val(1), save_detJ=Val(true)) where T 
-    GeoDiffOrder = max(increased_diff_order(get_mapping_type(ip_fun)) + _extract_val(difforder), _extract_val(save_detJ))
-    FunDiffOrder = _extract_val(difforder)
+function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation; FunDiffOrder=1, save_detJ=true) where T 
+    GeoDiffOrder = max(increased_diff_order(get_mapping_type(ip_fun)) + FunDiffOrder, save_detJ)
     geo_mapping = GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr)
     fun_values = FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo)
-    detJdV = _extract_val(save_detJ) ? fill(T(NaN), length(getweights(qr))) : nothing
+    detJdV = save_detJ ? fill(T(NaN), length(getweights(qr))) : nothing
     return CellValues(fun_values, geo_mapping, qr, detJdV)
 end
 

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -42,10 +42,8 @@ struct CellValues{FV, GM, QR, detT} <: AbstractCellValues
     detJdV::detT   # AbstractVector{<:Number}
 end
 function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation; difforder=Val(1), save_detJ=true) where T 
-    _difforder(::Val{N}) where N = N
-    _difforder(N::Int) = N
-    GeoDiffOrder = max(increased_diff_order(get_mapping_type(ip_fun)) + _difforder(difforder), save_detJ)
-    FunDiffOrder = _difforder(difforder)
+    GeoDiffOrder = max(increased_diff_order(get_mapping_type(ip_fun)) + _extract_val(difforder), save_detJ)
+    FunDiffOrder = _extract_val(difforder)
     geo_mapping = GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr)
     fun_values = FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo)
     detJdV = save_detJ ? fill(T(NaN), length(getweights(qr))) : nothing

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -58,18 +58,6 @@ function Base.copy(cv::CellValues)
     return CellValues(copy(cv.fun_values), copy(cv.geo_mapping), copy(cv.qr), copy(cv.detJdV))
 end
 
-"""
-    precompute_values!(cv::CellValues)
-
-Precompute all values for the current quadrature rule in `cv`. This method allows you to modify
-the quadrature positions, and then update all relevant parts of `cv` accordingly. 
-Used by `PointValues`.
-"""
-function precompute_values!(cv::CellValues)
-    precompute_values!(cv.fun_values, cv.qr)
-    precompute_values!(cv.geo_mapping, cv.qr)
-end
-
 # Access geometry values
 @propagate_inbounds getngeobasefunctions(cv::CellValues) = getngeobasefunctions(cv.geo_mapping)
 @propagate_inbounds geometric_value(cv::CellValues, args...) = geometric_value(cv.geo_mapping, args...)

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -95,7 +95,7 @@ end
 # Access quadrature rule values 
 getnquadpoints(cv::CellValues) = getnquadpoints(cv.qr)
 
-@propagate_inbounds function _update_detJdV!(detJvec::AbstractVector, q_point::Int, w, mapping)
+@inline function _update_detJdV!(detJvec::AbstractVector, q_point::Int, w, mapping)
     detJ = calculate_detJ(getjacobian(mapping))
     detJ > 0.0 || throw_detJ_not_pos(detJ)
     @inbounds detJvec[q_point] = detJ*w
@@ -116,7 +116,7 @@ function reinit!(cv::CellValues, x::AbstractVector{<:Vec}, cell=nothing)
     end
     @inbounds for (q_point, w) in enumerate(getweights(cv.qr))
         mapping = calculate_mapping(geo_mapping, q_point, x)
-        @inline _update_detJdV!(cv.detJdV, q_point, w, mapping)
+        _update_detJdV!(cv.detJdV, q_point, w, mapping)
         apply_mapping!(fun_values, q_point, mapping, cell)
     end
     return nothing

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -71,6 +71,7 @@ getnquadpoints(fv::FaceValues) = @inbounds getnquadpoints(fv.qr, getcurrentface(
 shape_value_type(fv::FaceValues) = shape_value_type(get_fun_values(fv))
 shape_gradient_type(fv::FaceValues) = shape_gradient_type(get_fun_values(fv))
 get_function_interpolation(fv::FaceValues) = get_function_interpolation(get_fun_values(fv))
+get_function_difforder(fv::FaceValues) = get_function_difforder(get_fun_values(fv))
 get_geometric_interpolation(fv::FaceValues) = get_geometric_interpolation(get_geo_mapping(fv))
 
 get_geo_mapping(fv::FaceValues) = @inbounds fv.geo_mapping[getcurrentface(fv)]

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -32,19 +32,17 @@ values of nodal functions, gradients and divergences of nodal functions etc. on 
 FaceValues
 
 struct FaceValues{FV, GM, QR, detT, nT, V_FV<:AbstractVector{FV}, V_GM<:AbstractVector{GM}} <: AbstractFaceValues
-    fun_values::V_FV # AbstractVector{FunctionValues}
+    fun_values::V_FV  # AbstractVector{FunctionValues}
     geo_mapping::V_GM # AbstractVector{GeometryMapping}
-    qr::QR           # FaceQuadratureRule
-    detJdV::detT     # AbstractVector{<:Number}
-    normals::nT      # AbstractVector{<:Vec}
+    qr::QR            # FaceQuadratureRule
+    detJdV::detT      # AbstractVector{<:Number}
+    normals::nT       # AbstractVector{<:Vec}
     current_face::ScalarWrapper{Int}
 end
 
 function FaceValues(::Type{T}, fqr::FaceQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim}=default_geometric_interpolation(ip_fun); difforder=Val(1)) where {T,sdim} 
-    _difforder(::Val{N}) where N = N
-    _difforder(N::Int) = N
-    GeoDiffOrder = increased_diff_order(get_mapping_type(ip_fun)) + _difforder(difforder)
-    FunDiffOrder = _difforder(difforder)
+    GeoDiffOrder = increased_diff_order(get_mapping_type(ip_fun)) + _extract_val(difforder)
+    FunDiffOrder = _extract_val(difforder)
     
     geo_mapping = [GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr) for qr in fqr.face_rules]
     fun_values = [FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for qr in fqr.face_rules]

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -100,18 +100,18 @@ getnormal(fv::FaceValues, qp::Int) = fv.normals[qp]
 
 nfaces(fv::FaceValues) = length(fv.geo_mapping)
 
-function boundscheck_face(fv::FaceValues, face_nr::Int)
+function set_current_face!(fv::FaceValues, face_nr::Int)
+    # Checking face_nr before setting current_face allows us to use @inbounds 
+    # when indexing by getcurrentface(fv) in other places!
     checkbounds(Bool, 1:nfaces(fv), face_nr) || throw(ArgumentError("Face index out of range."))
-    return nothing
+    fv.current_face[] = face_nr
 end
 
 function reinit!(fv::FaceValues, x::AbstractVector{Vec{dim,T}}, face_nr::Int, cell=nothing) where {dim, T}
     check_reinit_sdim_consistency(:FaceValues, shape_gradient_type(fv), eltype(x))
     
-    # Checking face_nr before setting current_face allows us to use @inbounds 
-    # when indexing by getcurrentface(fv) in other places!
-    boundscheck_face(fv, face_nr) 
-    fv.current_face[] = face_nr
+    
+    set_current_face!(fv, face_nr)
     
     n_geom_basefuncs = getngeobasefunctions(fv)
     if !checkbounds(Bool, x, 1:n_geom_basefuncs) || length(x)!=n_geom_basefuncs

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -40,10 +40,8 @@ struct FaceValues{FV, GM, QR, detT, nT, V_FV<:AbstractVector{FV}, V_GM<:Abstract
     current_face::ScalarWrapper{Int}
 end
 
-function FaceValues(::Type{T}, fqr::FaceQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim}=default_geometric_interpolation(ip_fun); difforder=Val(1)) where {T,sdim} 
-    GeoDiffOrder = increased_diff_order(get_mapping_type(ip_fun)) + _extract_val(difforder)
-    FunDiffOrder = _extract_val(difforder)
-    
+function FaceValues(::Type{T}, fqr::FaceQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim}=default_geometric_interpolation(ip_fun); FunDiffOrder=1) where {T,sdim} 
+    GeoDiffOrder = max(increased_diff_order(get_mapping_type(ip_fun)) + FunDiffOrder, 1)
     geo_mapping = [GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr) for qr in fqr.face_rules]
     fun_values = [FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for qr in fqr.face_rules]
     max_nquadpoints = maximum(qr->length(getweights(qr)), fqr.face_rules)

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -99,7 +99,7 @@ getnbasefunctions(funvals::FunctionValues) = size(funvals.N_x, 1)
 @propagate_inbounds shape_symmetric_gradient(funvals::FunctionValues, q_point::Int, base_func::Int) = symmetric(shape_gradient(funvals, q_point, base_func))
 
 get_function_interpolation(funvals::FunctionValues) = funvals.ip
-
+get_function_difforder(::FunctionValues{DiffOrder}) where DiffOrder = DiffOrder
 shape_value_type(funvals::FunctionValues) = eltype(funvals.N_x)
 shape_gradient_type(funvals::FunctionValues) = eltype(funvals.dNdx)
 shape_gradient_type(::FunctionValues{0}) = nothing

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -105,6 +105,7 @@ get_function_interpolation(funvals::FunctionValues) = funvals.ip
 
 shape_value_type(funvals::FunctionValues) = eltype(funvals.N_x)
 shape_gradient_type(funvals::FunctionValues) = eltype(funvals.dNdx)
+shape_gradient_type(::FunctionValues{0}) = nothing
 
 
 # Checks that the user provides the right dimension of coordinates to reinit! methods to ensure good error messages if not
@@ -114,9 +115,10 @@ sdim_from_gradtype(::Type{<:SMatrix{<:Any,sdim}}) where sdim = sdim
 
 # For performance, these must be fully inferrable for the compiler.
 # args: valname (:CellValues or :FaceValues), shape_gradient_type, eltype(x)
-function check_reinit_sdim_consistency(valname, gradtype, ::Type{<:Vec{sdim}}) where {sdim}
+function check_reinit_sdim_consistency(valname, gradtype::Type, ::Type{<:Vec{sdim}}) where {sdim}
     check_reinit_sdim_consistency(valname, Val(sdim_from_gradtype(gradtype)), Val(sdim))
 end
+check_reinit_sdim_consistency(_, ::Nothing, ::Type{<:Vec}) = nothing # gradient not stored, cannot check
 check_reinit_sdim_consistency(_, ::Val{sdim}, ::Val{sdim}) where sdim = nothing
 function check_reinit_sdim_consistency(valname, ::Val{sdim_val}, ::Val{sdim_x}) where {sdim_val, sdim_x}
     throw(ArgumentError("The $valname (sdim=$sdim_val) and coordinates (sdim=$sdim_x) have different spatial dimensions."))

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -136,7 +136,7 @@ get_mapping_type(fv::FunctionValues) = get_mapping_type(fv.ip)
 
 How many order higher geometric derivatives are required to  
 to map the function values and gradients from the reference cell 
-to the real cell geometry?
+to the physical cell geometry?
 """
 increased_diff_order(::IdentityMapping) = 0
 increased_diff_order(::ContravariantPiolaMapping) = 1

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -146,8 +146,8 @@ increased_diff_order(::ContravariantPiolaMapping) = 1
 increased_diff_order(::CovariantPiolaMapping) = 1
 
 # Support for embedded elements
-calculate_Jinv(J::Tensor{2}) = inv(J)
-calculate_Jinv(J::SMatrix) = pinv(J)
+@inline calculate_Jinv(J::Tensor{2}) = inv(J)
+@inline calculate_Jinv(J::SMatrix) = pinv(J)
 
 # Hotfix to get the dots right for embedded elements until mixed tensors are merged.
 # Scalar/Vector interpolations with sdim == rdim (== vdim)

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -59,7 +59,7 @@ function FunctionValues{0}(::Type{T}, ip::Interpolation, qr::QuadratureRule, ip_
     N_x = isa(get_mapping_type(ip), IdentityMapping) ? N_ξ : similar(N_ξ)
         
     fv = FunctionValues(ip, N_x, N_ξ, nothing, nothing)
-    precompute_values!(fv, qr) # Separate function for qr point update in PointValues
+    precompute_values!(fv, getpoints(qr)) # Separate function for qr point update in PointValues
     return fv
 end
 function FunctionValues{1}(::Type{T}, ip::Interpolation, qr::QuadratureRule, ip_geo::VectorizedInterpolation) where T
@@ -74,15 +74,15 @@ function FunctionValues{1}(::Type{T}, ip::Interpolation, qr::QuadratureRule, ip_
     dNdx = fill(zero(typeof_dNdx(T, ip_dims)) * T(NaN), n_shape, n_qpoints)
     
     fv = FunctionValues(ip, N_x, N_ξ, dNdx, dNdξ)
-    precompute_values!(fv, qr) # Separate function for qr point update in PointValues
+    precompute_values!(fv, getpoints(qr)) # Separate function for qr point update in PointValues
     return fv
 end
 
-function precompute_values!(fv::FunctionValues{0}, qr)
-    shape_values!(fv.N_ξ, fv.ip, qr)
+function precompute_values!(fv::FunctionValues{0}, qr_points::Vector{<:Vec})
+    shape_values!(fv.N_ξ, fv.ip, qr_points)
 end
-function precompute_values!(fv::FunctionValues{1}, qr)
-    shape_gradients_and_values!(fv.dNdξ, fv.N_ξ, fv.ip, qr)
+function precompute_values!(fv::FunctionValues{1}, qr_points::Vector{<:Vec})
+    shape_gradients_and_values!(fv.dNdξ, fv.N_ξ, fv.ip, qr_points)
 end
 
 function Base.copy(v::FunctionValues)

--- a/src/FEValues/GeometryMapping.jl
+++ b/src/FEValues/GeometryMapping.jl
@@ -55,7 +55,7 @@ function GeometryMapping{0}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRu
     n_shape = getnbasefunctions(ip)
     n_qpoints = getnquadpoints(qr)
     gm = GeometryMapping(ip, zeros(T, n_shape, n_qpoints), nothing, nothing)
-    precompute_values!(gm, qr) # Separate function for qr point update in PointValues
+    precompute_values!(gm, getpoints(qr))
     return gm
 end
 function GeometryMapping{1}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRule) where T
@@ -66,7 +66,7 @@ function GeometryMapping{1}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRu
     dMdξ = zeros(Vec{getdim(ip),T}, n_shape, n_qpoints)
 
     gm = GeometryMapping(ip, M, dMdξ, nothing)
-    precompute_values!(gm, qr) # Separate function for qr point update in PointValues
+    precompute_values!(gm, getpoints(qr))
     return gm
 end
 function GeometryMapping{2}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRule) where T
@@ -78,18 +78,18 @@ function GeometryMapping{2}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRu
     d2Mdξ2 = zeros(Tensor{2,getdim(ip),T}, n_shape, n_qpoints)
 
     gm = GeometryMapping(ip, M, dMdξ, d2Mdξ2)
-    precompute_values!(gm, qr) # Separate function for qr point update in PointValues
+    precompute_values!(gm, getpoints(qr))
     return gm
 end
 
-function precompute_values!(gm::GeometryMapping{0}, qr)
-    shape_values!(gm.M, gm.ip, qr)
+function precompute_values!(gm::GeometryMapping{0}, qr_points::Vector{<:Vec})
+    shape_values!(gm.M, gm.ip, qr_points)
 end
-function precompute_values!(gm::GeometryMapping{1}, qr)
-    shape_gradients_and_values!(gm.dMdξ, gm.M, gm.ip, qr)
+function precompute_values!(gm::GeometryMapping{1}, qr_points::Vector{<:Vec})
+    shape_gradients_and_values!(gm.dMdξ, gm.M, gm.ip, qr_points)
 end
-function precompute_values!(gm::GeometryMapping{2}, qr)
-    shape_hessians_gradients_and_values!(gm.d2Mdξ2, gm.dMdξ, gm.M, gm.ip, qr)
+function precompute_values!(gm::GeometryMapping{2}, qr_points::Vector{<:Vec})
+    shape_hessians_gradients_and_values!(gm.d2Mdξ2, gm.dMdξ, gm.M, gm.ip, qr_points)
 end
 
 function Base.copy(v::GeometryMapping)

--- a/src/FEValues/GeometryMapping.jl
+++ b/src/FEValues/GeometryMapping.jl
@@ -93,9 +93,7 @@ function precompute_values!(gm::GeometryMapping{2}, qr)
 end
 
 function Base.copy(v::GeometryMapping)
-    copy_or_nothing(x) = copy(x)
-    copy_or_nothing(::Nothing) = nothing
-    return GeometryMapping(copy(v.ip), copy(v.M), copy_or_nothing(v.dMdξ), copy_or_nothing(v.d2Mdξ2))
+    return GeometryMapping(copy(v.ip), copy(v.M), _copy_or_nothing(v.dMdξ), _copy_or_nothing(v.d2Mdξ2))
 end
 
 getngeobasefunctions(geo_mapping::GeometryMapping) = size(geo_mapping.M, 1)

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -275,6 +275,11 @@ function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVecto
     return vec
 end
 
+function shape_gradients_and_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
+    for (qp, ξ) in pairs(getpoints(qr))
+        shape_values!(@view(values[:, qp]), ip, ξ)
+    end
+end
 
 function shape_gradients_and_values!(gradients::AbstractMatrix, values::AbstractMatrix, ip, qr::QuadratureRule)
     for (qp, ξ) in pairs(getpoints(qr))

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -275,7 +275,7 @@ function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVecto
     return vec
 end
 
-function shape_gradients_and_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
+function shape_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
     for (qp, ξ) in pairs(getpoints(qr))
         shape_values!(@view(values[:, qp]), ip, ξ)
     end

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -47,7 +47,7 @@ function getnquadpoints end
     getdetJdV(fe_v::AbstractValues, q_point::Int)
 
 Return the product between the determinant of the Jacobian and the quadrature
-point weight for the given quadrature point: ``\\det(J(\\mathbf{x})) w_q``
+point weight for the given quadrature point: ``\\det(J(\\mathbf{x})) w_q``.
 
 This value is typically used when one integrates a function on a
 finite element cell or face as
@@ -73,6 +73,7 @@ Return the value of the geometric shape function `base_function` evaluated in
 quadrature point `q_point`.
 """
 geometric_value(fe_v::AbstractValues, q_point::Int, base_function::Int)
+
 
 """
     shape_gradient(fe_v::AbstractValues, q_point::Int, base_function::Int)
@@ -109,7 +110,7 @@ curl_from_gradient(∇v::SecondOrderTensor{3}) = Vec{3}((∇v[3,2] - ∇v[2,3], 
 curl_from_gradient(∇v::SecondOrderTensor{2}) = Vec{1}((∇v[2,1] - ∇v[1,2],)) # Alternatively define as Vec{3}((0,0,v))
 
 """
-    function_value(fe_v::AbstractValues, q_point::Int, u::AbstractVector)
+    function_value(fe_v::AbstractValues, q_point::Int, u::AbstractVector, [dof_range])
 
 Compute the value of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
@@ -146,7 +147,7 @@ end
 function_value_init(cv::AbstractValues, ::AbstractVector{T}) where {T} = zero(shape_value_type(cv)) * zero(T)
 
 """
-    function_gradient(fe_v::AbstractValues{dim}, q_point::Int, u::AbstractVector)
+    function_gradient(fe_v::AbstractValues{dim}, q_point::Int, u::AbstractVector, [dof_range])
 
 Compute the gradient of the function in a quadrature point. `u` is a vector with values
 for the degrees of freedom. For a scalar valued function, `u` contains scalars.
@@ -203,7 +204,7 @@ function function_gradient_init(cv::AbstractValues, ::AbstractVector{T}) where {
 end
 
 """
-    function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector)
+    function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector, [dof_range])
 
 Compute the symmetric gradient of the function, see [`function_gradient`](@ref).
 Return a `SymmetricTensor`.
@@ -212,19 +213,17 @@ The symmetric gradient of a scalar function is computed as
 ``\\left[ \\mathbf{\\nabla}  \\mathbf{u}(\\mathbf{x_q}) \\right]^\\text{sym} =  \\sum\\limits_{i = 1}^n  \\frac{1}{2} \\left[ \\mathbf{\\nabla} N_i (\\mathbf{x}_q) \\otimes \\mathbf{u}_i + \\mathbf{u}_i  \\otimes  \\mathbf{\\nabla} N_i (\\mathbf{x}_q) \\right]``
 where ``\\mathbf{u}_i`` are the nodal values of the function.
 """
-function function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector, dof_range = eachindex(u))
+function function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector, dof_range)
     grad = function_gradient(fe_v, q_point, u, dof_range)
     return symmetric(grad)
 end
 
-# TODO: Deprecate this, nobody is using this in practice...
-function function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector{<:Vec})
+function function_symmetric_gradient(fe_v::AbstractValues, q_point::Int, u::AbstractVector)
     grad = function_gradient(fe_v, q_point, u)
     return symmetric(grad)
 end
-
 """
-    function_divergence(fe_v::AbstractValues, q_point::Int, u::AbstractVector)
+    function_divergence(fe_v::AbstractValues, q_point::Int, u::AbstractVector, [dof_range])
 
 Compute the divergence of the vector valued function in a quadrature point.
 
@@ -248,6 +247,15 @@ function function_divergence(fe_v::AbstractValues, q_point::Int, u::AbstractVect
     return diverg
 end
 
+"""
+    function_curl(fe_v::AbstractValues, q_point::Int, u::AbstractVector, [dof_range])
+
+Compute the curl of the vector valued function in a quadrature point.
+
+The curl of a vector valued functions in the quadrature point ``\\mathbf{x}_q)`` is computed as
+``\\mathbf{\\nabla} \\times \\mathbf{u}(\\mathbf{x_q}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i \\times (\\mathbf{x_q}) \\cdot \\mathbf{u}_i``
+where ``\\mathbf{u}_i`` are the nodal values of the function.
+"""
 function_curl(fe_v::AbstractValues, q_point::Int, u::AbstractVector, dof_range = eachindex(u)) =
     curl_from_gradient(function_gradient(fe_v, q_point, u, dof_range))
 
@@ -264,11 +272,11 @@ coordinates of the cell.
 The coordinate is computed, using the geometric interpolation, as
 ``\\mathbf{x} = \\sum\\limits_{i = 1}^n M_i (\\mathbf{x}) \\mathbf{\\hat{x}}_i``
 """
-function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVector{Vec{dim,T}}) where {dim,T}
+function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVector{<:Vec})
     n_base_funcs = getngeobasefunctions(fe_v)
     length(x) == n_base_funcs || throw_incompatible_coord_length(length(x), n_base_funcs)
     @boundscheck checkquadpoint(fe_v, q_point)
-    vec = zero(Vec{dim,T})
+    vec = zero(eltype(x))
     @inbounds for i in 1:n_base_funcs
         vec += geometric_value(fe_v, q_point, i) * x[i]
     end

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -276,12 +276,9 @@ function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVecto
 end
 
 
-# Utility functions used by GeometryMapping, FunctionValues, FaceValues, CellValues 
+# Utility functions used by GeometryMapping, FunctionValues 
 _copy_or_nothing(x) = copy(x)
 _copy_or_nothing(::Nothing) = nothing
-
-_extract_val(v) = v
-_extract_val(::Val{N}) where N = N
 
 function shape_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
     for (qp, ξ) in pairs(getpoints(qr))

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -288,20 +288,20 @@ end
 _copy_or_nothing(x) = copy(x)
 _copy_or_nothing(::Nothing) = nothing
 
-function shape_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
-    for (qp, ξ) in pairs(getpoints(qr))
+function shape_values!(values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+    for (qp, ξ) in pairs(qr_points)
         shape_values!(@view(values[:, qp]), ip, ξ)
     end
 end
 
-function shape_gradients_and_values!(gradients::AbstractMatrix, values::AbstractMatrix, ip, qr::QuadratureRule)
-    for (qp, ξ) in pairs(getpoints(qr))
+function shape_gradients_and_values!(gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+    for (qp, ξ) in pairs(qr_points)
         shape_gradients_and_values!(@view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
     end
 end
 
-function shape_hessians_gradients_and_values!(hessians::AbstractMatrix, gradients::AbstractMatrix, values::AbstractMatrix, ip, qr::QuadratureRule)
-    for (qp, ξ) in pairs(getpoints(qr))
+function shape_hessians_gradients_and_values!(hessians::AbstractMatrix, gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+    for (qp, ξ) in pairs(qr_points)
         shape_hessians_gradients_and_values!(@view(hessians[:, qp]), @view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
     end
 end

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -275,6 +275,14 @@ function spatial_coordinate(fe_v::AbstractValues, q_point::Int, x::AbstractVecto
     return vec
 end
 
+
+# Utility functions used by GeometryMapping, FunctionValues, FaceValues, CellValues 
+_copy_or_nothing(x) = copy(x)
+_copy_or_nothing(::Nothing) = nothing
+
+_extract_val(v) = v
+_extract_val(::Val{N}) where N = N
+
 function shape_values!(values::AbstractMatrix, ip, qr::QuadratureRule)
     for (qp, ξ) in pairs(getpoints(qr))
         shape_values!(@view(values[:, qp]), ip, ξ)

--- a/src/FEValues/face_integrals.jl
+++ b/src/FEValues/face_integrals.jl
@@ -1,12 +1,21 @@
 """
     face_to_element_transformation(point::Vec, ::Type{<:AbstractRefShape}, face::Int)
 
-Transform quadrature point from face's reference (N-1)D coordinates to ND coordinates on the
-cell's face.
+Transform quadrature point from face's reference coordinates to coordinates on the
+cell's face, increasing the number of dimensions by one.
 """
 face_to_element_transformation
 
 """
+    element_to_face_transformation(point::AbstractVector, cell::AbstractCell{AbstractRefShape}, face::Int)
+
+Transform quadrature point from cell's coordinates to the face's reference coordinates, decreasing the number of dimensions by one.
+This is the inverse of `face_to_element_transformation`.
+"""
+element_to_face_transformation
+
+"""
+    weighted_normal(J::AbstractTensor, fv::FaceValues, face::Int)
     weighted_normal(J::AbstractTensor, ::Type{<:AbstractRefShape}, face::Int)
 
 Compute the vector normal to the face weighted by the area ratio between the face and the
@@ -59,9 +68,17 @@ end
 ##################
 
 # Mapping from to 0D node to 1D line vertex.
-function face_to_element_transformation(::Vec{0, T}, ::Type{RefLine}, face::Int) where {T}
+function face_to_element_transformation(::Union{Vec{0, T},Vec{1, T}}, ::Type{RefLine}, face::Int) where {T}
     face == 1 && return Vec{1, T}(( -one(T),))
     face == 2 && return Vec{1, T}((  one(T),))
+    throw(ArgumentError("unknown face number"))
+end
+
+# Mapping from 1D line to point.
+function element_to_face_transformation(point::Vec{1, T}, ::Type{RefLine}, face::Int) where T
+    x = point[]
+    face == 1 && return Vec(-x)
+    face == 2 && return Vec( x)
     throw(ArgumentError("unknown face number"))
 end
 
@@ -82,6 +99,16 @@ function face_to_element_transformation(point::Vec{1, T}, ::Type{RefQuadrilatera
     face == 2 && return Vec{2, T}(( one(T),     x))
     face == 3 && return Vec{2, T}(( -x,         one(T)))
     face == 4 && return Vec{2, T}(( -one(T),    -x))
+    throw(ArgumentError("unknown face number"))
+end
+
+# Mapping from 2D face of a quadrilateral to 1D line.
+function element_to_face_transformation(point::Vec{2, T}, ::Type{RefQuadrilateral}, face::Int) where T
+    x, y = point
+    face == 1 && return Vec( x)
+    face == 2 && return Vec( y)
+    face == 3 && return Vec( -x)
+    face == 4 && return Vec( -y)
     throw(ArgumentError("unknown face number"))
 end
 
@@ -108,6 +135,15 @@ function face_to_element_transformation(point::Vec{1, T},  ::Type{RefTriangle}, 
     throw(ArgumentError("unknown face number"))
 end
 
+# Mapping from 2D face of a triangle to 1D line.
+function element_to_face_transformation(point::Vec{2, T}, ::Type{RefTriangle}, face::Int) where T
+    x, y = point
+    face == 1 && return Vec( one(T) - x * 2)
+    face == 2 && return Vec( one(T) - y * 2 )
+    face == 3 && return Vec( x * 2 - one(T))
+    throw(ArgumentError("unknown face number"))
+end
+
 function weighted_normal(J::Tensor{2,2}, ::Type{RefTriangle}, face::Int)
     @inbounds begin
         face == 1 && return Vec{2}((-(J[2,1] - J[2,2]), J[1,1] - J[1,2]))
@@ -130,6 +166,18 @@ function face_to_element_transformation(point::Vec{2, T}, ::Type{RefHexahedron},
     face == 4 && return Vec{3, T}(( -x,     one(T),     y))
     face == 5 && return Vec{3, T}((-one(T), y,          x))
     face == 6 && return Vec{3, T}(( x,      y,          one(T)))
+    throw(ArgumentError("unknown face number"))
+end
+
+# Mapping from 3D face of a hexahedron to 2D quadrilateral.
+function element_to_face_transformation(point::Vec{3, T}, ::Type{RefHexahedron}, face::Int) where T
+    x, y, z = point
+    face == 1 && return Vec( y, x)
+    face == 2 && return Vec( x, z)
+    face == 3 && return Vec( y,  z)
+    face == 4 && return Vec( -x,  z)
+    face == 5 && return Vec( z,  y)
+    face == 6 && return Vec( x,  y)
     throw(ArgumentError("unknown face number"))
 end
 
@@ -159,6 +207,16 @@ function face_to_element_transformation(point::Vec{2, T}, ::Type{RefTetrahedron}
     throw(ArgumentError("unknown face number"))
 end
 
+# Mapping from 3D face of a tetrahedon to 2D triangle.
+function element_to_face_transformation(point::Vec{3, T}, ::Type{RefTetrahedron}, face::Int) where T
+    x, y, z = point
+    face == 1 && return Vec( one(T)-x-y,  y)
+    face == 2 && return Vec( one(T)-z-x,  x)
+    face == 3 && return Vec( x,  y)
+    face == 4 && return Vec( one(T)-y-z,  z)
+    throw(ArgumentError("unknown face number"))
+end
+
 function weighted_normal(J::Tensor{2,3}, ::Type{RefTetrahedron}, face::Int)
     @inbounds begin
         face == 1 && return J[:,2] × J[:,1]
@@ -185,6 +243,17 @@ function face_to_element_transformation(point::Vec{2, T}, ::Type{RefPrism}, face
     throw(ArgumentError("unknown face number"))
 end
 
+# Mapping from 3D face of a wedge to 2D triangle or 2D quadrilateral.
+function element_to_face_transformation(point::Vec{3, T}, ::Type{RefPrism}, face::Int) where T
+    x, y, z = point
+    face == 1 && return Vec( one(T)-x-y,  y)
+    face == 2 && return Vec( 2*x - one(T), 2*z - one(T) )
+    face == 3 && return Vec( 2*(one(T) - y) - one(T), 2*z - one(T) )
+    face == 4 && return Vec( 2*y - one(T), 2*z - one(T) )
+    face == 5 && return Vec( one(T) - x - y,  x)
+    throw(ArgumentError("unknown face number"))
+end
+
 function weighted_normal(J::Tensor{2,3}, ::Type{RefPrism}, face::Int)
     @inbounds begin
         face == 1 && return J[:,2] × J[:,1]
@@ -208,6 +277,17 @@ function face_to_element_transformation(point::Vec{2, T}, ::Type{RefPyramid}, fa
     face == 3 && return Vec{3, T}(( zero(T),        one(T)-x-y,         y))
     face == 4 && return Vec{3, T}(( x+y,            y,                  one(T)-x-y))
     face == 5 && return Vec{3, T}(( one(T)-x-y,     one(T)-y,           y))
+    throw(ArgumentError("unknown face number"))
+end
+
+# Mapping from 3D face of a pyramid to 2D triangle or 2D quadrilateral.
+function element_to_face_transformation(point::Vec{3, T}, ::Type{RefPyramid}, face::Int) where T
+    x, y, z = point
+    face == 1 && return Vec( 2*y - one(T),  2*x - one(T))
+    face == 2 && return Vec( one(T) - z - x, x)
+    face == 3 && return Vec( one(T) - y - z, z)
+    face == 4 && return Vec( x - y, y)
+    face == 5 && return Vec( one(T) - x - z,  z)
     throw(ArgumentError("unknown face number"))
 end
 

--- a/src/FEValues/interface_values.jl
+++ b/src/FEValues/interface_values.jl
@@ -1,0 +1,589 @@
+# Defines InterfaceValues and common methods
+"""
+    InterfaceValues
+
+An `InterfaceValues` object facilitates the process of evaluating values, averages, jumps
+and gradients of shape functions and function on the interfaces between elements.
+
+The first element of the interface is denoted "here" and the second element "there".
+
+**Constructors**
+* `InterfaceValues(qr::FaceQuadratureRule, ip::Interpolation)`: same quadrature rule and
+  interpolation on both sides, default linear Lagrange geometric interpolation.
+* `InterfaceValues(qr::FaceQuadratureRule, ip::Interpolation, ip_geo::Interpolation)`: same
+  as above but with given geometric interpolation.
+* `InterfaceValues(qr_here::FaceQuadratureRule, ip_here::Interpolation, qr_there::FaceQuadratureRule, ip_there::Interpolation)`:
+  different quadrature rule and interpolation on the two sides, default linear Lagrange
+  geometric interpolation.
+* `InterfaceValues(qr_here::FaceQuadratureRule, ip_here::Interpolation, ip_geo_here::Interpolation, qr_there::FaceQuadratureRule, ip_there::Interpolation, ip_geo_there::Interpolation)`:
+  same as above but with given geometric interpolation.
+* `InterfaceValues(fv::FaceValues)`: quadrature rule and interpolations from face values
+  (same on both sides).
+* `InterfaceValues(fv_here::FaceValues, fv_there::FaceValues)`: quadrature rule and
+  interpolations from the face values.
+
+**Associated methods:**
+* [`shape_value_average`](@ref)
+* [`shape_value_jump`](@ref)
+* [`shape_gradient_average`](@ref)
+* [`shape_gradient_jump`](@ref)
+
+**Common methods:**
+* [`reinit!`](@ref)
+* [`getnquadpoints`](@ref)
+* [`getdetJdV`](@ref)
+
+* [`shape_value`](@ref)
+* [`shape_gradient`](@ref)
+* [`shape_divergence`](@ref)
+* [`shape_curl`](@ref)
+
+* [`function_value`](@ref)
+* [`function_gradient`](@ref)
+* [`function_symmetric_gradient`](@ref)
+* [`function_divergence`](@ref)
+* [`function_curl`](@ref)
+* [`spatial_coordinate`](@ref)
+"""
+InterfaceValues
+
+struct InterfaceValues{FVA <: FaceValues, FVB <: FaceValues} <: AbstractValues
+    here::FVA
+    there::FVB
+    function InterfaceValues{FVA, FVB}(here::FVA, there::FVB) where {FVA, FVB}
+        # TODO: check that fields don't alias
+        return new{FVA, FVB}(here, there)
+    end
+end
+
+function InterfaceValues(
+        qr_here::FaceQuadratureRule, ip_here::Interpolation, ipg_here::Interpolation,
+        qr_there::FaceQuadratureRule, ip_there::Interpolation, ipg_there::Interpolation
+        )
+    # FaceValues constructor enforces that refshape matches for all arguments
+    here = FaceValues(qr_here, ip_here, ipg_here)
+    there = FaceValues(qr_there, ip_there, ipg_there)
+    return InterfaceValues{typeof(here), typeof(there)}(here, there)
+end
+
+# Same on both sides, default geometric mapping
+InterfaceValues(qr_here::FaceQuadratureRule, ip_here::Interpolation) =
+    InterfaceValues(qr_here, ip_here, deepcopy(qr_here), ip_here)
+# Same on both sides, given geometric mapping
+InterfaceValues(qr_here::FaceQuadratureRule, ip_here::Interpolation, ipg_here::Interpolation) =
+    InterfaceValues(qr_here, ip_here, ipg_here, deepcopy(qr_here), ip_here, ipg_here)
+# Different on both sides, default geometric mapping
+function InterfaceValues(
+        qr_here::FaceQuadratureRule, ip_here::Interpolation,
+        qr_there::FaceQuadratureRule, ip_there::Interpolation,
+    )
+    return InterfaceValues(
+        qr_here, ip_here, default_geometric_interpolation(ip_here),
+        qr_there, ip_there, default_geometric_interpolation(ip_there),
+    )
+end
+# From FaceValue(s)
+InterfaceValues(facevalues_here::FVA, facevalues_there::FVB = deepcopy(facevalues_here)) where {FVA <: FaceValues, FVB <: FaceValues} =
+    InterfaceValues{FVA,FVB}(facevalues_here, facevalues_there)
+
+function Base.copy(iv::InterfaceValues)
+    return InterfaceValues(copy(iv.here), copy(iv.there))
+end
+
+function getnbasefunctions(iv::InterfaceValues)
+    return getnbasefunctions(iv.here) + getnbasefunctions(iv.there)
+end
+
+"""
+    getnquadpoints(iv::InterfaceValues)
+
+Return the number of quadrature points on the interface for the current (most recently
+[`reinit!`](@ref)ed) interface.
+"""
+getnquadpoints(iv::InterfaceValues) = getnquadpoints(iv.here)
+
+@propagate_inbounds function getdetJdV(iv::InterfaceValues, q_point::Int)
+    return getdetJdV(iv.here, q_point)
+end
+
+"""
+    reinit!(
+        iv::InterfaceValues,
+        cell_here::AbstractCell, coords_here::AbstractVector{Vec{dim, T}}, face_here::Int,
+        cell_there::AbstractCell, coords_there::AbstractVector{Vec{dim, T}}, face_there::Int
+    )
+
+Update the [`InterfaceValues`](@ref) for the interface between `cell_here` (with cell
+coordinates `coords_here`) and `cell_there` (with cell coordinates `coords_there`).
+`face_here` and `face_there` are the (local) face numbers for the respective cell.
+"""
+function reinit!(
+        iv::InterfaceValues,
+        cell_here::AbstractCell, coords_here::AbstractVector{Vec{dim, T}}, face_here::Int,
+        cell_there::AbstractCell, coords_there::AbstractVector{Vec{dim, T}}, face_there::Int
+    ) where {dim, T}
+
+    # reinit! the here side as normal
+    reinit!(iv.here, coords_here, face_here)
+    dim == 1 && return reinit!(iv.there, coords_there, face_there)
+    # Transform the quadrature points from the here side to the there side
+    set_current_face!(iv.there, face_there)
+    interface_transformation = InterfaceOrientationInfo(cell_here, cell_there, face_here, face_there)
+    quad_points_a = getpoints(iv.here.qr, face_here)
+    quad_points_b = getpoints(iv.there.qr, face_there)
+    transform_interface_points!(quad_points_b, quad_points_a, interface_transformation)
+    @boundscheck checkface(iv.there, face_there)
+    # TODO: This is the bottleneck, cache it?
+    @assert length(quad_points_a) <= length(quad_points_b)
+    
+    # Re-evalutate shape functions in the transformed quadrature points
+    precompute_values!(iv.there.fun_values, quad_points_b)
+    precompute_values!(iv.there.geo_mapping, quad_points_b)
+    
+    # reinit! the "there" side
+    reinit!(iv.there, coords_there, face_there)
+    return iv
+end
+
+"""
+    getnormal(iv::InterfaceValues, qp::Int; here::Bool=true)
+
+Return the normal vector in the quadrature point `qp` on the interface. If `here = true`
+(default) the outward normal to the "here" element is returned, otherwise the outward normal
+to the "there" element.
+"""
+function getnormal(iv::InterfaceValues, qp::Int; here::Bool=true)
+    # TODO: Remove the `here` kwarg and let user use `- getnormal(iv, qp)` instead?
+    return getnormal(here ? iv.here : iv.there, qp)
+end
+
+"""
+    function_value(iv::InterfaceValues, q_point::Int, u; here::Bool)
+    function_value(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there; here::Bool)
+
+Compute the value of the function in quadrature point `q_point` on the "here" (`here=true`)
+or "there" (`here=false`) side of the interface. `u_here` and `u_there` are the values of
+the degrees of freedom for the respeciv element.
+
+`u` is a vector of scalar values for the degrees of freedom.
+This function can be used with a single `u` vector containing the dofs of both elements of the interface or
+two vectors (`u_here` and `u_there`) which contain the dofs of each cell of the interface respectively.
+
+`here` determines which element to use for calculating function value.
+`true` uses the value on the first element's side of the interface, while `false` uses the value on the second element's side.
+
+The value of a scalar valued function is computed as ``u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) u_i``
+where ``u_i`` are the value of ``u`` in the nodes. For a vector valued function the value is calculated as
+``\\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n N_i (\\mathbf{x}) \\mathbf{u}_i`` where ``\\mathbf{u}_i`` are the
+nodal values of ``\\mathbf{u}``.
+"""
+function_value(::InterfaceValues, ::Int, args...; kwargs...)
+
+
+"""
+    function_gradient(iv::InterfaceValues, q_point::Int, u; here::Bool)
+    function_gradient(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there; here::Bool)
+
+Compute the gradient of the function in a quadrature point. `u` is a vector of scalar values for the degrees of freedom.
+This function can be used with a single `u` vector containing the dofs of both elements of the interface or
+two vectors (`u_here` and `u_there`) which contain the dofs of each cell of the interface respectively.
+
+`here` determines which element to use for calculating function value.
+`true` uses the value on the first element's side of the interface, while `false` uses the value on the second element's side.
+
+The gradient of a scalar function or a vector valued function with use of `VectorValues` is computed as
+``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} N_i (\\mathbf{x}) u_i`` or
+``\\mathbf{\\nabla} u(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{\\nabla} \\mathbf{N}_i (\\mathbf{x}) u_i`` respectively,
+where ``u_i`` are the nodal values of the function.
+For a vector valued function with use of `ScalarValues` the gradient is computed as
+``\\mathbf{\\nabla} \\mathbf{u}(\\mathbf{x}) = \\sum\\limits_{i = 1}^n \\mathbf{u}_i \\otimes \\mathbf{\\nabla} N_i (\\mathbf{x})``
+where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
+"""
+function_gradient(::InterfaceValues, ::Int, args...; kwargs...)
+
+"""
+    shape_value_average(iv::InterfaceValues, qp::Int, i::Int)
+
+Compute the average of the value of shape function `i` at quadrature point `qp` across the
+interface.
+"""
+function shape_value_average end
+
+"""
+    shape_value_jump(iv::InterfaceValues, qp::Int, i::Int)
+
+Compute the jump of the value of shape function `i` at quadrature point `qp` across the
+interface.
+
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
+multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+
+"""
+function shape_value_jump end
+
+"""
+    shape_gradient_average(iv::InterfaceValues, qp::Int, i::Int)
+
+Compute the average of the gradient of shape function `i` at quadrature point `qp` across
+the interface.
+"""
+function shape_gradient_average end
+
+"""
+    shape_gradient_jump(iv::InterfaceValues, qp::Int, i::Int)
+
+Compute the jump of the gradient of shape function `i` at quadrature point `qp` across the
+interface.
+
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
+multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+"""
+function shape_gradient_jump end
+
+for (func,                      f_,              f_type) in (
+    (:shape_value,              :shape_value,    :shape_value_type),
+    (:shape_gradient,           :shape_gradient, :shape_gradient_type),
+)
+    @eval begin
+        function $(func)(iv::InterfaceValues, qp::Int, i::Int; here::Bool)
+            nbf = getnbasefunctions(iv)
+            nbf_a = getnbasefunctions(iv.here)
+            if i <= nbf_a
+                fv = iv.here
+                here || return zero($(f_type)(fv))
+                f_value = $(f_)(fv, qp, i)
+                return f_value
+            elseif i <= nbf
+                fv = iv.there
+                here && return zero($(f_type)(fv))
+                f_value = $(f_)(fv, qp, i - nbf_a)
+                return f_value
+            end
+            error("Invalid base function $i. Interface has only $(nbf) base functions")
+        end
+    end
+end
+
+for (func,                      f_,               is_avg) in (
+    (:shape_value_average,      :shape_value,     true),
+    (:shape_gradient_average,   :shape_gradient,  true),
+    (:shape_value_jump,         :shape_value,     false),
+    (:shape_gradient_jump,      :shape_gradient,  false),
+)
+    @eval begin
+        function $(func)(iv::InterfaceValues, qp::Int, i::Int)
+            f_here = $(f_)(iv, qp, i; here = true)
+            f_there = $(f_)(iv, qp, i; here = false)
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+        end
+    end
+end
+
+"""
+    function_value_average(iv::InterfaceValues, q_point::Int, u)
+    function_value_average(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
+
+Compute the average of the function value at the quadrature point on interface.
+"""
+function function_value_average end
+
+"""
+    function_value_jump(iv::InterfaceValues, q_point::Int, u)
+    function_value_jump(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
+
+Compute the jump of the function value at the quadrature point over the interface.
+
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
+multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+"""
+function function_value_jump end
+
+"""
+    function_gradient_average(iv::InterfaceValues, q_point::Int, u)
+    function_gradient_average(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
+
+Compute the average of the function gradient at the quadrature point on the interface.
+"""
+function function_gradient_average end
+
+"""
+    function_gradient_jump(iv::InterfaceValues, q_point::Int, u)
+    function_gradient_jump(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
+
+Compute the jump of the function gradient at the quadrature point over the interface.
+
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
+multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+"""
+function function_gradient_jump end
+
+for (func,                          ) in (
+    (:function_value,               ),
+    (:function_gradient,            ),
+)
+    @eval begin
+        function $(func)(
+                iv::InterfaceValues, q_point::Int, u::AbstractVector;
+                here::Bool
+            )
+            @boundscheck checkbounds(u, 1:getnbasefunctions(iv))
+            if here
+                dof_range_here = 1:getnbasefunctions(iv.here)
+                return $(func)(iv.here, q_point, @view(u[dof_range_here]))
+            else # there
+                dof_range_there = (1:getnbasefunctions(iv.there)) .+ getnbasefunctions(iv.here)
+                return $(func)(iv.there, q_point, @view(u[dof_range_there]))
+            end
+        end
+        function $(func)(
+                iv::InterfaceValues, q_point::Int,
+                u::AbstractVector,
+                dof_range_here::AbstractUnitRange{Int}, dof_range_there::AbstractUnitRange{Int};
+                here::Bool
+            )
+            @boundscheck checkbounds(u, dof_range_here)
+            @boundscheck checkbounds(u, dof_range_there)
+            if here
+                return $(func)(iv.here, q_point, u, dof_range_here)
+            else # there
+                return $(func)(iv.there, q_point, u, dof_range_there)
+            end
+        end
+    end
+end
+
+for (func,                          f_,                     is_avg) in (
+    (:function_value_average,       :function_value,        true ),
+    (:function_gradient_average,    :function_gradient,     true ),
+    (:function_value_jump,          :function_value,        false),
+    (:function_gradient_jump,       :function_gradient,     false),
+)
+    @eval begin
+        function $(func)(iv::InterfaceValues, qp::Int, u::AbstractVector)
+            @boundscheck checkbounds(u, getnbasefunctions(iv))
+            dof_range_here = 1:getnbasefunctions(iv.here)
+            dof_range_there = (1:getnbasefunctions(iv.there)) .+ getnbasefunctions(iv.here)
+            f_here = $(f_)(iv.here, qp, @view(u[dof_range_here]))
+            f_there = $(f_)(iv.there, qp, @view(u[dof_range_there]))
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+        end
+        function $(func)(
+                iv::InterfaceValues, qp::Int,
+                u::AbstractVector,
+                dof_range_here::AbstractUnitRange{Int}, dof_range_there::AbstractUnitRange{Int},
+            )
+            f_here = $(f_)(iv.here, qp, u, dof_range_here)
+            f_there = $(f_)(iv.there, qp, u, dof_range_there)
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+        end
+    end
+end
+
+function spatial_coordinate(
+        iv::InterfaceValues, q_point::Int,
+        x_here::AbstractVector{<:Vec}, x_there::AbstractVector{<:Vec}; here::Bool,
+    )
+    if here
+        return spatial_coordinate(iv.here, q_point, x_here)
+    else
+        return spatial_coordinate(iv.there, q_point, x_there)
+    end
+end
+
+
+# Transformation of quadrature points
+
+@doc raw"""
+    InterfaceOrientationInfo
+
+Relative orientation information for 1D and 2D interfaces in 2D and 3D elements respectively.
+This information is used to construct the transformation matrix to
+transform the quadrature points from face_a to face_b achieving synced
+spatial coordinates. Face B's orientation relative to Face A's can
+possibly flipped (i.e. the vertices indices order is reversed)
+and the vertices can be rotated against each other.
+The reference orientation of face B is such that the first node
+has the lowest vertex index. Thus, this structure also stores the
+shift of the lowest vertex index which is used to reorient the face in
+case of flipping ["transform_interface_points!"](@ref).
+"""
+struct InterfaceOrientationInfo{RefShapeA, RefShapeB}
+    flipped::Bool
+    shift_index::Int
+    lowest_node_shift_index::Int
+    face_a::Int
+    face_b::Int
+end
+
+"""
+    InterfaceOrientationInfo(cell_a::AbstractCell, cell_b::AbstractCell, face_a::Int, face_b::Int)
+
+Return the relative orientation info for face B with regards to face A.
+Relative orientation is computed using a [`OrientationInfo`](@ref) for each side of the interface.
+"""
+function InterfaceOrientationInfo(cell_a::AbstractCell{RefShapeA}, cell_b::AbstractCell{RefShapeB}, face_a::Int, face_b::Int) where {RefShapeA <: AbstractRefShape, RefShapeB <: AbstractRefShape}
+    OI_a = OrientationInfo(faces(cell_a)[face_a])
+    OI_b = OrientationInfo(faces(cell_b)[face_b])
+    flipped = OI_a.flipped != OI_b.flipped
+    shift_index = OI_b.shift_index - OI_a.shift_index
+    return InterfaceOrientationInfo{RefShapeA, RefShapeB}(flipped, shift_index, OI_b.shift_index, face_a, face_b)
+end
+
+function InterfaceOrientationInfo(_::AbstractCell{RefShapeA}, _::AbstractCell{RefShapeB}, _::Int, _::Int) where {RefShapeA <: AbstractRefShape{1}, RefShapeB <: AbstractRefShape{1}}
+    (error("1D elements don't use transformations for interfaces."))
+end
+
+"""
+    get_transformation_matrix(interface_transformation::InterfaceOrientationInfo)
+
+Returns the transformation matrix corresponding to the interface orientation information stored in `InterfaceOrientationInfo`.
+The transformation matrix is constructed using a combination of affine transformations defined for each interface reference shape.
+The transformation for a flipped face is a function of both relative orientation and the orientation of the second face.
+If the face is not flipped then the transfromation is a function of relative orientation only.
+"""
+get_transformation_matrix
+
+function get_transformation_matrix(interface_transformation::InterfaceOrientationInfo{RefShapeA}) where RefShapeA <: AbstractRefShape{3}
+    face_a = interface_transformation.face_a
+    facenodes = reference_faces(RefShapeA)[face_a]
+    _get_transformation_matrix(facenodes, interface_transformation)
+end
+
+@inline function _get_transformation_matrix(::NTuple{3,Int}, interface_transformation::InterfaceOrientationInfo)
+    flipped = interface_transformation.flipped
+    shift_index = interface_transformation.shift_index
+    lowest_node_shift_index = interface_transformation.lowest_node_shift_index
+
+    θ = 2*shift_index/3
+    θpre = 2*lowest_node_shift_index/3
+
+    flipping = SMatrix{3,3}(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
+
+    translate_1 = SMatrix{3,3}(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -sinpi(2/3)/3, -0.5, 1.0)
+    stretch_1 = SMatrix{3,3}(sinpi(2/3), 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+    translate_2 = SMatrix{3,3}(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, sinpi(2/3)/3, 0.5, 1.0)
+    stretch_2 = SMatrix{3,3}(1/sinpi(2/3), -1/2/sinpi(2/3), 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+    return flipped ? stretch_2 * translate_2 * rotation_tensor(0,0,θpre*pi) * flipping * rotation_tensor(0,0,(θ - θpre)*pi) * translate_1 * stretch_1 :
+        stretch_2 * translate_2 * rotation_tensor(0,0,θ*pi) * translate_1 * stretch_1
+end
+
+@inline function _get_transformation_matrix(::NTuple{4,Int}, interface_transformation::InterfaceOrientationInfo)
+    flipped = interface_transformation.flipped
+    shift_index = interface_transformation.shift_index
+    lowest_node_shift_index = interface_transformation.lowest_node_shift_index
+
+    θ = 2*shift_index/4
+    θpre = 2*lowest_node_shift_index/4
+
+    flipping = SMatrix{3,3}(0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+    return flipped ? rotation_tensor(0,0,θpre*pi) * flipping * rotation_tensor(0,0,(θ - θpre)*pi) :  rotation_tensor(0,0,θ*pi)
+end
+
+@inline function _get_transformation_matrix(::NTuple{N,Int}, ::InterfaceOrientationInfo) where N
+    throw(ArgumentError("transformation is not implemented"))    
+end
+
+@doc raw"""
+    transform_interface_points!(dst::Vector{Vec{3, Float64}}, points::Vector{Vec{3, Float64}}, interface_transformation::InterfaceTransformation)
+
+Transform the points from face A to face B using the orientation information of the interface and store it in the vecotr dst.
+For 3D, the faces are transformed to regular polygons such that the rotation angle is the shift in reference node index × 2π ÷ number of edges in face.
+If the face is flipped then the flipping is about the axis that perserves the position of the first node (which is the reference node after being rotated to be in the first position,
+it's rotated back in the opposite direction after flipping).
+Take for example the interface
+```
+        2           3
+        | \         | \
+        |  \        |  \
+y       | A \       | B \
+↑       |    \      |    \
+→  x    1-----3     1-----2
+```
+Transforming A to a equilateral triangle and translating it such that {0,0} is equidistant to all nodes
+```
+        3
+        +
+       / \
+      /   \
+     /  x  \
+    /   ↑   \
+   /  ←      \
+  /  y        \
+2+-------------+1
+```
+Rotating it -270° (or 120°) such that the reference node (the node with smallest index) is at index 1
+```
+        1
+        +
+       / \
+      /   \
+     /  x  \
+    /   ↑   \
+   /  ←      \
+  /  y        \
+3+-------------+2
+```
+Flipping about the x axis (such that the position of the reference node doesn't change) and rotating 270° (or -120°)
+```
+        2
+        +
+       / \
+      /   \
+     /  x  \
+    /   ↑   \
+   /  ←      \
+  /  y        \
+3+-------------+1
+```
+Transforming back to triangle B
+```
+       3
+       | \
+       |  \
+y      |   \
+↑      |    \
+→ x    1-----2
+```
+"""
+transform_interface_points!
+
+function transform_interface_points!(dst::Vector{Vec{3, Float64}}, points::Vector{Vec{3, Float64}}, interface_transformation::InterfaceOrientationInfo{RefShapeA, RefShapeB}) where {RefShapeA <: AbstractRefShape{3}, RefShapeB <: AbstractRefShape{3}}
+    face_a = interface_transformation.face_a
+    face_b = interface_transformation.face_b
+
+    M = get_transformation_matrix(interface_transformation)
+    for (idx, point) in pairs(points)
+        face_point = element_to_face_transformation(point, RefShapeA, face_a)
+        result = M * Vec(face_point[1],face_point[2], 1.0)
+        dst[idx] = face_to_element_transformation(Vec(result[1],result[2]), RefShapeB, face_b)
+    end
+    return nothing
+end
+
+function transform_interface_points!(dst::Vector{Vec{2, Float64}}, points::Vector{Vec{2, Float64}}, interface_transformation::InterfaceOrientationInfo{RefShapeA, RefShapeB}) where {RefShapeA <: AbstractRefShape{2}, RefShapeB <: AbstractRefShape{2}}
+    face_a = interface_transformation.face_a
+    face_b = interface_transformation.face_b
+    flipped = interface_transformation.flipped
+
+    for (idx, point) in pairs(points)
+        face_point = element_to_face_transformation(point, RefShapeA, face_a)
+        flipped && (face_point *= -1)
+        dst[idx] = face_to_element_transformation(face_point, RefShapeB, face_b)
+    end
+    return nothing
+end
+
+function Base.show(io::IO, m::MIME"text/plain", iv::InterfaceValues)
+    println(io, "InterfaceValues with")
+    print(io, "{Here} ")
+    show(io,m,iv.here)
+    println(io)
+    print(io, "{There} ")
+    show(io,m,iv.there)
+end

--- a/src/FEValues/interface_values.jl
+++ b/src/FEValues/interface_values.jl
@@ -127,18 +127,17 @@ function reinit!(
     reinit!(iv.here, coords_here, face_here)
     dim == 1 && return reinit!(iv.there, coords_there, face_there)
     # Transform the quadrature points from the here side to the there side
-    set_current_face!(iv.there, face_there)
+    set_current_face!(iv.there, face_there) # Includes boundscheck
     interface_transformation = InterfaceOrientationInfo(cell_here, cell_there, face_here, face_there)
     quad_points_a = getpoints(iv.here.qr, face_here)
     quad_points_b = getpoints(iv.there.qr, face_there)
     transform_interface_points!(quad_points_b, quad_points_a, interface_transformation)
-    @boundscheck checkface(iv.there, face_there)
     # TODO: This is the bottleneck, cache it?
     @assert length(quad_points_a) <= length(quad_points_b)
     
     # Re-evalutate shape functions in the transformed quadrature points
-    precompute_values!(iv.there.fun_values, quad_points_b)
-    precompute_values!(iv.there.geo_mapping, quad_points_b)
+    precompute_values!(get_fun_values(iv.there),  quad_points_b)
+    precompute_values!(get_geo_mapping(iv.there), quad_points_b)
     
     # reinit! the "there" side
     reinit!(iv.there, coords_there, face_there)

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -33,6 +33,8 @@ const RefTetrahedron   = RefSimplex{3}
 struct RefPrism         <: AbstractRefShape{3} end
 struct RefPyramid       <: AbstractRefShape{3} end
 
+abstract type AbstractCell{refshape <: AbstractRefShape} end
+
 abstract type AbstractValues end
 abstract type AbstractCellValues <: AbstractValues end
 abstract type AbstractFaceValues <: AbstractValues end
@@ -86,6 +88,8 @@ include("FEValues/GeometryMapping.jl")
 include("FEValues/FunctionValues.jl")
 include("FEValues/CellValues.jl")
 include("FEValues/FaceValues.jl")
+include("FEValues/interface_values.jl")
+
 include("PointEval/point_values.jl")
 include("FEValues/common_values.jl")
 include("FEValues/face_integrals.jl")

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -39,7 +39,8 @@ get_coordinate_eltype(::Node{dim,T}) where {dim,T} = T
 # AbstractCell interface #
 ##########################
 
-abstract type AbstractCell{refshape <: AbstractRefShape} end
+# Defined in src/Ferrite.jl
+# abstract type AbstractCell{refshape <: AbstractRefShape} end
 
 getrefshape(::AbstractCell{refshape}) where refshape = refshape
 
@@ -765,8 +766,11 @@ for INDEX in (:VertexIndex, :EdgeIndex, :FaceIndex)
         #To be able to do a,b = faceidx
         Base.iterate(I::($INDEX), state::Int=1) = (state==3) ?  nothing : (I[state], state+1)
 
-        #For (cellid, faceidx) in faceset
-        Base.in(v::Tuple{Int, Int}, s::Set{$INDEX}) = in($INDEX(v), s)
+        # Necessary to check if, e.g. `(cellid, faceidx) in faceset`
+        Base.isequal(x::$INDEX, y::$INDEX) = x.idx == y.idx
+        Base.isequal(x::Tuple{Int, Int}, y::$INDEX) = x[1] == y.idx[1] && x[2] == y.idx[2]
+        Base.isequal(y::$INDEX, x::Tuple{Int, Int}) = x[1] == y.idx[1] && x[2] == y.idx[2]
+        Base.hash(x::$INDEX, h::UInt) = hash(x.idx, h)
     end
 end
 
@@ -822,4 +826,69 @@ the shift index.
 struct SurfaceOrientationInfo
     #flipped::Bool
     #shift_index::Int
+end
+
+
+@doc raw"""
+    InterfaceOrientationInfo
+
+Orientation information for 1D and 2D entities.
+The orientation is defined by the indices of the grid nodes
+associated to the vertices. To give an example, the oriented path
+```
+1 ---> 2
+```
+is called *regular*, indicated by `flipped=false`, while the oriented path
+```
+2 ---> 1
+```
+is called *inverted*, indicated by `flipped=true`.
+
+2D entities can be flipped (i.e. the defining vertex order is reverse to the 
+spanning vertex order) and the vertices can be rotated against each other.
+
+The reference entity is a one with it's first node is the lowest index vertex
+and its vertices span counter-clock-wise.
+Take for example the faces
+```
+1           2
+| \         | \
+|  \        |  \
+| A \       | B \
+|    \      |    \
+2-----3     3-----1
+```
+which are rotated against each other by 240° after tranfroming to an
+equilateral triangle (shift index is 2). Or the faces
+```
+3           2
+| \         | \
+|  \        |  \
+| A \       | B \
+|    \      |    \
+2-----1     3-----1
+```
+which are flipped against each other.
+"""
+struct OrientationInfo
+    flipped::Bool
+    shift_index::Int
+end
+
+function OrientationInfo(path::NTuple{2, Int})
+    flipped = first(path) < last(path)
+    return OrientationInfo(flipped, 0)
+end
+
+function OrientationInfo(surface::NTuple{N, Int}) where N
+    min_idx = argmin(surface)
+    shift_index = min_idx - 1
+    if min_idx == 1
+        flipped = surface[2] < surface[end]
+    elseif min_idx == length(surface)
+        flipped = surface[1] < surface[end-1]
+    else
+        flipped = surface[min_idx + 1] < surface[min_idx - 1]
+    end
+    return OrientationInfo(flipped, shift_index)
 end

--- a/src/Grid/topology.jl
+++ b/src/Grid/topology.jl
@@ -260,17 +260,15 @@ function getneighborhood(top::ExclusiveTopology, grid::AbstractGrid, vertexidx::
     cellid, local_vertexid = vertexidx[1], vertexidx[2]
     cell_vertices = vertices(getcells(grid,cellid))
     global_vertexid = cell_vertices[local_vertexid]
-    if include_self
-        vertex_to_cell = top.vertex_to_cell[global_vertexid]
-        self_reference_local = Vector{VertexIndex}(undef,length(vertex_to_cell))
-        for (i,cellid) in enumerate(vertex_to_cell)
-            local_vertex = VertexIndex(cellid,findfirst(x->x==global_vertexid,vertices(getcells(grid,cellid)))::Int)
-            self_reference_local[i] = local_vertex
-        end
-        return [top.vertex_vertex_neighbor[global_vertexid].neighbor_info; self_reference_local]
-    else
-        return top.vertex_vertex_neighbor[global_vertexid].neighbor_info
+    vertex_to_cell = top.vertex_to_cell[global_vertexid]
+    self_reference_local = Vector{VertexIndex}()
+    sizehint!(self_reference_local, length(vertex_to_cell))
+    for (i,cellid) in enumerate(vertex_to_cell)
+        local_vertex = VertexIndex(cellid,findfirst(x->x==global_vertexid,vertices(getcells(grid,cellid)))::Int)
+        !include_self && local_vertex == vertexidx && continue
+        push!(self_reference_local, local_vertex)
     end
+    return self_reference_local
 end
 
 function getneighborhood(top::ExclusiveTopology, grid::AbstractGrid{3}, edgeidx::EdgeIndex, include_self=false)

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -183,9 +183,9 @@ end
 function evaluate_at_points(ph::PointEvalHandler{<:Any, dim, T1}, dh::AbstractDofHandler, dof_vals::AbstractVector{T2},
                            fname::Symbol=find_single_field(dh)) where {dim, T1, T2}
     npoints = length(ph.cells)
-    # Figure out the value type by creating a dummy PointValuesInternal
+    # Figure out the value type by creating a dummy PointValues
     ip = getfieldinterpolation(dh, find_field(dh, fname))
-    pv = PointValuesInternal(zero(Vec{dim, T1}), ip)
+    pv = PointValues(T1, ip; difforder=Val(0))
     zero_val = function_value_init(pv, dof_vals)
     # Allocate the output as NaNs
     nanv = convert(typeof(zero_val), NaN * zero_val)
@@ -241,11 +241,12 @@ function _evaluate_at_points!(
     # preallocate some stuff specific to this cellset
     idx = findfirst(!isnothing, local_coords)
     idx === nothing && return out_vals
-    pv = PointValuesInternal(local_coords[idx], ip)
+    pv = PointValues(local_coords[idx], ip; difforder=Val(0))
     first_cell = cellset === nothing ? 1 : first(cellset)
     cell_dofs = Vector{Int}(undef, ndofs_per_cell(dh, first_cell))
     u_e = Vector{T}(undef, ndofs_per_cell(dh, first_cell))
-
+    grid = get_grid(dh)
+    x = getcoordinates(grid, first_cell)
     # compute point values
     for pointid in eachindex(ph.cells)
         cellid = ph.cells[pointid]
@@ -255,7 +256,8 @@ function _evaluate_at_points!(
         for (i, I) in pairs(cell_dofs)
             u_e[i] = dof_vals[I]
         end
-        reinit!(pv, local_coords[pointid])
+        getcoordinates!(x, grid, cellid)
+        reinit!(pv, x, local_coords[pointid])
         out_vals[pointid] = function_value(pv, 1, u_e, dofrange)
     end
     return out_vals

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -241,11 +241,12 @@ function _evaluate_at_points!(
     # preallocate some stuff specific to this cellset
     idx = findfirst(!isnothing, local_coords)
     idx === nothing && return out_vals
-    pv = PointValues(local_coords[idx], ip; difforder=Val(0))
     first_cell = cellset === nothing ? 1 : first(cellset)
-    cell_dofs = Vector{Int}(undef, ndofs_per_cell(dh, first_cell))
-    u_e = Vector{T}(undef, ndofs_per_cell(dh, first_cell))
     grid = get_grid(dh)
+    ip_geo = default_interpolation(getcelltype(grid, first_cell))
+    pv = PointValues(eltype(local_coords[idx]), ip, ip_geo; difforder=Val(0))
+    cell_dofs = Vector{Int}(undef, ndofs_per_cell(dh, first_cell))
+    u_e = Vector{T}(undef, ndofs_per_cell(dh, first_cell))    
     x = getcoordinates(grid, first_cell)
     # compute point values
     for pointid in eachindex(ph.cells)

--- a/src/PointEval/PointEvalHandler.jl
+++ b/src/PointEval/PointEvalHandler.jl
@@ -185,7 +185,7 @@ function evaluate_at_points(ph::PointEvalHandler{<:Any, dim, T1}, dh::AbstractDo
     npoints = length(ph.cells)
     # Figure out the value type by creating a dummy PointValues
     ip = getfieldinterpolation(dh, find_field(dh, fname))
-    pv = PointValues(T1, ip; difforder=Val(0))
+    pv = PointValues(T1, ip; FunDiffOrder=0)
     zero_val = function_value_init(pv, dof_vals)
     # Allocate the output as NaNs
     nanv = convert(typeof(zero_val), NaN * zero_val)
@@ -244,7 +244,7 @@ function _evaluate_at_points!(
     first_cell = cellset === nothing ? 1 : first(cellset)
     grid = get_grid(dh)
     ip_geo = default_interpolation(getcelltype(grid, first_cell))
-    pv = PointValues(eltype(local_coords[idx]), ip, ip_geo; difforder=Val(0))
+    pv = PointValues(eltype(local_coords[idx]), ip, ip_geo; FunDiffOrder=0)
     cell_dofs = Vector{Int}(undef, ndofs_per_cell(dh, first_cell))
     u_e = Vector{T}(undef, ndofs_per_cell(dh, first_cell))    
     x = getcoordinates(grid, first_cell)

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -66,7 +66,8 @@ function reinit!(pv::PointValues, x::AbstractVector{<:Vec{D}}, ξ::Vec{D}) where
     qr_points = getpoints(pv.cv.qr)
     qr_points[1] = ξ
     # Precompute all values again to reflect the updated ξ coordinate
-    precompute_values!(pv.cv)
+    precompute_values!(pv.cv.fun_values, qr_points)
+    precompute_values!(pv.cv.geo_mapping, qr_points)
     # Regular reinit
     reinit!(pv.cv, x)
     return nothing

--- a/src/PointEval/point_values.jl
+++ b/src/PointEval/point_values.jl
@@ -28,8 +28,7 @@ function PointValues(cv::CellValues)
     T = typeof(getdetJdV(cv, 1))
     ip_fun = get_function_interpolation(cv)
     ip_geo = get_geometric_interpolation(cv)
-    FunDiffOrder = get_function_difforder(cv)
-    return PointValues(T, ip_fun, ip_geo; difforder=Val(FunDiffOrder))
+    return PointValues(T, ip_fun, ip_geo; FunDiffOrder = get_function_difforder(cv))
 end
 function PointValues(ip::Interpolation, ipg::Interpolation = default_geometric_interpolation(ip); kwargs...)
     return PointValues(Float64, ip, ipg; kwargs...)
@@ -40,7 +39,7 @@ function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolati
     GIP <: Interpolation{shape}
 }
     qr = QuadratureRule{shape, T}([one(T)], [zero(Vec{dim, T})])
-    cv = CellValues(T, qr, ip, ipg; save_detJ=Val(false), kwargs...)
+    cv = CellValues(T, qr, ip, ipg; save_detJ=false, kwargs...)
     return PointValues{typeof(cv)}(cv)
 end
 

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -220,7 +220,7 @@ end
             else # Krow > dofs[Kerow]
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(val) || error("some row indices were not found")
+                iszero(val) || _missing_sparsity_pattern_error(Krow, Kcol)
                 # Advance the local matrix row pointer
                 ri += 1
             end
@@ -228,13 +228,23 @@ end
         # Make sure that remaining entries in this column of the local matrix are all zero
         for i in ri:maxlookups
             if !iszero(Ke[permutation[i], Kecol])
-                error("some row indices were not found")
+                _missing_sparsity_pattern_error(sorteddofs[i], Kcol)
             end
         end
         current_col += 1
     end
 end
 
+function _missing_sparsity_pattern_error(Krow::Int, Kcol::Int)
+    throw(ErrorException(
+        "You are trying to assemble values in to K[$(Krow), $(Kcol)], but K[$(Krow), " *
+        "$(Kcol)] is missing in the sparsity pattern. Make sure you have called `K = " *
+        "create_sparsity_pattern(dh)` or `K = create_sparsity_pattern(dh, ch)` if you " *
+        "have affine constraints. This error might also happen if you are using " *
+        "`::AssemblerSparsityPattern` in a threaded assembly loop (you need to create an " *
+        "`assembler::AssemblerSparsityPattern` for each task)."
+    ))
+end
 
 ## assemble! with local condensation ##
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -156,7 +156,7 @@ end
 
 # TODO: Are these needed to be deprecated - harder? with the new parameterization
 # (Cell|Face)Values with vector dofs
-const _VectorValues = Union{CellValues{<:FV}, FaceValues{<:FV}} where {FV <: FunctionValues{<:VectorInterpolation}}
+const _VectorValues = Union{CellValues{<:FV}, FaceValues{<:FV}} where {FV <: FunctionValues{<:Any,<:VectorInterpolation}}
 @deprecate      function_value(fe_v::_VectorValues, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T}      function_value(fe_v, q_point, reinterpret(T, u))
 @deprecate   function_gradient(fe_v::_VectorValues, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T}   function_gradient(fe_v, q_point, reinterpret(T, u))
 @deprecate function_divergence(fe_v::_VectorValues, q_point::Int, u::AbstractVector{Vec{dim,T}}) where {dim,T} function_divergence(fe_v, q_point, reinterpret(T, u))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -19,6 +19,7 @@ export
     Nedelec,
     RaviartThomas,
     getnbasefunctions,
+    getrefshape,
 
 # Quadrature
     QuadratureRule,
@@ -30,6 +31,7 @@ export
     AbstractFaceValues,
     CellValues,
     FaceValues,
+    InterfaceValues,
     reinit!,
     shape_value,
     shape_gradient,
@@ -44,6 +46,14 @@ export
     spatial_coordinate,
     getnormal,
     getdetJdV,
+    shape_value_average,
+    shape_value_jump,
+    shape_gradient_average,
+    shape_gradient_jump,
+    function_value_average,
+    function_value_jump,
+    function_gradient_average,
+    function_gradient_jump,
 
 # Grid
     Grid,

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -91,9 +91,6 @@ end
 # reinit! FEValues with CellCache
 reinit!(cv::CellValues, cc::CellCache) = reinit!(cv, cc.coords)
 reinit!(fv::FaceValues, cc::CellCache, f::Int) = reinit!(fv, cc.coords, f) # TODO: Deprecate?
-# TODOL enable this after InterfaceValues are merges
-# reinit!(iv::InterfaceValues, ic::InterfaceCache) = reinit!(iv, FaceIndex(cellid(ic.face_a), ic.face_a.current_faceid[]), getcoordinates(ic.face_a),
-#     FaceIndex(cellid(ic.face_b), ic.face_b.current_faceid[]), getcoordinates(ic.face_b), ic.face_a.cc.grid)
 
 # Accessor functions (TODO: Deprecate? We are so inconsistent with `getxx` vs `xx`...)
 getnodes(cc::CellCache) = cc.nodes
@@ -208,7 +205,20 @@ function reinit!(cache::InterfaceCache, face_a::FaceIndex, face_b::FaceIndex)
     return cache
 end
 
+function reinit!(iv::InterfaceValues, ic::InterfaceCache)
+    return reinit!(iv,
+        getcells(ic.a.cc.grid, cellid(ic.a)),
+        getcoordinates(ic.a),
+        ic.a.current_faceid[],
+        getcells(ic.b.cc.grid, cellid(ic.b)),
+        getcoordinates(ic.b),
+        ic.b.current_faceid[],
+   )
+end
+
 interfacedofs(ic::InterfaceCache) = ic.dofs
+dof_range(ic::InterfaceCache, field::Symbol) = (dof_range(ic.a.cc.dh, field), dof_range(ic.b.cc.dh, field) .+ length(celldofs(ic.a)))
+getcoordinates(ic::InterfaceCache) = (getcoordinates(ic.a), getcoordinates(ic.b))
 
 ####################
 ## Grid iterators ##

--- a/test/integration/test_simple_scalar_convergence.jl
+++ b/test/integration/test_simple_scalar_convergence.jl
@@ -1,0 +1,216 @@
+using Ferrite, Test
+import Ferrite: getdim, default_interpolation
+
+module ConvergenceTestHelper
+
+using Ferrite, SparseArrays, ForwardDiff, Test
+import LinearAlgebra: diag
+
+get_geometry(::Ferrite.Interpolation{RefLine}) = Line
+get_geometry(::Ferrite.Interpolation{RefQuadrilateral}) = Quadrilateral
+get_geometry(::Ferrite.Interpolation{RefTriangle}) = Triangle
+get_geometry(::Ferrite.Interpolation{RefPrism}) = Wedge
+get_geometry(::Ferrite.Interpolation{RefHexahedron}) = Hexahedron
+get_geometry(::Ferrite.Interpolation{RefTetrahedron}) = Tetrahedron
+get_geometry(::Ferrite.Interpolation{RefPyramid}) = Pyramid
+
+get_quadrature_order(::Lagrange{shape, order}) where {shape, order} = 2*order
+get_quadrature_order(::Serendipity{shape, order}) where {shape, order} = 2*order
+get_quadrature_order(::CrouzeixRaviart{shape, order}) where {shape, order} = 2*order+1
+get_quadrature_order(::BubbleEnrichedLagrange{shape, order}) where {shape, order} = 2*order
+
+get_num_elements(::Ferrite.Interpolation{shape, 1}) where {shape} = 21
+get_num_elements(::Ferrite.Interpolation{shape, 2}) where {shape} = 7
+get_num_elements(::Ferrite.Interpolation{RefHexahedron, 1}) = 11
+get_num_elements(::Ferrite.Interpolation{RefHexahedron, 2}) = 4
+get_num_elements(::Ferrite.Interpolation{shape, 3}) where {shape} = 8
+get_num_elements(::Ferrite.Interpolation{shape, 4}) where {shape} = 5
+get_num_elements(::Ferrite.Interpolation{shape, 5}) where {shape} = 3
+
+analytical_solution(x) = prod(cos, x*π/2)
+analytical_rhs(x) = -Tensors.laplace(analytical_solution,x)
+
+# Standard assembly copy pasta for Poisson problem
+function assemble_element!(Ke::Matrix, fe::Vector, cellvalues::CellValues, coords)
+    n_basefuncs = getnbasefunctions(cellvalues)
+    ## Reset to 0
+    fill!(Ke, 0)
+    fill!(fe, 0)
+    ## Loop over quadrature points
+    for q_point in 1:getnquadpoints(cellvalues)
+        ## Get the quadrature weight
+        dΩ = getdetJdV(cellvalues, q_point)
+        x = spatial_coordinate(cellvalues, q_point, coords)
+        ## Loop over test shape functions
+        for i in 1:n_basefuncs
+            δu  = shape_value(cellvalues, q_point, i)
+            ∇δu = shape_gradient(cellvalues, q_point, i)
+            ## Add contribution to fe
+            fe[i] += analytical_rhs(x) * δu * dΩ
+            ## Loop over trial shape functions
+            for j in 1:n_basefuncs
+                ∇u = shape_gradient(cellvalues, q_point, j)
+                ## Add contribution to Ke
+                Ke[i, j] += (∇δu ⋅ ∇u) * dΩ
+            end
+        end
+    end
+    return Ke, fe
+end
+
+# Standard assembly copy pasta for Poisson problem
+function assemble_global(cellvalues::CellValues, K::SparseMatrixCSC, dh::DofHandler)
+    ## Allocate the element stiffness matrix and element force vector
+    n_basefuncs = getnbasefunctions(cellvalues)
+    Ke = zeros(n_basefuncs, n_basefuncs)
+    fe = zeros(n_basefuncs)
+    ## Allocate global force vector f
+    f = zeros(ndofs(dh))
+    ## Create an assembler
+    assembler = start_assemble(K, f)
+    ## Loop over all cels
+    for cell in CellIterator(dh)
+        ## Reinitialize cellvalues for this cell
+        reinit!(cellvalues, cell)
+        coords = getcoordinates(cell)
+        ## Compute element contribution
+        assemble_element!(Ke, fe, cellvalues, coords)
+        ## Assemble Ke and fe into K and f
+        assemble!(assembler, celldofs(cell), Ke, fe)
+    end
+    return K, f
+end
+
+# Compute norms
+function check_and_compute_convergence_norms(dh, u, cellvalues, testatol)
+    L2norm = 0.0
+    ∇L2norm = 0.0
+    L∞norm = 0.0
+    for cell in CellIterator(dh)
+        reinit!(cellvalues, cell)
+        n_basefuncs = getnbasefunctions(cellvalues)
+        coords = getcoordinates(cell)
+        uₑ = u[celldofs(cell)]
+        for q_point in 1:getnquadpoints(cellvalues)
+            dΩ = getdetJdV(cellvalues, q_point)
+            x = spatial_coordinate(cellvalues, q_point, coords)
+            uₐₙₐ    = prod(cos, x*π/2)
+            uₐₚₚᵣₒₓ = function_value(cellvalues, q_point, uₑ)
+            L∞norm = max(L∞norm, norm(uₐₙₐ-uₐₚₚᵣₒₓ))
+            L2norm  += norm(uₐₙₐ-uₐₚₚᵣₒₓ)^2*dΩ
+
+            ∇uₐₙₐ    = gradient(x-> prod(cos, x*π/2), x)
+            ∇uₐₚₚᵣₒₓ = function_gradient(cellvalues, q_point, uₑ)
+            ∇L2norm += norm(∇uₐₙₐ-∇uₐₚₚᵣₒₓ)^2*dΩ
+            
+            # Pointwise convergence
+            @test uₐₙₐ ≈ uₐₚₚᵣₒₓ atol=testatol
+        end
+    end
+    √(L2norm), √(∇L2norm), L∞norm
+end
+
+# Assemble and solve
+function solve(dh, ch, cellvalues)
+    K, f = assemble_global(cellvalues, create_sparsity_pattern(dh), dh);
+    apply!(K, f, ch)
+    u = K \ f;
+end
+
+function setup_poisson_problem(grid, interpolation, interpolation_geo, qr)
+    # Construct Ferrite stuff
+    dh = DofHandler(grid)
+    add!(dh, :u, interpolation)
+    close!(dh);
+
+    ch = ConstraintHandler(dh);
+    ∂Ω = union(
+        values(grid.facesets)...
+    );
+    dbc = Dirichlet(:u, ∂Ω, (x, t) -> analytical_solution(x))
+    add!(ch, dbc);
+    close!(ch);
+
+    cellvalues = CellValues(qr, interpolation, interpolation_geo);
+
+    return dh, ch, cellvalues
+end
+
+end # module ConvergenceTestHelper
+
+# These test only for convergence within margins
+@testset "convergence analysis" begin
+    @testset "$interpolation" for interpolation in (
+        Lagrange{RefTriangle, 3}(),
+        Lagrange{RefTriangle, 4}(),
+        Lagrange{RefTriangle, 5}(),
+        Lagrange{RefHexahedron, 1}(),
+        Lagrange{RefTetrahedron, 1}(),
+        Lagrange{RefPrism, 1}(),
+        Lagrange{RefPyramid, 1}(),
+        #
+        Serendipity{RefQuadrilateral, 2}(),
+        Serendipity{RefHexahedron, 2}(),
+        #
+        BubbleEnrichedLagrange{RefTriangle, 1}(),
+        #
+        CrouzeixRaviart{RefTriangle, 1}(),
+    )
+        # Generate a grid ...
+        geometry = ConvergenceTestHelper.get_geometry(interpolation)
+        interpolation_geo = default_interpolation(geometry)
+        N = ConvergenceTestHelper.get_num_elements(interpolation)
+        grid = generate_grid(geometry, ntuple(x->N, getdim(geometry)));
+        # ... a suitable quadrature rule ...
+        qr_order = ConvergenceTestHelper.get_quadrature_order(interpolation)
+        qr = QuadratureRule{getrefshape(interpolation)}(qr_order)
+        # ... and then pray to the gods of convergence.
+        dh, ch, cellvalues = ConvergenceTestHelper.setup_poisson_problem(grid, interpolation, interpolation_geo, qr)
+        u = ConvergenceTestHelper.solve(dh, ch, cellvalues)
+        ConvergenceTestHelper.check_and_compute_convergence_norms(dh, u, cellvalues, 1e-2)
+    end
+end
+
+# These test also for correct convergence rates
+@testset "convergence rate" begin
+    @testset "$interpolation" for interpolation in (
+        Lagrange{RefLine, 1}(),
+        Lagrange{RefLine, 2}(),
+        Lagrange{RefQuadrilateral, 1}(),
+        Lagrange{RefQuadrilateral, 2}(),
+        Lagrange{RefQuadrilateral, 3}(),
+        Lagrange{RefTriangle, 1}(),
+        Lagrange{RefTriangle, 2}(),
+        Lagrange{RefHexahedron, 2}(),
+        Lagrange{RefTetrahedron, 2}(),
+        Lagrange{RefPrism, 2}(),
+    )
+        # Generate a grid ...
+        geometry = ConvergenceTestHelper.get_geometry(interpolation)
+        interpolation_geo = default_interpolation(geometry)
+        # "Coarse case"
+        N₁ = ConvergenceTestHelper.get_num_elements(interpolation)
+        grid = generate_grid(geometry, ntuple(x->N₁, getdim(geometry)));
+        # ... a suitable quadrature rule ...
+        qr_order = ConvergenceTestHelper.get_quadrature_order(interpolation)
+        qr = QuadratureRule{getrefshape(interpolation)}(qr_order)
+        # ... and then pray to the gods of convergence.
+        dh, ch, cellvalues = ConvergenceTestHelper.setup_poisson_problem(grid, interpolation, interpolation_geo, qr)
+        u = ConvergenceTestHelper.solve(dh, ch, cellvalues)
+        L2₁, H1₁, _ = ConvergenceTestHelper.check_and_compute_convergence_norms(dh, u, cellvalues, 1e-2)
+        
+        # "Fine case"
+        N₂ = 2*N₁
+        grid = generate_grid(geometry, ntuple(x->N₂, getdim(geometry)));
+        # ... a suitable quadrature rule ...
+        qr_order = ConvergenceTestHelper.get_quadrature_order(interpolation)
+        qr = QuadratureRule{getrefshape(interpolation)}(qr_order)
+        # ... and then pray to the gods of convergence.
+        dh, ch, cellvalues = ConvergenceTestHelper.setup_poisson_problem(grid, interpolation, interpolation_geo, qr)
+        u = ConvergenceTestHelper.solve(dh, ch, cellvalues)
+        L2₂, H1₂, _ = ConvergenceTestHelper.check_and_compute_convergence_norms(dh, u, cellvalues, 5e-3)
+
+        @test -(log(L2₂)-log(L2₁))/(log(N₂)-log(N₁)) ≈ Ferrite.getorder(interpolation)+1 atol=0.1
+        @test -(log(H1₂)-log(H1₁))/(log(N₂)-log(N₁)) ≈ Ferrite.getorder(interpolation) atol=0.1
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,9 +18,12 @@ if HAS_EXTENSIONS && MODULE_CAN_BE_TYPE_PARAMETER
 end
 
 include("test_utils.jl")
+
+# Unit tests
 include("test_interpolations.jl")
 include("test_cellvalues.jl") 
 include("test_facevalues.jl")
+include("test_interfacevalues.jl")
 include("test_quadrules.jl")
 include("test_assemble.jl")
 include("test_dofs.jl")
@@ -38,3 +41,6 @@ include("test_deprecations.jl")
 HAS_EXTENSIONS && include("blockarrays.jl")
 include("test_examples.jl")
 @test all(x -> isdefined(Ferrite, x), names(Ferrite))  # Test that all exported symbols are defined
+
+# Integration tests
+include("integration/test_simple_scalar_convergence.jl")

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -137,13 +137,13 @@ end
     K = spdiagm(0 => zeros(2))
     a = start_assemble(K)
     as = start_assemble(Symmetric(K))
-    errr = ErrorException("some row indices were not found")
+    errr(i,j) = try Ferrite._missing_sparsity_pattern_error(i, j) catch e e end
     ## Errors below diagonal
-    @test_throws errr assemble!(a, [1, 2], [1.0 0.0; 3.0 4.0])
-    @test_throws errr assemble!(a, [2, 1], [1.0 2.0; 0.0 4.0])
+    @test_throws errr(2,1) assemble!(a, [1, 2], [1.0 0.0; 3.0 4.0])
+    @test_throws errr(2,1) assemble!(a, [2, 1], [1.0 2.0; 0.0 4.0])
     ## Errors above diagonal
-    @test_throws errr assemble!(a, [1, 2], [1.0 2.0; 0.0 4.0])
-    @test_throws errr assemble!(as, [1, 2], [1.0 2.0; 0.0 4.0])
-    @test_throws errr assemble!(a, [2, 1], [1.0 0.0; 3.0 4.0])
-    @test_throws errr assemble!(as, [2, 1], [1.0 0.0; 3.0 4.0])
+    @test_throws errr(2,2) assemble!(a, [1, 2], [1.0 2.0; 0.0 4.0])
+    @test_throws errr(2,2) assemble!(as, [1, 2], [1.0 2.0; 0.0 4.0])
+    @test_throws errr(2,2) assemble!(a, [2, 1], [1.0 0.0; 3.0 4.0])
+    @test_throws errr(2,2) assemble!(as, [2, 1], [1.0 0.0; 3.0 4.0])
 end

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -286,9 +286,13 @@ end
     linegrid = generate_grid(Line,(3,))
     linetopo = ExclusiveTopology(linegrid)
     @test linetopo.vertex_vertex_neighbor[1,2] == Ferrite.EntityNeighborhood(VertexIndex(2,1))
+    @test getneighborhood(linetopo, linegrid, VertexIndex(1,2)) == [VertexIndex(2,1)]
     @test linetopo.vertex_vertex_neighbor[2,1] == Ferrite.EntityNeighborhood(VertexIndex(1,2))
+    @test getneighborhood(linetopo, linegrid, VertexIndex(2,1)) == [VertexIndex(1,2)]
     @test linetopo.vertex_vertex_neighbor[2,2] == Ferrite.EntityNeighborhood(VertexIndex(3,1))
+    @test getneighborhood(linetopo, linegrid, VertexIndex(2,2)) == [VertexIndex(3,1)]
     @test linetopo.vertex_vertex_neighbor[3,1] == Ferrite.EntityNeighborhood(VertexIndex(2,2))
+    @test getneighborhood(linetopo, linegrid, VertexIndex(3,1)) == [VertexIndex(2,2)]
     linefaceskeleton = Ferrite.faceskeleton(linetopo, linegrid)
     @test length(linefaceskeleton) == 4
 
@@ -306,31 +310,52 @@ end
     #test vertex neighbors maps cellid and local vertex id to neighbor id and neighbor local vertex id
     @test topology.vertex_vertex_neighbor[1,3] == Ferrite.EntityNeighborhood(VertexIndex(4,1))
     @test topology.vertex_vertex_neighbor[2,4] == Ferrite.EntityNeighborhood(VertexIndex(3,2))
+    @test Set(getneighborhood(topology, quadgrid, VertexIndex(2,4))) == Set([VertexIndex(1,3), VertexIndex(3,2), VertexIndex(4,1)])
     @test topology.vertex_vertex_neighbor[3,3] == Ferrite.EntityNeighborhood(VertexIndex(6,1))
     @test topology.vertex_vertex_neighbor[3,2] == Ferrite.EntityNeighborhood(VertexIndex(2,4))
     @test topology.vertex_vertex_neighbor[4,1] == Ferrite.EntityNeighborhood(VertexIndex(1,3))
     @test topology.vertex_vertex_neighbor[4,4] == Ferrite.EntityNeighborhood(VertexIndex(5,2))
     @test topology.vertex_vertex_neighbor[5,2] == Ferrite.EntityNeighborhood(VertexIndex(4,4))
     @test topology.vertex_vertex_neighbor[6,1] == Ferrite.EntityNeighborhood(VertexIndex(3,3))
+    @test isempty(getneighborhood(topology, quadgrid, VertexIndex(2,2)))
+    @test length(getneighborhood(topology, quadgrid, VertexIndex(2,4))) == 3
     #test face neighbor maps cellid and local face id to neighbor id and neighbor local face id
     @test topology.face_face_neighbor[1,2] == Ferrite.EntityNeighborhood(FaceIndex(2,4))
+    @test getneighborhood(topology, quadgrid, FaceIndex(1,2)) == [FaceIndex(2,4)]
     @test topology.face_face_neighbor[1,3] == Ferrite.EntityNeighborhood(FaceIndex(3,1))
+    @test getneighborhood(topology, quadgrid, FaceIndex(1,3)) == [FaceIndex(3,1)]
     @test topology.face_face_neighbor[2,3] == Ferrite.EntityNeighborhood(FaceIndex(4,1))
+    @test getneighborhood(topology, quadgrid, FaceIndex(2,3)) == [FaceIndex(4,1)]
     @test topology.face_face_neighbor[2,4] == Ferrite.EntityNeighborhood(FaceIndex(1,2))
+    @test getneighborhood(topology, quadgrid, FaceIndex(2,4)) == [FaceIndex(1,2)]
     @test topology.face_face_neighbor[3,1] == Ferrite.EntityNeighborhood(FaceIndex(1,3))
+    @test getneighborhood(topology, quadgrid, FaceIndex(3,1)) == [FaceIndex(1,3)]
     @test topology.face_face_neighbor[3,2] == Ferrite.EntityNeighborhood(FaceIndex(4,4))
+    @test getneighborhood(topology, quadgrid, FaceIndex(3,2)) == [FaceIndex(4,4)]
     @test topology.face_face_neighbor[3,3] == Ferrite.EntityNeighborhood(FaceIndex(5,1))
+    @test getneighborhood(topology, quadgrid, FaceIndex(3,3)) == [FaceIndex(5,1)]
     @test topology.face_face_neighbor[4,1] == Ferrite.EntityNeighborhood(FaceIndex(2,3))
+    @test getneighborhood(topology, quadgrid, FaceIndex(4,1)) == [FaceIndex(2,3)]
     @test topology.face_face_neighbor[4,3] == Ferrite.EntityNeighborhood(FaceIndex(6,1))
+    @test getneighborhood(topology, quadgrid, FaceIndex(4,3)) == [FaceIndex(6,1)]
     @test topology.face_face_neighbor[4,4] == Ferrite.EntityNeighborhood(FaceIndex(3,2))
+    @test getneighborhood(topology, quadgrid, FaceIndex(1,2)) == [FaceIndex(2,4)]
     @test topology.face_face_neighbor[5,1] == Ferrite.EntityNeighborhood(FaceIndex(3,3))
+    @test getneighborhood(topology, quadgrid, FaceIndex(5,1)) == [FaceIndex(3,3)]
     @test topology.face_face_neighbor[5,2] == Ferrite.EntityNeighborhood(FaceIndex(6,4))
+    @test getneighborhood(topology, quadgrid, FaceIndex(5,2)) == [FaceIndex(6,4)]
     @test topology.face_face_neighbor[5,3] == Ferrite.EntityNeighborhood(Ferrite.BoundaryIndex[])
+    @test getneighborhood(topology, quadgrid, FaceIndex(5,3)) == FaceIndex[]
     @test topology.face_face_neighbor[5,4] == Ferrite.EntityNeighborhood(Ferrite.BoundaryIndex[])
+    @test getneighborhood(topology, quadgrid, FaceIndex(5,4)) == FaceIndex[]
     @test topology.face_face_neighbor[6,1] == Ferrite.EntityNeighborhood(FaceIndex(4,3))
+    @test getneighborhood(topology, quadgrid, FaceIndex(6,1)) == [FaceIndex(4,3)]
     @test topology.face_face_neighbor[6,2] == Ferrite.EntityNeighborhood(Ferrite.BoundaryIndex[])
+    @test getneighborhood(topology, quadgrid, FaceIndex(6,2)) == FaceIndex[]
     @test topology.face_face_neighbor[6,3] == Ferrite.EntityNeighborhood(Ferrite.BoundaryIndex[])
+    @test getneighborhood(topology, quadgrid, FaceIndex(6,3)) == FaceIndex[]
     @test topology.face_face_neighbor[6,4] == Ferrite.EntityNeighborhood(FaceIndex(5,2))
+    @test getneighborhood(topology, quadgrid, FaceIndex(6,4)) == [FaceIndex(5,2)]
 #                         (8)
 #                (7) +-----+-----+(9)
 #                    |  3  |  4  |
@@ -349,8 +374,10 @@ end
     topology = ExclusiveTopology(hexgrid)
     @test topology.edge_edge_neighbor[1,11] == Ferrite.EntityNeighborhood(EdgeIndex(4,9))
     @test Set(getneighborhood(topology,hexgrid,EdgeIndex(1,11),true)) == Set([EdgeIndex(4,9),EdgeIndex(2,12),EdgeIndex(3,10),EdgeIndex(1,11)])
+    @test Set(getneighborhood(topology,hexgrid,EdgeIndex(1,11),false)) == Set([EdgeIndex(4,9),EdgeIndex(2,12),EdgeIndex(3,10)])
     @test topology.edge_edge_neighbor[2,12] == Ferrite.EntityNeighborhood(EdgeIndex(3,10))
     @test Set(getneighborhood(topology,hexgrid,EdgeIndex(2,12),true)) == Set([EdgeIndex(3,10),EdgeIndex(1,11),EdgeIndex(4,9),EdgeIndex(2,12)])
+    @test Set(getneighborhood(topology,hexgrid,EdgeIndex(2,12),false)) == Set([EdgeIndex(3,10),EdgeIndex(1,11),EdgeIndex(4,9)])
     @test topology.edge_edge_neighbor[3,10] == Ferrite.EntityNeighborhood(EdgeIndex(2,12))
     @test topology.edge_edge_neighbor[4,9] == Ferrite.EntityNeighborhood(EdgeIndex(1,11))
     @test getneighborhood(topology,hexgrid,FaceIndex((1,3))) == [FaceIndex((2,5))]
@@ -468,27 +495,26 @@ end
 #                   |  1  |  2  |  3  |
 #                   +-----+-----+-----+
 # test application: integrate jump across element boundary 5
-    ip = Lagrange{RefQuadrilateral, 1}()^2
+    ip = DiscontinuousLagrange{RefQuadrilateral, 1}()^2
     qr_face = FaceQuadratureRule{RefQuadrilateral}(2)
-    fv_ele = FaceValues(qr_face, ip)
-    fv_neighbor = FaceValues(qr_face, ip)
-    u_ele5 = [3.0 for _ in 1:8]
-    u_neighbors = [5.0 for _ in 1:8]
+    iv = InterfaceValues(qr_face, ip)
+    dh = DofHandler(quadgrid)
+    add!(dh, :u, ip)
+    close!(dh)
+    u = [5.0 for _ in 1:4*9*2]
+    u[4*4*2+1 : 5*4*2] .= 3.0
     jump_int = 0.
     jump_abs = 0.
     # Test interface Iterator
-    for ic in InterfaceIterator(quadgrid)
+    for ic in InterfaceIterator(dh)
         any(cellid.([ic.a, ic.b]) .== 5) || continue
-        reinit!(fv_ele, ic.a.cc, ic.a.current_faceid[])
-        for q_point in 1:getnquadpoints(fv_ele)
-            dΩ = getdetJdV(fv_ele, q_point)
-            normal_a = getnormal(fv_ele, q_point)
-            u_5_n = function_value(fv_ele, q_point, cellid(ic.a) == 5 ? u_ele5 : u_neighbors) ⋅ normal_a
-            reinit!(fv_neighbor, ic.b.cc, ic.b.current_faceid[])
-            normal_b = getnormal(fv_neighbor, q_point)
-            u_neighbor = function_value(fv_neighbor, q_point, cellid(ic.a) == 5 ? u_neighbors : u_ele5) ⋅ normal_b
-            jump_int += (u_5_n + u_neighbor) * dΩ
-            jump_abs += abs(u_5_n + u_neighbor) * dΩ
+        reinit!(iv, ic)
+        for q_point in 1:getnquadpoints(iv)
+            dΩ = getdetJdV(iv, q_point)
+            normal_a = getnormal(iv, q_point)
+            u_interface = u[interfacedofs(ic)]
+            jump_int += function_value_jump(iv, q_point, u_interface) ⋅ normal_a * dΩ
+            jump_abs += abs(function_value_jump(iv, q_point, u_interface) ⋅ normal_a) * dΩ
         end
     end
     @test isapprox(jump_abs, 2/3*2*4,atol=1e-6) # 2*4*0.66666, jump is always 2, 4 sides, length =0.66

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -1,7 +1,7 @@
 @testset "InterfaceValues" begin
     function test_interfacevalues(grid::Ferrite.AbstractGrid, iv::InterfaceValues; tol = 0)
-        ip_here = iv.here.func_interp
-        ip_there = iv.there.func_interp
+        ip_here = Ferrite.get_function_interpolation(iv.here)
+        ip_there = Ferrite.get_function_interpolation(iv.there)
         ndim = Ferrite.getdim(ip_here)
         n_basefuncs = getnbasefunctions(ip_here) + getnbasefunctions(ip_there)
 
@@ -252,8 +252,8 @@
         @test_throws ArgumentError("transformation is not implemented") Ferrite.get_transformation_matrix(it)
     end
     @testset "show" begin
-        # Just smoke test to make sure show doesn't error. 
         iv = InterfaceValues(FaceQuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}())
-        show(stdout, MIME"text/plain"(), iv)
+        showstring = show_as_string(iv)
+        @test contains(showstring, "InterfaceValues with")
     end
 end # of testset

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -1,0 +1,259 @@
+@testset "InterfaceValues" begin
+    function test_interfacevalues(grid::Ferrite.AbstractGrid, iv::InterfaceValues; tol = 0)
+        ip_here = iv.here.func_interp
+        ip_there = iv.there.func_interp
+        ndim = Ferrite.getdim(ip_here)
+        n_basefuncs = getnbasefunctions(ip_here) + getnbasefunctions(ip_there)
+
+        @test getnbasefunctions(iv) == n_basefuncs
+
+        for ic in InterfaceIterator(grid)
+            reinit!(iv, ic)
+            coords_here, coords_there = getcoordinates(ic)
+            nqp = getnquadpoints(iv)
+            # Should have same quadrature points
+            @test nqp == getnquadpoints(iv.here) == getnquadpoints(iv.there)
+            for qp in 1:nqp
+                # If correctly synced quadrature points coordinates should match
+                @test isapprox(spatial_coordinate(iv, qp, coords_here, coords_there; here = true),
+                    spatial_coordinate(iv, qp, coords_here, coords_there; here = false); atol = tol)
+                for i in 1:getnbasefunctions(iv)
+                    here = i <= getnbasefunctions(iv.here)
+                    shapevalue = shape_value(iv, qp, i; here = here)
+                    shape_avg = shape_value_average(iv, qp, i)
+                    shape_jump = shape_value_jump(iv, qp, i)
+
+                    shapegrad = shape_gradient(iv, qp, i; here = here)
+                    shapegrad_avg = shape_gradient_average(iv, qp, i)
+                    shapegrad_jump = shape_gradient_jump(iv, qp, i)
+
+                    normal = getnormal(iv, qp; here=false)
+                    # Test values (May be removed as it mirrors implementation)
+                    if i > getnbasefunctions(iv.here)
+                        @test shapevalue ≈ shape_value(iv.there, qp, i - getnbasefunctions(iv.here))
+                        @test shapegrad ≈ shape_gradient(iv.there, qp, i - getnbasefunctions(iv.here))
+
+                        @test shape_jump ≈ -shapevalue
+                        @test shapegrad_jump ≈ -shapegrad
+                    else
+                        normal = getnormal(iv, qp)
+                        @test shapevalue ≈ shape_value(iv.here, qp, i)
+                        @test shapegrad ≈ shape_gradient(iv.here, qp, i)
+
+                        @test shape_jump ≈ shapevalue
+                        @test shapegrad_jump ≈ shapegrad
+                    end
+
+                    @test shape_avg ≈ 0.5 * shapevalue
+                    @test shapegrad_avg ≈ 0.5 * shapegrad
+
+                end
+            end
+            @test_throws ErrorException("Invalid base function $(n_basefuncs + 1). Interface has only $(n_basefuncs) base functions") shape_value_jump(iv, 1, n_basefuncs + 1)
+            @test_throws ErrorException("Invalid base function $(n_basefuncs + 1). Interface has only $(n_basefuncs) base functions") shape_gradient_average(iv, 1, n_basefuncs + 1)
+
+            # Test function* copied from facevalues tests
+            nbf_a = Ferrite.getngeobasefunctions(iv.here)
+            nbf_b = Ferrite.getngeobasefunctions(iv.there)
+            for here in (true, false)
+                u_a = Vec{ndim, Float64}[zero(Tensor{1,ndim}) for i in 1: nbf_a]
+                u_b = Vec{ndim, Float64}[zero(Tensor{1,ndim}) for i in 1: nbf_b]
+                u_scal_a = zeros(nbf_a)
+                u_scal_b = zeros(nbf_b)
+                H = rand(Tensor{2, ndim})
+                V = rand(Tensor{1, ndim})
+                for i in 1:nbf_a
+                    xs = coords_here
+                    u_a[i] = H ⋅ xs[i]
+                    u_scal_a[i] = V ⋅ xs[i]
+                end
+                for i in 1:nbf_b
+                    xs = coords_there
+                    u_b[i] = H ⋅ xs[i]
+                    u_scal_b[i] = V ⋅ xs[i]
+                end
+                u = vcat(u_a, u_b)
+                u_scal = vcat(u_scal_a, u_scal_b)
+                u_vector = reinterpret(Float64, u)
+                for i in 1:getnquadpoints(iv)
+                    if ip_here isa Ferrite.ScalarInterpolation
+                        @test function_gradient(iv, i, u, here = here) ≈ H
+                        @test function_gradient(iv, i, u_scal, here = here) ≈ V
+
+                        @test isapprox(function_value_average(iv, i, u_scal), function_value(iv, i, u_scal, here = here); atol = tol)
+                        @test all(function_value_jump(iv, i, u_scal) .<= 30 * eps(Float64))
+                        @test isapprox(function_gradient_average(iv, i, u_scal), function_gradient(iv, i, u_scal, here = here); atol = tol)
+                        @test all(function_gradient_jump(iv, i, u_scal) .<= 30 * eps(Float64))
+
+                        @test isapprox(function_value_average(iv, i, u), function_value(iv, i, u, here = here); atol = tol)
+                        @test all(function_value_jump(iv, i, u) .<= 30 * eps(Float64))
+                        @test isapprox(function_gradient_average(iv, i, u), function_gradient(iv, i, u, here = here); atol = tol)
+                        @test all(function_gradient_jump(iv, i, u) .<= 30 * eps(Float64))
+                    else # func_interpol isa Ferrite.VectorInterpolation
+                        @test function_gradient(iv, i, u_vector; here = here) ≈ H
+                        @test isapprox(function_value_average(iv, i, u_vector), function_value(iv, i, u_vector, here = here); atol = tol)
+                        @test all(function_value_jump(iv, i, u_vector) .<= 30 * eps(Float64))
+                        @test isapprox(function_gradient_average(iv, i, u_vector), function_gradient(iv, i, u_vector, here = here); atol = tol)
+                        @test all(function_gradient_jump(iv, i, u_vector) .<= 30 * eps(Float64))
+                    end
+                end
+                # Test of volume
+                vol = 0.0
+                for i in 1:getnquadpoints(iv)
+                    vol += getdetJdV(iv, i)
+                end
+                xs = here ? coords_here : coords_there
+                face = here ? Ferrite.getcurrentface(iv.here) : Ferrite.getcurrentface(iv.there)
+                func_interpol = here ? ip_here : ip_there
+                let ip_base = func_interpol isa VectorizedInterpolation ? func_interpol.ip : func_interpol
+                    x_face = xs[[Ferrite.dirichlet_facedof_indices(ip_base)[face]...]]
+                    @test vol ≈ calculate_face_area(ip_base, x_face, face)
+                end
+            end
+        end
+    end
+    getcelltypedim(::Type{<:Ferrite.AbstractCell{shape}}) where {dim, shape <: Ferrite.AbstractRefShape{dim}} = dim
+    for (cell_shape, scalar_interpol, quad_rule) in (
+                                        (Line, DiscontinuousLagrange{RefLine, 1}(), FaceQuadratureRule{RefLine}(2)),
+                                        (QuadraticLine, DiscontinuousLagrange{RefLine, 2}(), FaceQuadratureRule{RefLine}(2)),
+                                        (Quadrilateral, DiscontinuousLagrange{RefQuadrilateral, 1}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                        (QuadraticQuadrilateral, DiscontinuousLagrange{RefQuadrilateral, 2}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                        (Triangle, DiscontinuousLagrange{RefTriangle, 1}(), FaceQuadratureRule{RefTriangle}(2)),
+                                        (QuadraticTriangle, DiscontinuousLagrange{RefTriangle, 2}(), FaceQuadratureRule{RefTriangle}(2)),
+                                        (Hexahedron, DiscontinuousLagrange{RefHexahedron, 1}(), FaceQuadratureRule{RefHexahedron}(2)),
+                                        # (QuadraticQuadrilateral, Serendipity{RefQuadrilateral, 2}(), FaceQuadratureRule{RefQuadrilateral}(2)),
+                                        (Tetrahedron, DiscontinuousLagrange{RefTetrahedron, 1}(), FaceQuadratureRule{RefTetrahedron}(2)),
+                                        # (QuadraticTetrahedron, Lagrange{RefTetrahedron, 2}(), FaceQuadratureRule{RefTetrahedron}(2)),
+                                        (Wedge, DiscontinuousLagrange{RefPrism, 1}(), FaceQuadratureRule{RefPrism}(2)),
+                                        (Pyramid, DiscontinuousLagrange{RefPyramid, 1}(), FaceQuadratureRule{RefPyramid}(2)),
+                                       )
+        dim = getcelltypedim(cell_shape)
+        grid = generate_grid(cell_shape, ntuple(i -> 2, dim))
+        ip = scalar_interpol isa DiscontinuousLagrange ? Lagrange{Ferrite.getrefshape(scalar_interpol), Ferrite.getorder(scalar_interpol)}() : scalar_interpol
+        @testset "faces nodes indicies" begin
+            cell = getcells(grid, 1)
+            geom_ip_faces_indices = Ferrite.facedof_indices(ip)
+            Ferrite.getdim(ip) > 1 && (geom_ip_faces_indices = Tuple([face[collect(face .∉ Ref(interior))] for (face, interior) in [(geom_ip_faces_indices[i], Ferrite.facedof_interior_indices(ip)[i]) for i in 1:nfaces(ip)]]))
+            faces_indicies = Ferrite.reference_faces(Ferrite.getrefshape(Ferrite.default_interpolation(typeof(cell))))
+            node_ids = Ferrite.get_node_ids(cell)
+            @test getindex.(Ref(node_ids), collect.(faces_indicies)) == Ferrite.faces(cell) == getindex.(Ref(node_ids), collect.(geom_ip_faces_indices))
+        end
+        @testset "error paths" begin
+            cell = getcells(grid, 1)
+            dim == 1 && @test_throws ErrorException("1D elements don't use transformations for interfaces.") Ferrite.InterfaceOrientationInfo(cell,cell,1,1)
+            @test_throws ArgumentError("unknown face number") Ferrite.element_to_face_transformation(Vec{dim,Float64}(ntuple(_->0.0, dim)), Ferrite.getrefshape(cell), 100)
+            @test_throws ArgumentError("unknown face number") Ferrite.face_to_element_transformation(Vec{dim-1,Float64}(ntuple(_->0.0, dim-1)), Ferrite.getrefshape(cell), 100)
+        end
+        for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
+            iv = cell_shape ∈ (QuadraticLine, QuadraticQuadrilateral, QuadraticTriangle, QuadraticTetrahedron) ? 
+                InterfaceValues(quad_rule, func_interpol, ip) : InterfaceValues(quad_rule, func_interpol)
+            test_interfacevalues(grid, iv)
+        end
+    end
+    # Custom quadrature
+    @testset "Custom quadrature interface values" begin
+        cell_shape = Tetrahedron
+        scalar_interpol = DiscontinuousLagrange{RefTetrahedron, 1}()
+        # From https://www.researchgate.net/publication/258241862_Application_of_Composite_Numerical_Integrations_Using_Gauss-Radau_and_Gauss-Lobatto_Quadrature_Rules?enrichId=rgreq-a5675bf95a198061d6e153e39f856f53-XXX&enrichSource=Y292ZXJQYWdlOzI1ODI0MTg2MjtBUzo5ODgzMzU0MzQ2NzAxOUAxNDAwNTc1MTYxNjA2&el=1_x_2&_esc=publicationCoverPdf
+        points = Vec{2, Float64}.([[0.0, 0.844948974278318], [0.205051025721682, 0.694948974278318], [0.487979589711327, 0.487979589711327], [0.0, 0.355051025721682], [0.29202041028867254, 0.29202041028867254], [0.694948974278318, 0.205051025721682], [0.0, 0.0], [0.355051025721682, 0.0], [0.844948974278318, 0.0]])
+        # Weights resulted in 4 times the volume [-1, 1] -> so /4 to get [0, 1]
+        weights = [0.096614387479324, 0.308641975308642, 0.087870061825481, 0.187336229804627, 0.677562036939952, 0.308641975308642, 0.049382716049383, 0.187336229804627, 0.096614387479324] / 4
+        quad_rule = Ferrite.create_face_quad_rule(RefTetrahedron, weights, points)
+        dim = getcelltypedim(cell_shape)
+        grid = generate_grid(cell_shape, ntuple(i -> 2, dim))
+        @testset "faces nodes indicies" begin
+            ip = scalar_interpol isa DiscontinuousLagrange ? Lagrange{Ferrite.getrefshape(scalar_interpol), Ferrite.getorder(scalar_interpol)}() : scalar_interpol
+            cell = getcells(grid, 1)
+            geom_ip_faces_indices = Ferrite.facedof_indices(ip)
+            Ferrite.getdim(ip) > 1 && (geom_ip_faces_indices = Tuple([face[collect(face .∉ Ref(interior))] for (face, interior) in [(geom_ip_faces_indices[i], Ferrite.facedof_interior_indices(ip)[i]) for i in 1:nfaces(ip)]]))
+            faces_indicies = Ferrite.reference_faces(Ferrite.getrefshape(Ferrite.default_interpolation(typeof(cell))))
+            node_ids = Ferrite.get_node_ids(cell)
+            @test getindex.(Ref(node_ids), collect.(faces_indicies)) == Ferrite.faces(cell) == getindex.(Ref(node_ids), collect.(geom_ip_faces_indices))
+        end
+        @testset "error paths" begin
+            cell = getcells(grid, 1)
+            @test_throws ArgumentError("unknown face number") Ferrite.element_to_face_transformation(Vec{dim,Float64}(ntuple(_->0.0, dim)), Ferrite.getrefshape(cell), 100)
+            @test_throws ArgumentError("unknown face number") Ferrite.face_to_element_transformation(Vec{dim-1,Float64}(ntuple(_->0.0, dim-1)), Ferrite.getrefshape(cell), 100)
+        end
+        for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
+            iv = InterfaceValues(quad_rule, func_interpol)
+            test_interfacevalues(grid, iv; tol = 5*eps(Float64))
+        end
+    end
+    # @testset "Mixed elements 2D grids" begin # TODO: this shouldn't work because it should change the FaceValues object
+    #     dim = 2
+    #     nodes = [Node((-1.0, 0.0)), Node((0.0, 0.0)), Node((1.0, 0.0)), Node((-1.0, 1.0)), Node((0.0, 1.0))]
+    #     cells = [
+    #                 Quadrilateral((1,2,5,4)),
+    #                 Triangle((3,5,2)),
+    #             ]
+
+    #     grid = Grid(cells, nodes)
+    #     topology = ExclusiveTopology(grid)
+    #     test_interfacevalues(grid,
+    #     DiscontinuousLagrange{RefQuadrilateral, 1}(), FaceQuadratureRule{RefQuadrilateral}(2),
+    #     DiscontinuousLagrange{RefTriangle, 1}(), FaceQuadratureRule{RefTriangle}(2))
+    # end
+    @testset "Unordered nodes 3D" begin
+        dim = 2
+        nodes = [Node((-1.0, 0.0, 0.0)), Node((0.0, 0.0, 0.0)), Node((1.0, 0.0, 0.0)), 
+                Node((-1.0, 1.0, 0.0)), Node((0.0, 1.0, 0.0)), Node((1.0, 1.0, 0.0)), 
+                Node((-1.0, 0.0, 1.0)), Node((0.0, 0.0, 1.0)), Node((1.0, 0.0, 1.0)), 
+                Node((-1.0, 1.0, 1.0)), Node((0.0, 1.0, 1.0)), Node((1.0, 1.0, 1.0)), 
+                ]
+        cells = [
+                    Hexahedron((1,2,5,4,7,8,11,10)),
+                    Hexahedron((5,6,12,11,2,3,9,8)),
+                ]
+
+        grid = Grid(cells, nodes)
+        test_interfacevalues(grid,
+            InterfaceValues(FaceQuadratureRule{RefHexahedron}(2), DiscontinuousLagrange{RefHexahedron, 1}()))
+    end
+    @testset "Interface dof_range" begin
+        grid = generate_grid(Quadrilateral,(3,3))
+        ip_u = DiscontinuousLagrange{RefQuadrilateral, 1}()^2
+        ip_p = DiscontinuousLagrange{RefQuadrilateral, 1}()
+        qr_face = FaceQuadratureRule{RefQuadrilateral}(2)
+        iv = InterfaceValues(qr_face, ip_p)
+        @test iv == InterfaceValues(iv.here, iv.there)
+        dh = DofHandler(grid)
+        add!(dh, :u, ip_u)
+        add!(dh, :p, ip_p)
+        add!(dh, :_p, ip_p)
+        close!(dh)
+        ic = first(InterfaceIterator(dh))
+        @test dof_range(ic, :p) == (9:12, 25:28)
+    end
+    # Test copy
+    iv = InterfaceValues(FaceQuadratureRule{RefQuadrilateral}(2), DiscontinuousLagrange{RefQuadrilateral, 1}())
+    ivc = copy(iv)
+    @test typeof(iv) == typeof(ivc)
+    for fname in fieldnames(typeof(iv))
+        v = getfield(iv, fname)
+        v isa Ferrite.ScalarWrapper && continue
+        vc = getfield(ivc, fname)
+        if hasmethod(pointer, Tuple{typeof(v)})
+            @test pointer(v) != pointer(vc)
+        end
+        v isa FaceValues && continue
+        for fname in fieldnames(typeof(vc))
+            v2 = getfield(v, fname)
+            v2 isa Ferrite.ScalarWrapper && continue
+            vc2 = getfield(vc, fname)
+            if hasmethod(pointer, Tuple{typeof(v2)})
+                @test pointer(v2) != pointer(vc2)
+            end
+            @test v2 == vc2
+        end
+    end
+    @testset "undefined transformation matrix error path" begin
+        it = Ferrite.InterfaceOrientationInfo{DummyRefShapes.RefDodecahedron, DummyRefShapes.RefDodecahedron}(false, 0, 0, 1, 1)
+        @test_throws ArgumentError("transformation is not implemented") Ferrite.get_transformation_matrix(it)
+    end
+    @testset "show" begin
+        # Just smoke test to make sure show doesn't error. 
+        iv = InterfaceValues(FaceQuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral,2}())
+        show(stdout, MIME"text/plain"(), iv)
+    end
+end # of testset

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -33,12 +33,13 @@
                       DiscontinuousLagrange{RefHexahedron, 1}(),
                       DiscontinuousLagrange{RefTriangle, 1}(),
                       DiscontinuousLagrange{RefTetrahedron, 1}(),
+                      DiscontinuousLagrange{RefPrism, 1}(),
+                      DiscontinuousLagrange{RefPyramid, 1}(),
                       #
                       BubbleEnrichedLagrange{RefTriangle, 1}(),
                       #
                       CrouzeixRaviart{RefTriangle, 1}(),
     )
-
         # Test of utility functions
         ref_dim = Ferrite.getdim(interpolation)
         ref_shape = Ferrite.getrefshape(interpolation)
@@ -47,20 +48,49 @@
 
         # Note that not every element formulation exists for every order and dimension.
         applicable(Ferrite.getlowerorder, interpolation) && @test typeof(Ferrite.getlowerorder(interpolation)) <: Interpolation{ref_shape,func_order-1}
+        @testset "transform face points" begin
+            # Test both center point and random points on the face
+            ref_coord = Ferrite.reference_coordinates(Lagrange{ref_shape, 1}())
+            for face in 1:nfaces(interpolation)
+                face_nodes = Ferrite.reference_faces(ref_shape)[face]
+                center_coord = [0.0 for _ in 1:ref_dim]
+                rand_coord = [0.0 for _ in 1:ref_dim]
+                rand_weights = rand(length(face_nodes))
+                rand_weights /= sum(rand_weights)
+                for (i, node) in pairs(face_nodes)
+                    center_coord += ref_coord[node] / length(face_nodes)
+                    rand_coord += rand_weights[i] .* ref_coord[node]
+                end
+                for point in (center_coord, rand_coord)
+                    vec_point = Vec{ref_dim}(point)
+                    cell_to_face = Ferrite.element_to_face_transformation(vec_point, ref_shape, face)
+                    face_to_cell = Ferrite.face_to_element_transformation(cell_to_face, ref_shape, face)
+                    @test vec_point ≈ face_to_cell
+                end
+            end
+        end
+        n_basefuncs = getnbasefunctions(interpolation)
+        coords = Ferrite.reference_coordinates(interpolation)
+        @test length(coords) == n_basefuncs
+        f(x) = [shape_value(interpolation, Tensor{1, ref_dim}(x), i) for i in 1:n_basefuncs]
 
-    # Check partition of unity at random point.
-    n_basefuncs = getnbasefunctions(interpolation)
-    x = rand(Tensor{1, ref_dim})
-    f = (x) -> [shape_value(interpolation, Tensor{1, ref_dim}(x), i) for i in 1:n_basefuncs]
-    @test vec(ForwardDiff.jacobian(f, Array(x))') ≈
-        reinterpret(Float64, [shape_gradient(interpolation, x, i) for i in 1:n_basefuncs])
-    @test sum([shape_value(interpolation, x, i) for i in 1:n_basefuncs]) ≈ 1.0
-
-    # Check if the important functions are consistent
-    coords = Ferrite.reference_coordinates(interpolation)
-    @test length(coords) == n_basefuncs
-    @test shape_value(interpolation, x, n_basefuncs) == shape_value(interpolation, x, n_basefuncs)
-    @test_throws ArgumentError shape_value(interpolation, x, n_basefuncs+1)
+        #TODO prefer this test style after 1.6 is removed from CI
+        # @testset let x = sample_random_point(ref_shape) # not compatible with Julia 1.6
+        x = sample_random_point(ref_shape)
+        random_point_testset = @testset "Random point test" begin
+            # Check gradient evaluation
+            @test vec(ForwardDiff.jacobian(f, Array(x))') ≈
+                reinterpret(Float64, [shape_gradient(interpolation, x, i) for i in 1:n_basefuncs])
+            # Check partition of unity at random point.
+            @test sum([shape_value(interpolation, x, i) for i in 1:n_basefuncs]) ≈ 1.0
+            # Check if the important functions are consistent
+            @test_throws ArgumentError shape_value(interpolation, x, n_basefuncs+1)
+            # Idempotency test
+            @test shape_value(interpolation, x, n_basefuncs) == shape_value(interpolation, x, n_basefuncs)
+        end
+        # Remove after 1.6 is removed from CI (see above)
+        # Show coordinate in case failure (see issue #811)
+        !isempty(random_point_testset.results) && println("^^^^^Random point test failed at $x for $interpolation !^^^^^")
 
         # Test whether we have for each entity corresponding dof indices (possibly empty)
         @test length(Ferrite.vertexdof_indices(interpolation)) == Ferrite.nvertices(interpolation)
@@ -99,18 +129,18 @@
         end
         @test all([all(0 .< i .<= n_basefuncs) for i ∈ Ferrite.celldof_interior_indices(interpolation)])
 
-    # Check for dirac delta property of interpolation
-    @testset "dirac delta property of dof $dof" for dof in 1:n_basefuncs
-        for k in 1:n_basefuncs
-            N_dof = shape_value(interpolation, coords[dof], k)
-            if k == dof
-                @test N_dof ≈ 1.0
-            else
-                factor = interpolation isa Lagrange{RefQuadrilateral, 3} ? 200 : 4
-                @test N_dof ≈ 0.0 atol = factor * eps(Float64)
+        # Check for dirac delta property of interpolation
+        @testset "dirac delta property of dof $dof" for dof in 1:n_basefuncs
+            for k in 1:n_basefuncs
+                N_dof = shape_value(interpolation, coords[dof], k)
+                if k == dof
+                    @test N_dof ≈ 1.0
+                else
+                    factor = interpolation isa Lagrange{RefQuadrilateral, 3} ? 200 : 4
+                    @test N_dof ≈ 0.0 atol = factor * eps(Float64)
+                end
             end
         end
-    end
 
         # Test that facedof_indices(...) return in counter clockwise order (viewing from the outside)
         if interpolation isa Lagrange

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -202,22 +202,22 @@ function calculate_volume(::Serendipity{RefQuadrilateral, 2}, x::Vector{Vec{2, T
     return vol
 end
 
-function calculate_face_area(ip::Lagrange{RefLine}, x::Vector{<:Vec}, faceindex::Int)
+function calculate_face_area(ip::Union{Lagrange{RefLine}, DiscontinuousLagrange{RefLine}}, x::Vector{<:Vec}, faceindex::Int)
     return one(eltype(eltype(x)))
 end
-function calculate_face_area(ip::Lagrange{RefQuadrilateral, order}, x::Vector{<:Vec}, faceindex::Int) where order
+function calculate_face_area(ip::Union{Lagrange{RefQuadrilateral, order}, DiscontinuousLagrange{RefQuadrilateral, order}}, x::Vector{<:Vec}, faceindex::Int) where order
     return calculate_volume(Lagrange{RefLine, order}(), x)
 end
-function calculate_face_area(ip::Lagrange{RefTriangle, order}, x::Vector{<:Vec}, faceindex::Int) where order
+function calculate_face_area(ip::Union{Lagrange{RefTriangle, order}, DiscontinuousLagrange{RefTriangle, order}}, x::Vector{<:Vec}, faceindex::Int) where order
     return calculate_volume(Lagrange{RefLine, order}(), x)
 end
-function calculate_face_area(ip::Lagrange{RefHexahedron, order}, x::Vector{<:Vec}, faceindex::Int) where order
+function calculate_face_area(ip::Union{Lagrange{RefHexahedron, order}, DiscontinuousLagrange{RefHexahedron, order}}, x::Vector{<:Vec}, faceindex::Int) where order
     return calculate_volume(Lagrange{RefQuadrilateral, order}(), x)
 end
 function calculate_face_area(ip::Serendipity{RefQuadrilateral, order}, x::Vector{<:Vec}, faceindex::Int) where order
     return calculate_volume(Lagrange{RefLine, order}(), x)
 end
-function calculate_face_area(ip::Lagrange{RefTetrahedron, order}, x::Vector{<:Vec}, faceindex::Int) where order
+function calculate_face_area(p::Union{Lagrange{RefTetrahedron, order}, DiscontinuousLagrange{RefTetrahedron, order}}, x::Vector{<:Vec}, faceindex::Int) where order
     return calculate_volume(Lagrange{RefTriangle, order}(), x)
 end
 function calculate_face_area(p::Union{Lagrange{RefPrism, order}, DiscontinuousLagrange{RefPrism, order}}, x::Vector{<:Vec}, faceindex::Int) where order
@@ -251,6 +251,28 @@ coords_on_faces(x, ::Serendipity{RefHexahedron, 2}) =
 check_equal_or_nan(a::Any, b::Any) = a==b || (isnan(a) && isnan(b))
 check_equal_or_nan(a::Union{Tensor, Array}, b::Union{Tensor, Array}) = all(check_equal_or_nan.(a, b))
 
+# Hypercube is simply ⨂ᵈⁱᵐ Line :)
+sample_random_point(::Type{Ferrite.RefHypercube{ref_dim}}) where {ref_dim} = Vec{ref_dim}(2.0 .* rand(Vec{ref_dim}) .- 1.0)
+# Dirichlet type sampling
+function sample_random_point(::Type{Ferrite.RefSimplex{ref_dim}}) where {ref_dim} 
+    ξ = rand(ref_dim+1)
+    ξₜ = -log.(ξ)
+    return Vec{ref_dim}(ntuple(i->ξₜ[i], ref_dim) ./ sum(ξₜ))
+end
+# Wedge = Triangle ⊗ Line
+function sample_random_point(::Type{RefPrism})
+    (ξ₁, ξ₂) = sample_random_point(RefTriangle)
+    ξ₃ = rand(Float64)
+    return Vec{3}((ξ₁, ξ₂, ξ₃))
+end
+# TODO what to do here? The samplig is not uniform...
+function sample_random_point(::Type{RefPyramid})
+    ξ₃ = (1-1e-3)*rand(Float64) # Derivative is discontinuous at the top
+    # If we fix a z coordinate we get a Quad with extends (1-ξ₃)
+    (ξ₁, ξ₂) = (1.0 - ξ₃) .* rand(Vec{2})
+    return Vec{3}((ξ₁, ξ₂, ξ₃))
+end
+
 ######################################################
 # Helpers for testing face_to_element_transformation #
 ######################################################
@@ -265,4 +287,17 @@ function show_as_string(value, mime=MIME"text/plain"())
     io = IOBuffer()
     show(IOContext(io), mime, value)
     return String(take!(io))
+end
+
+######################################################
+# Dummy RefShape to test get_transformation_matrix   #
+######################################################
+module DummyRefShapes
+    import Ferrite
+    struct RefDodecahedron  <: Ferrite.AbstractRefShape{3} end
+    function Ferrite.reference_faces(::Type{RefDodecahedron})
+        return (
+            (1, 5, 4, 3, 2), 
+        )
+    end
 end


### PR DESCRIPTION
One way to generalize for more derivative orders while also supporting non-identity mappings. 
These changes make it possible to have a `PointValues` equivalent to `PointValuesInternal`, and the latter is just removed. With this setup, also non-identity mapping should work where `PointValuesInternal` previously was used. 