### PR TITLE
Fix bug in L2Projector

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1019,8 +1019,9 @@ function _add!(ch::ConstraintHandler, pdbc::PeriodicDirichlet, interpolation::In
     # Dof map for mirror dof => image dof
     dof_map = Dict{dof_map_t,dof_map_t}()
 
-    mirror_dofs = zeros(Int, ndofs_per_cell(ch.dh))
-     image_dofs = zeros(Int, ndofs_per_cell(ch.dh))
+    n = ndofs_per_cell(ch.dh, first(face_map).mirror[1])
+    mirror_dofs = zeros(Int, n)
+    image_dofs  = zeros(Int, n)
     for face_pair in face_map
         m = face_pair.mirror
         i = face_pair.image

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -175,12 +175,14 @@ function ndofs_per_cell(dh::DofHandler)
     @assert length(dh.subdofhandlers) != 0
     return @inbounds ndofs_per_cell(dh.subdofhandlers[1])
 end
-function ndofs_per_cell(dh::DofHandler, cell::Int)
+@inline function ndofs_per_cell(dh::DofHandler, cell::Int)
     @boundscheck 1 <= cell <= getncells(get_grid(dh)) || throw(ArgumentError("cell = $cell ∉ 1:$(getncells(get_grid(dh)))"))
-    return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
+    sdh_idx = dh.cell_to_subdofhandler[cell]
+    @boundscheck 1 <= sdh_idx <= length(dh.subdofhandlers) || throw(ArgumentError("cell = $cell does no belong to any SubDofHandler"))
+    return @inbounds ndofs_per_cell(dh.subdofhandlers[sdh_idx])
 end
-ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
-ndofs_per_cell(sdh::SubDofHandler, ::Int) = sdh.ndofs_per_cell[] # for compatibility with DofHandler
+@inline ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
+@inline ndofs_per_cell(sdh::SubDofHandler, ::Int) = sdh.ndofs_per_cell[] # for compatibility with DofHandler
 
 """
     celldofs!(global_dofs::Vector{Int}, dh::AbstractDofHandler, i::Int)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -176,7 +176,7 @@ function ndofs_per_cell(dh::DofHandler)
     return @inbounds ndofs_per_cell(dh.subdofhandlers[1])
 end
 function ndofs_per_cell(dh::DofHandler, cell::Int)
-    @boundscheck 1 <= cell <= getncells(get_grid(dh))
+    @boundscheck 1 <= cell <= getncells(get_grid(dh)) || throw(ArgumentError("cell = $cell ∉ 1:$(getncells(get_grid(dh)))"))
     return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end
 ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -175,14 +175,11 @@ function ndofs_per_cell(dh::DofHandler)
     @assert length(dh.subdofhandlers) != 0
     return @inbounds ndofs_per_cell(dh.subdofhandlers[1])
 end
-@inline function ndofs_per_cell(dh::DofHandler, cell::Int)
-    @boundscheck 1 <= cell <= getncells(get_grid(dh)) || throw(ArgumentError("cell = $cell ∉ 1:$(getncells(get_grid(dh)))"))
-    sdh_idx = dh.cell_to_subdofhandler[cell]
-    @boundscheck 1 <= sdh_idx <= length(dh.subdofhandlers) || throw(ArgumentError("cell = $cell does no belong to any SubDofHandler"))
-    return @inbounds ndofs_per_cell(dh.subdofhandlers[sdh_idx])
+function ndofs_per_cell(dh::DofHandler, cell::Int)
+    return ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end
-@inline ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
-@inline ndofs_per_cell(sdh::SubDofHandler, ::Int) = sdh.ndofs_per_cell[] # for compatibility with DofHandler
+ndofs_per_cell(sdh::SubDofHandler) = sdh.ndofs_per_cell[]
+ndofs_per_cell(sdh::SubDofHandler, ::Int) = sdh.ndofs_per_cell[] # for compatibility with DofHandler
 
 """
     celldofs!(global_dofs::Vector{Int}, dh::AbstractDofHandler, i::Int)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -168,7 +168,14 @@ Return the number of degrees of freedom for the cell with index `cell`.
 
 See also [`ndofs`](@ref).
 """
-function ndofs_per_cell(dh::DofHandler, cell::Int=1)
+function ndofs_per_cell(dh::DofHandler)
+    if length(dh.subdofhandlers) > 1
+        error("There are more than one subdofhandler. Use `ndofs_per_cell(dh, cellid::Int)` instead.")
+    end
+    @assert length(dh.subdofhandlers) != 0
+    return @inbounds ndofs_per_cell(dh.subdofhandlers[1])
+end
+function ndofs_per_cell(dh::DofHandler, cell::Int)
     @boundscheck 1 <= cell <= getncells(get_grid(dh))
     return @inbounds ndofs_per_cell(dh.subdofhandlers[dh.cell_to_subdofhandler[cell]])
 end

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -388,7 +388,7 @@ to a Node.
 "Returns the number of nodes in the grid."
 @inline getnnodes(grid::AbstractGrid) = length(grid.nodes)
 "Returns the number of nodes of the `i`-th cell."
-@inline function nnodes_per_cell(grid::AbstractGrid) 
+function nnodes_per_cell(grid::AbstractGrid) 
     if !isconcretetype(getcelltype(grid))
         error("There are different celltypes in the `grid`. Use `nnodes_per_cell(grid, cellid::Int)` instead")
     end

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -388,7 +388,13 @@ to a Node.
 "Returns the number of nodes in the grid."
 @inline getnnodes(grid::AbstractGrid) = length(grid.nodes)
 "Returns the number of nodes of the `i`-th cell."
-@inline nnodes_per_cell(grid::AbstractGrid, i::Int=1) = nnodes(grid.cells[i])
+@inline function nnodes_per_cell(grid::AbstractGrid) 
+    if !isconcretetype(getcelltype(grid))
+        error("There are different celltypes in the `grid`. Use `nnodes_per_cell(grid, cellid::Int)` instead")
+    end
+    return nnodes(first(grid.cells))
+end
+@inline nnodes_per_cell(grid::AbstractGrid, i::Int) = nnodes(grid.cells[i])
 
 "Return the number type of the nodal coordinates."
 @inline get_coordinate_eltype(grid::AbstractGrid) = get_coordinate_eltype(first(getnodes(grid)))

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -53,14 +53,7 @@ function L2Projector(
     dh = DofHandler(grid)
     sdh = SubDofHandler(dh, Set(set))
     add!(sdh, :_, func_ip) # we need to create the field, but the interpolation is not used here
-    close!(dh)
-    # The dofhandler `dh` in the L2Project creates an "incomplete" dofhandler, i.e not all cells belongs to a subdofhandler
-    # This causes an error when calling Ferrite.evaluate_at_grid_nodes(proj, point_vars) (when creating a CellIterator), see PR870.
-    # HACK: To solve this, we need can make all cells point to the same subdofhandler.
-    for i in 1:length(dh.cell_to_subdofhandler)
-        dh.cell_to_subdofhandler[i] = 1
-    end
-    
+    close!(dh)  
 
     M = _assemble_L2_matrix(fe_values_mass, set, dh)  # the "mass" matrix
     M_cholesky = cholesky(M)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -268,8 +268,6 @@ function _evaluate_at_grid_nodes(
 end
 function _evaluate_at_grid_nodes!(data, cv, dh, set, u::AbstractVector{S}) where S
     ue = zeros(S, getnbasefunctions(cv))
-    @show dh.field_names
-    @show dh.cell_to_subdofhandler[1]
     for cell in CellIterator(dh, set)
         @assert getnquadpoints(cv) == length(cell.nodes)
         for (i, I) in pairs(cell.dofs)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -55,8 +55,8 @@ function L2Projector(
     add!(sdh, :_, func_ip) # we need to create the field, but the interpolation is not used here
     close!(dh)
     # The dofhandler `dh` in the L2Project creates an "incomplete" dofhandler, i.e not all cells belongs to a subdofhandler
-    # This causes error in Ferrite.evaluate_at_grid_nodes(proj, point_vars) when createing an CellIterator, see PR###.
-    # HACK: To solve this, we need can make all cell points to the same subdofhandler.
+    # This causes an error when calling Ferrite.evaluate_at_grid_nodes(proj, point_vars) (when creating a CellIterator), see PR870.
+    # HACK: To solve this, we need can make all cells point to the same subdofhandler.
     for i in 1:length(dh.cell_to_subdofhandler)
         dh.cell_to_subdofhandler[i] = 1
     end

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -53,7 +53,7 @@ function L2Projector(
     dh = DofHandler(grid)
     sdh = SubDofHandler(dh, Set(set))
     add!(sdh, :_, func_ip) # we need to create the field, but the interpolation is not used here
-    close!(dh)  
+    close!(dh)
 
     M = _assemble_L2_matrix(fe_values_mass, set, dh)  # the "mass" matrix
     M_cholesky = cholesky(M)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -51,24 +51,18 @@ struct CellCache{X,G<:AbstractGrid,DH<:Union{AbstractDofHandler,Nothing}}
 end
 
 function CellCache(grid::Grid{dim,C,T}, flags::UpdateFlags=UpdateFlags()) where {dim,C,T}
-    N = 0
-    if isconcretetype(getcelltype(grid))
-        N = nnodes_per_cell(grid)
-    end
+    N = nnodes_per_cell(grid, 1) # nodes and coords will be resized in `reinit!`
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim,T}, N)
     return CellCache(flags, grid, ScalarWrapper(-1), nodes, coords, nothing, Int[])
 end
 
 function CellCache(dh::DofHandler{dim}, flags::UpdateFlags=UpdateFlags()) where {dim}
-    N = 0
-    if isconcretetype(getcelltype(get_grid(dh)))
-        N = nnodes_per_cell(get_grid(dh))
-    end
-    n = 0
+    n = 0 # celldofs will be resized in reinit!
     if length(dh.subdofhandlers) == 1
         n = ndofs_per_cell(dh)
     end
+    N = nnodes_per_cell(get_grid(dh), 1)
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, get_coordinate_eltype(get_grid(dh))}, N)
     celldofs = zeros(Int, n)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -58,10 +58,7 @@ function CellCache(grid::Grid{dim,C,T}, flags::UpdateFlags=UpdateFlags()) where 
 end
 
 function CellCache(dh::DofHandler{dim}, flags::UpdateFlags=UpdateFlags()) where {dim}
-    n = 0 # celldofs will be resized in reinit!
-    if length(dh.subdofhandlers) == 1
-        n = ndofs_per_cell(dh)
-    end
+    n = ndofs_per_cell(dh.subdofhandlers[1]) # dofs and coords will be resized in `reinit!`
     N = nnodes_per_cell(get_grid(dh), 1)
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, get_coordinate_eltype(get_grid(dh))}, N)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -51,17 +51,26 @@ struct CellCache{X,G<:AbstractGrid,DH<:Union{AbstractDofHandler,Nothing}}
 end
 
 function CellCache(grid::Grid{dim,C,T}, flags::UpdateFlags=UpdateFlags()) where {dim,C,T}
-    N = nnodes_per_cell(grid)
+    N = 0
+    if isconcretetype(getcelltype(grid))
+        N = nnodes_per_cell(grid)
+    end
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim,T}, N)
     return CellCache(flags, grid, ScalarWrapper(-1), nodes, coords, nothing, Int[])
 end
 
 function CellCache(dh::DofHandler{dim}, flags::UpdateFlags=UpdateFlags()) where {dim}
-    N = nnodes_per_cell(get_grid(dh))
+    N = 0
+    if isconcretetype(getcelltype(get_grid(dh)))
+        N = nnodes_per_cell(get_grid(dh))
+    end
+    n = 0
+    if length(dh.subdofhandlers) == 1
+        n = ndofs_per_cell(dh)
+    end
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, get_coordinate_eltype(get_grid(dh))}, N)
-    n = ndofs_per_cell(dh)
     celldofs = zeros(Int, n)
     return CellCache(flags, get_grid(dh), ScalarWrapper(-1), nodes, coords, dh, celldofs)
 end

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -145,6 +145,13 @@ function test_projection_mixedgrid()
     proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=quadset)
     point_vars = project(proj, qp_values, qr)
     point_vars_2 = project(proj, qp_values_matrix, qr)
+    projection_at_nodes = evaluate_at_grid_nodes(proj, point_vars)
+    for cellid in quadset
+        for nodeid in mesh.cells[cellid].nodes
+            x = mesh.nodes[nodeid].x
+            @test projection_at_nodes[nodeid] ≈ f(x)
+        end
+    end
 
     ae = zeros(3, length(point_vars))
     for i in 1:3
@@ -154,7 +161,6 @@ function test_projection_mixedgrid()
     @test point_vars ≈ point_vars_2 ≈ ae
 
     # Do the same thing but for the triangle set
-    order = 2
     ip = Lagrange{RefTriangle, order}()
     ip_geom = Lagrange{RefTriangle, 1}()
     qr = QuadratureRule{RefTriangle}(4)
@@ -175,6 +181,14 @@ function test_projection_mixedgrid()
     proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=triaset)
     point_vars = project(proj, qp_values_tria, qr)
     point_vars_2 = project(proj, qp_values_matrix_tria, qr)
+    projection_at_nodes = evaluate_at_grid_nodes(proj, point_vars)
+    for cellid in triaset
+        for nodeid in mesh.cells[cellid].nodes
+            x = mesh.nodes[nodeid].x
+            @test projection_at_nodes[nodeid] ≈ f(x)
+        end
+    end
+
     ae = zeros(3, length(point_vars))
     for i in 1:3
         apply_analytical!(@view(ae[i, :]), proj.dh, :_, x -> f(x).data[i], triaset)

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -134,6 +134,7 @@ function test_2d_mixed_2_el()
     @test ndofs_per_cell(dh, 2) == 9
     @test ndofs_per_cell(dh.subdofhandlers[2]) == 9
     @test_throws ErrorException ndofs_per_cell(dh)
+    @test_throws ErrorException Ferrite.nnodes_per_cell(grid)
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     @test celldofs(dh, 2) == [5, 6, 3, 4, 13, 14, 11, 10, 15]
 end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -133,6 +133,7 @@ function test_2d_mixed_2_el()
     @test ndofs_per_cell(dh.subdofhandlers[1]) == 12
     @test ndofs_per_cell(dh, 2) == 9
     @test ndofs_per_cell(dh.subdofhandlers[2]) == 9
+    @test_throws ErrorException ndofs_per_cell(dh)
     @test celldofs(dh, 1) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     @test celldofs(dh, 2) == [5, 6, 3, 4, 13, 14, 11, 10, 15]
 end


### PR DESCRIPTION
I had a bug in the L2Projector when projecting the results to the nodes for a subset of cells in a mixed grid. Specifically the error is caused when calling `Ferrite.evaluate_at_grid_nodes(proj, point_vars)`

The error comes from that the L2Projector creates a DofHandler where not all cells belong to a subdofhandler (should this be allowed?). This in turns causes an error when ndofs_per_cell(dh, [cellid=1]) is called internally in L2Projector, where cell with id 1 does not belong to a subdofhandler.

There are probably multiple ways to fix this. I did not want to "leak" this issue to other parts of the code, so this PR creates a small hack in the L2Projector.

In the future we should probably improve the interface for the L2Projector anyways (#610 ), so maybe this is an ok fix for now?

```
using Ferrite

dim = 2
nodes = Node{dim, Float64}[]
push!(nodes, Node((0.0, 0.0)))
push!(nodes, Node((1.0, 0.0)))
push!(nodes, Node((2.0, 0.0)))
push!(nodes, Node((0.0, 1.0)))
push!(nodes, Node((1.0, 1.0)))
push!(nodes, Node((2.0, 1.0)))

cells = Ferrite.AbstractCell[]
push!(cells, Quadrilateral((1,2,5,4)))
push!(cells, Triangle((2,3,6)))
push!(cells, Triangle((2,6,5)))

quadset = 1:1
triaset = 2:3
mesh = Grid(cells, nodes)

# Triangle set
order = 2
ip = Lagrange{RefTriangle, order}()
ip_geom = Lagrange{RefTriangle, 1}()
qr = QuadratureRule{RefTriangle}(4)
nqp = getnquadpoints(qr)

qp_values_tria = [zeros(SymmetricTensor{2,2}, nqp) for _ in triaset]
#tria
proj = L2Projector(ip, mesh; geom_ip=ip_geom, set=triaset)
point_vars = project(proj, qp_values_tria, qr)

projection_at_nodes = evaluate_at_grid_nodes(proj, point_vars) #ERROR
```

Error:
```
ERROR: OutOfMemoryError()
Stacktrace:
  [1] Array
    @ ./boot.jl:477 [inlined]
  [2] Array
    @ ./boot.jl:486 [inlined]
  [3] zeros
    @ ./array.jl:584 [inlined]
  [4] zeros
    @ ./array.jl:580 [inlined]
  [5] CellCache(dh::DofHandler{2, Grid{2, Ferrite.AbstractCell, Float64}}, flags::UpdateFlags)
    @ Ferrite ~/Documents/juliapkg/Ferrite.jl/src/iterators.jl:65
  [6] CellIterator(gridordh::DofHandler{2, Grid{2, Ferrite.AbstractCell, Float64}}, set::Vector{Int64}, flags::UpdateFlags)
    @ Ferrite ~/Documents/juliapkg/Ferrite.jl/src/iterators.jl:274
  [7] CellIterator
    @ ~/Documents/juliapkg/Ferrite.jl/src/iterators.jl:265 [inlined]
  [8] _evaluate_at_grid_nodes!(data::Vector{SymmetricTensor{2, 2, Float64, 3}}, cv::CellValues{Ferrite.FunctionValues{1, Lagrange{RefTriangle, 2, Nothing}, Matrix{Float64}, Matrix{Vec{2, Float64}}, Matrix{Vec{2, Float64}}}, Ferrite.GeometryMapping{1, Lagrange{RefTriangle, 1, Nothing}, Matrix{Float64}, Matrix{Vec{2, Float64}}, Nothing}, QuadratureRule{RefTriangle, Float64, 2}, Vector{Float64}}, dh::DofHandler{2, Grid{2, Ferrite.AbstractCell, Float64}}, set::Vector{Int64}, u::Vector{SymmetricTensor{2, 2, Float64, 3}})
    @ Ferrite ~/Documents/juliapkg/Ferrite.jl/src/L2_projection.jl:273
  [9] _evaluate_at_grid_nodes(proj::L2Projector, vals::Vector{SymmetricTensor{2, 2, Float64, 3}}, #unused#::Val{false})
    @ Ferrite ~/Documents/juliapkg/Ferrite.jl/src/L2_projection.jl:267
 [10] evaluate_at_grid_nodes(proj::L2Projector, vals::Vector{SymmetricTensor{2, 2, Float64, 3}})
    @ Ferrite ~/Documents/juliapkg/Ferrite.jl/src/L2_projection.jl:240
 [11] top-level scope
    @ ~/Documents/juliapkg/Ferrite.jl/test/test_l2_projection.jl:184
```