### PR TITLE
Make default constructor type stable

### DIFF
--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -42,13 +42,14 @@ struct CellValues{FV, GM, QR, detT} <: AbstractCellValues
     detJdV::detT   # AbstractVector{<:Number} or Nothing
 end
 function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation; 
-        update_gradients::Bool = true, update_detJdV::Bool = true) where T 
+        update_gradients::Union{Bool,Nothing} = nothing, update_detJdV::Union{Bool,Nothing} = nothing) where T 
     
-    FunDiffOrder = convert(Int, update_gradients) # Logic must change when supporting update_hessian kwargs
-    GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), update_detJdV)
+    _update_detJdV = update_detJdV === nothing ? true : update_detJdV
+    FunDiffOrder = update_gradients === nothing ? 1 : convert(Int, update_gradients) # Logic must change when supporting update_hessian kwargs
+    GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), _update_detJdV)
     geo_mapping = GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr)
     fun_values = FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo)
-    detJdV = update_detJdV ? fill(T(NaN), length(getweights(qr))) : nothing
+    detJdV = _update_detJdV ? fill(T(NaN), length(getweights(qr))) : nothing
     return CellValues(fun_values, geo_mapping, qr, detJdV)
 end
 

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -41,9 +41,9 @@ struct FaceValues{FV, GM, FQR, detT, nT, V_FV<:AbstractVector{FV}, V_GM<:Abstrac
 end
 
 function FaceValues(::Type{T}, fqr::FaceQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim} = default_geometric_interpolation(ip_fun); 
-        update_gradients::Bool = true) where {T,sdim} 
+        update_gradients::Union{Bool,Nothing} = nothing) where {T,sdim} 
     
-    FunDiffOrder = convert(Int, update_gradients) # Logic must change when supporting update_hessian kwargs
+    FunDiffOrder = update_gradients === nothing ? 1 : convert(Int, update_gradients) # Logic must change when supporting update_hessian kwargs
     GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), 1)
     geo_mapping = [GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr) for qr in fqr.face_rules]
     fun_values = [FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for qr in fqr.face_rules]

--- a/src/FEValues/FaceValues.jl
+++ b/src/FEValues/FaceValues.jl
@@ -45,17 +45,19 @@ function FaceValues(::Type{T}, fqr::FaceQuadratureRule, ip_fun::Interpolation, i
     
     FunDiffOrder = update_gradients === nothing ? 1 : convert(Int, update_gradients) # Logic must change when supporting update_hessian kwargs
     GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), 1)
-    geo_mapping = [GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr) for qr in fqr.face_rules]
-    fun_values = [FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for qr in fqr.face_rules]
+    # Not sure why the type-asserts are required here but not for CellValues, 
+    # but they solve the type-instability for FaceValues
+    geo_mapping = [GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr) for qr in fqr.face_rules]::Vector{<:GeometryMapping{GeoDiffOrder}}
+    fun_values = [FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for qr in fqr.face_rules]::Vector{<:FunctionValues{FunDiffOrder}}
     max_nquadpoints = maximum(qr->length(getweights(qr)), fqr.face_rules)
     detJdV  = fill(T(NaN), max_nquadpoints)
     normals = fill(zero(Vec{sdim, T}) * T(NaN), max_nquadpoints)
     return FaceValues(fun_values, geo_mapping, fqr, detJdV, normals, ScalarWrapper(1))
 end
 
-FaceValues(qr::FaceQuadratureRule, ip::Interpolation, args...) = FaceValues(Float64, qr, ip, args...)
-function FaceValues(::Type{T}, qr::FaceQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation) where T
-    return FaceValues(T, qr, ip, VectorizedInterpolation(ip_geo))
+FaceValues(qr::FaceQuadratureRule, ip::Interpolation, args...; kwargs...) = FaceValues(Float64, qr, ip, args...; kwargs...)
+function FaceValues(::Type{T}, qr::FaceQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation; kwargs...) where T
+    return FaceValues(T, qr, ip, VectorizedInterpolation(ip_geo); kwargs...)
 end
 
 function Base.copy(fv::FaceValues)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -18,12 +18,9 @@
                                    )
 
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
-        # Ensure type-stable default constructor 
-        @test_call CellValues(quad_rule, func_interpol)
-        
         geom_interpol = scalar_interpol # Tests below assume this
         n_basefunc_base = getnbasefunctions(scalar_interpol)
-        cv = CellValues(quad_rule, func_interpol, geom_interpol)
+        cv = @inferred CellValues(quad_rule, func_interpol, geom_interpol)
         ndim = Ferrite.getdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)
 

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -18,6 +18,9 @@
                                    )
 
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
+        # Ensure type-stable default constructor 
+        @test_call CellValues(quad_rule, func_interpol)
+        
         geom_interpol = scalar_interpol # Tests below assume this
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         cv = CellValues(quad_rule, func_interpol, geom_interpol)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -15,6 +15,9 @@ for (scalar_interpol, quad_rule) in (
                                    )
 
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
+        # Ensure type-stable default constructor 
+        @test_call FaceValues(quad_rule, func_interpol)
+        
         geom_interpol = scalar_interpol # Tests below assume this
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         fv = FaceValues(quad_rule, func_interpol, geom_interpol)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -17,7 +17,11 @@ for (scalar_interpol, quad_rule) in (
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
         geom_interpol = scalar_interpol # Tests below assume this
         n_basefunc_base = getnbasefunctions(scalar_interpol)
-        fv = @inferred FaceValues(quad_rule, func_interpol, geom_interpol)
+        fv = if VERSION ≥ v"1.9"
+            @inferred FaceValues(quad_rule, func_interpol, geom_interpol)
+        else # Type unstable on 1.6, but works at least for 1.9 and later. PR882
+            FaceValues(quad_rule, func_interpol, geom_interpol)
+        end
         ndim = Ferrite.getdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)
 

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -15,12 +15,9 @@ for (scalar_interpol, quad_rule) in (
                                    )
 
     for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol))
-        # Ensure type-stable default constructor 
-        @test_call FaceValues(quad_rule, func_interpol)
-        
         geom_interpol = scalar_interpol # Tests below assume this
         n_basefunc_base = getnbasefunctions(scalar_interpol)
-        fv = FaceValues(quad_rule, func_interpol, geom_interpol)
+        fv = @inferred FaceValues(quad_rule, func_interpol, geom_interpol)
         ndim = Ferrite.getdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)
 


### PR DESCRIPTION
The update keyword arguments to `FaceValues` and `CellValues` are not fixed yet and are not public API. However, at least the default update behavior shouldn't be type unstable, mwe from @AbdAlazezAhmed show a very standard case when this is an issue, see below. 

When adding higher order derivative outputs, a proper API must be decided, e.g. a `ValuesUpdateFlags` input instead of the current keyword arguments. 

```julia
using Ferrite

grid = generate_grid(Hexahedron, (2, 2, 2));
ip = Lagrange{RefHexahedron, 1}()
dh = DofHandler(grid)
add!(dh, :u, ip)
close!(dh);
function assemble_global(dh, ip)
    qr = QuadratureRule{RefHexahedron}(2)
    cellvalues = CellValues(qr, ip);
    for cell in CellIterator(dh)
        reinit!(cellvalues, cell)
    end
end
@code_warntype assemble_global(dh, ip)
```
<details><summary>output (master)</summary>

```julia
MethodInstance for assemble_global(::DofHandler{3, Grid{3, Hexahedron, Float64}}, ::Lagrange{RefHexahedron, 1, Nothing})
  from assemble_global(dh, ip) @ Main REPL[9]:1
Arguments
  #self#::Core.Const(assemble_global)
  dh::DofHandler{3, Grid{3, Hexahedron, Float64}}
  ip::Core.Const(Lagrange{RefHexahedron, 1}())
Locals
  @_4::Union{Nothing, Tuple{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Int64}}
  cellvalues::CellValues{_A, _B, QuadratureRule{RefHexahedron, Float64, 3}} where {_A, _B}
  qr::QuadratureRule{RefHexahedron, Float64, 3}
  cell::CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}
Body::Nothing
1 ─ %1  = Core.apply_type(Main.QuadratureRule, Main.RefHexahedron)::Core.Const(QuadratureRule{RefHexahedron})
│         (qr = (%1)(2))
│         (cellvalues = Main.CellValues(qr, ip))
│   %4  = Main.CellIterator(dh)::Core.PartialStruct(CellIterator{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, UnitRange{Int64}}, Any[CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Core.PartialStruct(UnitRange{Int64}, Any[Core.Const(1), Int64])])
│         (@_4 = Base.iterate(%4))
│   %6  = (@_4 === nothing)::Bool
│   %7  = Base.not_int(%6)::Bool
└──       goto #4 if not %7
2 ┄ %9  = @_4::Tuple{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Int64}
│         (cell = Core.getfield(%9, 1))
│   %11 = Core.getfield(%9, 2)::Int64
│         Main.reinit!(cellvalues, cell)
│         (@_4 = Base.iterate(%4, %11))
│   %14 = (@_4 === nothing)::Bool
│   %15 = Base.not_int(%14)::Bool
└──       goto #4 if not %15
3 ─       goto #2
4 ┄       return nothing
```
</details>

<details><summary>output (pr)</summary>

```julia
MethodInstance for assemble_global(::DofHandler{3, Grid{3, Hexahedron, Float64}}, ::Lagrange{RefHexahedron, 1, Nothing})
  from assemble_global(dh, ip) @ Main REPL[9]:1
Arguments
  #self#::Core.Const(assemble_global)
  dh::DofHandler{3, Grid{3, Hexahedron, Float64}}
  ip::Core.Const(Lagrange{RefHexahedron, 1}())
Locals
  @_4::Union{Nothing, Tuple{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Int64}}
  cellvalues::CellValues{Ferrite.FunctionValues{1, Lagrange{RefHexahedron, 1, Nothing}, Matrix{Float64}, Matrix{Vec{3, Float64}}, Matrix{Vec{3, Float64}}}, Ferrite.GeometryMapping{1, Lagrange{RefHexahedron, 1, Nothing}, Matrix{Float64}, Matrix{Vec{3, Float64}}, Nothing}, QuadratureRule{RefHexahedron, Float64, 3}, Vector{Float64}}
  qr::QuadratureRule{RefHexahedron, Float64, 3}
  cell::CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}
Body::Nothing
1 ─ %1  = Core.apply_type(Main.QuadratureRule, Main.RefHexahedron)::Core.Const(QuadratureRule{RefHexahedron})
│         (qr = (%1)(2))
│         (cellvalues = Main.CellValues(qr, ip))
│   %4  = Main.CellIterator(dh)::Core.PartialStruct(CellIterator{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, UnitRange{Int64}}, Any[CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Core.PartialStruct(UnitRange{Int64}, Any[Core.Const(1), Int64])])
│         (@_4 = Base.iterate(%4))
│   %6  = (@_4 === nothing)::Bool
│   %7  = Base.not_int(%6)::Bool
└──       goto #4 if not %7
2 ┄ %9  = @_4::Tuple{CellCache{Vec{3, Float64}, Grid{3, Hexahedron, Float64}, DofHandler{3, Grid{3, Hexahedron, Float64}}}, Int64}
│         (cell = Core.getfield(%9, 1))
│   %11 = Core.getfield(%9, 2)::Int64
│         Main.reinit!(cellvalues, cell)
│         (@_4 = Base.iterate(%4, %11))
│   %14 = (@_4 === nothing)::Bool
│   %15 = Base.not_int(%14)::Bool
└──       goto #4 if not %15
3 ─       goto #2
4 ┄       return nothing
```
</details>
