### PR TITLE
Add helper function compute_bouding_box 

### DIFF
--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -99,6 +99,7 @@ include("Grid/topology.jl")
 include("Grid/utils.jl")
 include("Grid/grid_generators.jl")
 include("Grid/coloring.jl")
+include("Grid/grid_utils.jl")
 
 # Dofs
 include("Dofs/DofHandler.jl")

--- a/src/Grid/grid_utils.jl
+++ b/src/Grid/grid_utils.jl
@@ -1,0 +1,19 @@
+
+
+"""
+    compute_bounding_box(grid::AbstractGrid)
+
+Computes the bounding box for a given grid, based on its node coordinates. 
+Returns the minimum and maximum vertices of the bounding box.
+"""
+function compute_bounding_box(grid::AbstractGrid{dim}) where {dim}
+    T = get_coordinate_eltype(grid)
+    min_vertex = Vec{dim}(i->T(+Inf))
+    max_vertex = Vec{dim}(i->T(-Inf))
+    for node in getnodes(grid)
+        x = get_node_coordinate(node)
+        max_vertex = Vec{dim}(i -> max(x[i], max_vertex[i]))
+        min_vertex = Vec{dim}(i -> min(x[i], min_vertex[i]))
+    end
+    return min_vertex, max_vertex
+end

--- a/test/test_abstractgrid.jl
+++ b/test/test_abstractgrid.jl
@@ -82,6 +82,10 @@
     @test Ferrite.ndofs(dhs[1]) == Ferrite.ndofs(dhs[2])
     @test isapprox(u1,u2,atol=1e-8)
 
+    minv, maxv = Ferrite.compute_bounding_box(subtype_grid)
+    @test minv == Vec((-1.0,-1.0))
+    @test maxv == Vec((+1.0,1.0))
+
     colors1 = Ferrite.create_coloring(subtype_grid, alg = ColoringAlgorithm.WorkStream)
     colors2 = Ferrite.create_coloring(reference_grid, alg = ColoringAlgorithm.WorkStream)
     @test all(colors1 .== colors2)

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -91,6 +91,10 @@ end
             rm(dofhandlerfilename*".vtu")
         end
 
+        minv, maxv = Ferrite.compute_bounding_box(grid)
+        @test minv == 2left
+        @test maxv == 2right
+    
     end
 
 end # of testset


### PR DESCRIPTION
I think it can be nice to add some grid utils. In this PR I am adding `compute_bouding_box() `, which I have recently needed for some pre-processing stuff.

Note. The current code is type unstable for some reason. Both `max_vertex` and `min_vertex` are both `Core.Box`. Anyone understands why?
