### PR TITLE
Simplify and speedup shape_gradient_and_value for embedded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.14"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -35,7 +36,6 @@ WriteVTK = "1.13"
 julia = "1.6"
 
 [extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FerriteGmsh = "4f95f4f8-b27c-4ae5-9a39-ea55e634e36b"
@@ -45,6 +45,7 @@ IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -429,7 +429,7 @@ uuid = "29a986be-02c6-4525-aec4-84b980013641"
 version = "2.0.0"
 
 [[deps.Ferrite]]
-deps = ["EnumX", "LinearAlgebra", "NearestNeighbors", "OrderedCollections", "Preferences", "Reexport", "SparseArrays", "StaticArrays", "Tensors", "WriteVTK"]
+deps = ["EnumX", "ForwardDiff", "LinearAlgebra", "NearestNeighbors", "OrderedCollections", "Preferences", "Reexport", "SparseArrays", "StaticArrays", "Tensors", "WriteVTK"]
 path = ".."
 uuid = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
 version = "0.3.14"

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -23,6 +23,8 @@ using WriteVTK:
 using Tensors:
     Tensors, AbstractTensor, SecondOrderTensor, SymmetricTensor, Tensor, Vec, gradient,
     rotation_tensor, symmetric, tovoigt!
+using ForwardDiff:
+    ForwardDiff
 
 
 include("exports.jl")

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1526,8 +1526,8 @@ end
 function shape_gradient_and_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
     tosvec(v::Vec) = SVector((v...,))
     tovec(sv::SVector) = Vec((sv...))
-    val = Ferrite.shape_value(ipv, ξ, I)
-    grad = ForwardDiff.jacobian(sv -> tosvec(Ferrite.shape_value(ipv, tovec(sv), I)), tosvec(ξ))
+    val = shape_value(ipv, ξ, I)
+    grad = ForwardDiff.jacobian(sv -> tosvec(shape_value(ipv, tovec(sv), I)), tosvec(ξ))
     return grad, val
 end
 


### PR DESCRIPTION
Noticed this when reviewing #938 

```julia
ip = Lagrange{RefQuadrilateral,1}()^3; ξ = rand(Vec{2});
@btime Ferrite.shape_gradient_and_value($ip, $ξ, 1);
# PR:     15.030 ns (0 allocations: 0 bytes)
# master: 26.459 ns (1 allocation: 64 bytes)
```
