### PR TITLE
Explicitly import all names 2

### DIFF
--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -13,6 +13,8 @@ using LinearAlgebra:
     pinv, tr
 using NearestNeighbors:
     NearestNeighbors, KDTree, knn
+using Preferences:
+    Preferences
 using SparseArrays:
     SparseArrays, SparseMatrixCSC, nonzeros, nzrange, rowvals, sparse, spzeros
 using StaticArrays:

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,8 +1,7 @@
 Base.@deprecate_binding DirichletBoundaryConditions ConstraintHandler
 Base.@deprecate_binding DirichletBoundaryCondition Dirichlet
 
-import Base: push!
-@deprecate push!(dh::AbstractDofHandler, args...) add!(dh, args...)
+@deprecate Base.push!(dh::AbstractDofHandler, args...) add!(dh, args...)
 
 @deprecate vertices(ip::Interpolation) vertexdof_indices(ip) false
 @deprecate faces(ip::Interpolation) facedof_indices(ip) false

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,7 +1,7 @@
 Base.@deprecate_binding DirichletBoundaryConditions ConstraintHandler
 Base.@deprecate_binding DirichletBoundaryCondition Dirichlet
 
-@deprecate Base.push!(dh::AbstractDofHandler, args...) add!(dh, args...)
+@deprecate Base.push!(dh::AbstractDofHandler, args...) add!(dh, args...) false
 
 @deprecate vertices(ip::Interpolation) vertexdof_indices(ip) false
 @deprecate faces(ip::Interpolation) facedof_indices(ip) false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,3 @@
-import Preferences
-
 const DEBUG = Preferences.@load_preference("use_debug", false)
 
 """


### PR DESCRIPTION
xref #905 

Just noticed these when merging #692 

Most important was the `import Base: push!`, but figured preferences should also be imported in `src/Ferrite.jl` instead of in the utils

I guess `using Preferences: Preferences` is equivalent to `import Preferences`, but I changed it just to be consistent with the remaining statements. 