### PR TITLE
Update benchmarks

### DIFF
--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -69,8 +69,8 @@ for spatial_dim ∈ 1:3
                 LAGRANGE_SUITE["petrov-galerkin"]["face-flux"] = @benchmarkable FerriteAssemblyHelper._generalized_petrov_galerkin_assemble_local_matrix($grid, $fsv, shape_gradient, $fsv2, shape_value, *)
                 
                 ip = DiscontinuousLagrange{ref_type, order}()
-                isv = InterfaceValues(qr_face, ip, ip_geo; geom_interpol_b = ip_geo);
-                isv2 = InterfaceValues(qr_face, ip, ip_geo; geom_interpol_b = ip_geo);
+                isv = InterfaceValues(qr_face, ip, ip_geo);
+                isv2 = InterfaceValues(qr_face, ip, ip_geo);
                 dh = DofHandler(grid)
                 add!(dh, :u, ip)
                 close!(dh)

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -65,9 +65,7 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
     f
 end
 
-function _generalized_ritz_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler,
-    interfacevalues::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}},
-    f_shape, f_test, op) where {_, dim}
+function _generalized_ritz_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues::InterfaceValues, f_shape, f_test, op)
     n_basefuncs = getnbasefunctions(interfacevalues)
 
     K = zeros(ndofs(dh), ndofs(dh))
@@ -148,9 +146,7 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     f
 end
 
-function _generalized_petrov_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler,
-    interfacevalues_shape::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}}, f_shape,
-    interfacevalues_test::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}}, f_test, op) where {_, dim}
+function _generalized_petrov_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues_shape::InterfaceValues, f_shape, interfacevalues_test::InterfaceValues, f_test, op)
     n_basefuncs_shape = getnbasefunctions(interfacevalues_shape)
     n_basefuncs_test = getnbasefunctions(interfacevalues_test)
 

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -65,7 +65,9 @@ function _generalized_ritz_galerkin_assemble_local_matrix(grid::Ferrite.Abstract
     f
 end
 
-function _generalized_ritz_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_shape, f_test, op) where {dim}
+function _generalized_ritz_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler,
+    interfacevalues::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}},
+    f_shape, f_test, op) where {_, dim}
     n_basefuncs = getnbasefunctions(interfacevalues)
 
     K = zeros(ndofs(dh), ndofs(dh))
@@ -96,11 +98,11 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     Ke = zeros(n_basefuncs_test, n_basefuncs_shape)
 
     #implicit assumption: Same geometry!
-    X_shape = zeros(get_coordinate_type(grid), Ferrite.getngeobasefunctions(cellvalues_shape))
+    X_shape = zeros(Ferrite.get_coordinate_type(grid), Ferrite.getngeobasefunctions(cellvalues_shape))
     getcoordinates!(X_shape, grid, 1)
     reinit!(cellvalues_shape, X_shape)
 
-    X_test = zeros(get_coordinate_type(grid), Ferrite.getngeobasefunctions(cellvalues_test))
+    X_test = zeros(Ferrite.get_coordinate_type(grid), Ferrite.getngeobasefunctions(cellvalues_test))
     getcoordinates!(X_test, grid, 1)
     reinit!(cellvalues_test, X_test)
 
@@ -146,7 +148,9 @@ function _generalized_petrov_galerkin_assemble_local_matrix(grid::Ferrite.Abstra
     f
 end
 
-function _generalized_petrov_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler, interfacevalues_shape::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_shape, interfacevalues_test::InterfaceValues{<: FaceValues{<: Ferrite.InterpolationByDim{dim}}}, f_test, op) where {dim}
+function _generalized_petrov_galerkin_assemble_interfaces(dh::Ferrite.AbstractDofHandler,
+    interfacevalues_shape::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}}, f_shape,
+    interfacevalues_test::InterfaceValues{<: FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}}}, f_test, op) where {_, dim}
     n_basefuncs_shape = getnbasefunctions(interfacevalues_shape)
     n_basefuncs_test = getnbasefunctions(interfacevalues_test)
 


### PR DESCRIPTION
Updates benchmarks ~after the changes in #764~ to work with master
Changes:
- ~Using `FaceValues{<: Ferrite.FunctionValues{_, <: Ferrite.InterpolationByDim{dim}}` to dispatch over `dim`~ removed dim
- `get_coordinate_type(grid)` is not exported