### PR TITLE
Faster ExclusiveTopology construction

### DIFF
--- a/src/Grid/topology.jl
+++ b/src/Grid/topology.jl
@@ -107,9 +107,10 @@ function _num_shared_vertices(cell_a::C1, cell_b::C2) where {C1, C2}
 end
 
 function _exclusive_topology_ctor(cells::Vector{C}, vertex_cell_table::Array{Set{Int}}, vertex_table, face_table, edge_table, cell_neighbor_table) where C <: AbstractCell
+    cell_neighbor_ids = Set{Int}()
     for (cell_id, cell) in enumerate(cells)
         # Gather all cells which are connected via vertices
-        cell_neighbor_ids = Set{Int}()
+        empty!(cell_neighbor_ids)
         for vertex ∈ vertices(cell)
             for vertex_cell_id ∈ vertex_cell_table[vertex]
                 if vertex_cell_id != cell_id
@@ -117,7 +118,7 @@ function _exclusive_topology_ctor(cells::Vector{C}, vertex_cell_table::Array{Set
                 end
             end
         end
-        cell_neighbor_table[cell_id] = EntityNeighborhood(CellIndex.(collect(cell_neighbor_ids)))
+        cell_neighbor_table[cell_id] = EntityNeighborhood([CellIndex(cell_id) for cell_id in cell_neighbor_ids])
 
         # Any of the neighbors is now sorted in the respective categories
         for cell_neighbor_id ∈ cell_neighbor_ids

--- a/src/Grid/topology.jl
+++ b/src/Grid/topology.jl
@@ -187,24 +187,10 @@ function ExclusiveTopology(cells::Vector{C}) where C <: AbstractCell
     end
 
     # Setup matrices
-    vertex_table = Matrix{EntityNeighborhood{VertexIndex}}(undef, length(cells), max_vertices)
-    for j = 1:size(vertex_table,2)
-        for i = 1:size(vertex_table,1)
-            vertex_table[i,j] = EntityNeighborhood{VertexIndex}(VertexIndex[])
-        end
-    end
-    face_table   = Matrix{EntityNeighborhood{FaceIndex}}(undef, length(cells), max_faces)
-    for j = 1:size(face_table,2)
-        for i = 1:size(face_table,1)
-            face_table[i,j] = EntityNeighborhood{FaceIndex}(FaceIndex[])
-        end
-    end
-    edge_table   = Matrix{EntityNeighborhood{EdgeIndex}}(undef, length(cells), max_edges)
-    for j = 1:size(edge_table,2)
-        for i = 1:size(edge_table,1)
-            edge_table[i,j] = EntityNeighborhood{EdgeIndex}(EdgeIndex[])
-        end
-    end
+    vertex_table = [EntityNeighborhood{VertexIndex}(VertexIndex[]) for _ in 1:length(cells), _ in 1:max_vertices]
+    edge_table   = [EntityNeighborhood{EdgeIndex  }(EdgeIndex[]  ) for _ in 1:length(cells), _ in 1:max_edges]
+    face_table   = [EntityNeighborhood{FaceIndex  }(FaceIndex[]  ) for _ in 1:length(cells), _ in 1:max_faces]
+
     cell_neighbor_table = Vector{EntityNeighborhood{CellIndex}}(undef, length(cells))
 
     _exclusive_topology_ctor(cells, vertex_cell_table, vertex_table, face_table, edge_table, cell_neighbor_table)


### PR DESCRIPTION
Had this as notes lingering around after seeing #617, nothing urgent or major.
Timings should be verified by someone since this is so heavy on GC it seems to be quite unreliable to time it and profiling changes from run to run...

Somewhat representative btime runs give 
```julia
grid = generate_grid(Hexahedron, (40, 40, 40)) # more stable timings than 3x80
@btime ExclusiveTopology($grid);
528.067 ms (3582741 allocations: 378.69 MiB) # PR
580.268 ms (4094719 allocations: 464.89 MiB) # master
```
