### PR TITLE
Add list of registered packages in the Ferrite ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Please keep in mind that we are part of the Julia community and adhere to the
 
 ## Related packages
 The following registered packages are part of the `Ferrite.jl` ecosystem in addition to Ferrite itself:
-* [FerriteViz.jl](https://github.com/Ferrite-FEM/FerriteViz.jl): [Makie.jl](https://docs.makie.org/stable/)-based visualization of Ferrite data
-* [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl): Create, interact, and import [Gmsh](https://gmsh.info/) meshes into Ferrite
+* [Tensors.jl](https://github.com/Ferrite-FEM/Tensors.jl): Used throughout Ferrite for efficient tensor manipulation.
+* [FerriteViz.jl](https://github.com/Ferrite-FEM/FerriteViz.jl): [Makie.jl](https://docs.makie.org/stable/)-based visualization of Ferrite data.
+* [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl): Create, interact, and import [Gmsh](https://gmsh.info/) meshes into Ferrite.
 * [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl): Parse the mesh from Abaqus input files into a Ferrite mesh. 
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If you encounter what you think is a bug please report it, see
 Please keep in mind that we are part of the Julia community and adhere to the
 [Julia Community Standards][standards].
 
+## Related packages
+The following registered packages are part of the `Ferrite.jl` ecosystem in addition to Ferrite itself:
+* [FerriteViz.jl](https://github.com/Ferrite-FEM/FerriteViz.jl): [Makie.jl](https://docs.makie.org/stable/)-based visualization of Ferrite data
+* [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl): Create, interact, and import [Gmsh](https://gmsh.info/) meshes into Ferrite
+* [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl): Parse the mesh from Abaqus input files into a Ferrite mesh. 
+
 
 [docs-stable-img]: https://img.shields.io/badge/docs-latest%20release-blue
 [docs-stable-url]: http://ferrite-fem.github.io/Ferrite.jl/

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Please keep in mind that we are part of the Julia community and adhere to the
 
 ## Related packages
 The following registered packages are part of the `Ferrite.jl` ecosystem in addition to Ferrite itself:
-* [Tensors.jl](https://github.com/Ferrite-FEM/Tensors.jl): Used throughout Ferrite for efficient tensor manipulation.
-* [FerriteViz.jl](https://github.com/Ferrite-FEM/FerriteViz.jl): [Makie.jl](https://docs.makie.org/stable/)-based visualization of Ferrite data.
-* [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl): Create, interact, and import [Gmsh](https://gmsh.info/) meshes into Ferrite.
-* [FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl): Parse the mesh from Abaqus input files into a Ferrite mesh. 
+* [Tensors.jl][Tensors]: Used throughout Ferrite for efficient tensor manipulation.
+* [FerriteViz.jl][FerriteViz]: [Makie.jl][Makie]-based visualization of Ferrite data.
+* [FerriteGmsh.jl][FerriteGmsh]: Create, interact with, and import [Gmsh][Gmsh] meshes into Ferrite.
+* [FerriteMeshParser.jl][FerriteMeshParser]: Parse the mesh from Abaqus input files into a Ferrite mesh.
 
 
 [docs-stable-img]: https://img.shields.io/badge/docs-latest%20release-blue
@@ -56,3 +56,10 @@ The following registered packages are part of the `Ferrite.jl` ecosystem in addi
 [julia-slack]: https://julialang.org/slack/
 [julia-zulip]: https://julialang.zulipchat.com/
 [gh-discussion]: https://github.com/Ferrite-FEM/Ferrite.jl/discussions/new
+
+[Tensors]: https://github.com/Ferrite-FEM/Tensors.jl
+[FerriteViz]: https://github.com/Ferrite-FEM/FerriteViz.jl
+[FerriteGmsh]: https://github.com/Ferrite-FEM/FerriteGmsh.jl
+[FerriteMeshParser]: https://github.com/Ferrite-FEM/FerriteMeshParser.jl
+[Makie]: https://docs.makie.org/stable/
+[Gmsh]: https://gmsh.info/


### PR DESCRIPTION
Solves #868 

I limited to registered packages in this list that are made specifically (except Tensors) for Ferrite. I think that unregistered packages perhaps shouldn't be advertised as official (even though mentioning e.g. IGA.jl would be nice, what do you think @lijas?)
For related packages such as linear solvers and DifferentialEquations.jl, I suppose the tutorials take care of that?