### PR TITLE
Rename default_interpolation -> geometric_interpolation

### DIFF
--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -14,7 +14,7 @@ for spatial_dim ∈ 1:3
 
         grid = generate_grid(geo_type, tuple(repeat([2], spatial_dim)...));
         topology = ExclusiveTopology(grid)
-        ip_geo = Ferrite.default_interpolation(geo_type)
+        ip_geo = Ferrite.geometric_interpolation(geo_type)
         ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
 
         # Nodal interpolation tests

--- a/benchmark/benchmarks-boundary-conditions.jl
+++ b/benchmark/benchmarks-boundary-conditions.jl
@@ -13,7 +13,7 @@ for spatial_dim ∈ [2]
     geo_type = Quadrilateral
     grid = generate_grid(geo_type, ntuple(x->2, spatial_dim));
     ref_type = FerriteBenchmarkHelper.getrefshape(geo_type)
-    ip_geo = Ferrite.default_interpolation(geo_type)
+    ip_geo = Ferrite.geometric_interpolation(geo_type)
     order = 2
 
     # assemble a mass matrix to apply BCs on (because its cheap)

--- a/docs/src/devdocs/elements.md
+++ b/docs/src/devdocs/elements.md
@@ -13,7 +13,7 @@ Ferrite.vertices(::Ferrite.AbstractCell)
 Ferrite.edges(::Ferrite.AbstractCell)
 Ferrite.reference_faces(::Ferrite.AbstractRefShape)
 Ferrite.faces(::Ferrite.AbstractCell)
-Ferrite.default_interpolation(::Ferrite.AbstractCell)
+Ferrite.geometric_interpolation(::Ferrite.AbstractCell)
 ```
 
 ### Common utilities and definitions when working with grids internally.

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -337,7 +337,7 @@ end
 
 function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcnodes::AbstractVecOrSet{Int}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, cellset::AbstractVecOrSet{Int}=OrderedSet{Int}(1:getncells(get_grid(ch.dh))))
     grid = get_grid(ch.dh)
-    if interpolation !== default_interpolation(getcelltype(grid, first(cellset)))
+    if interpolation !== geometric_interpolation(getcelltype(grid, first(cellset)))
         @warn("adding constraint to nodeset is not recommended for sub/super-parametric approximations.")
     end
 
@@ -834,7 +834,7 @@ function add!(ch::ConstraintHandler, dbc::Dirichlet)
             EntityType = FacetIndex
         end
         CT = getcelltype(sdh) # Same celltype enforced in SubDofHandler constructor
-        bcvalues = BCValues(interpolation, default_interpolation(CT), EntityType)
+        bcvalues = BCValues(interpolation, geometric_interpolation(CT), EntityType)
         # Recreate the Dirichlet(...) struct with the filtered set and call internal add!
         filtered_dbc = Dirichlet(dbc.field_name, filtered_set, dbc.f, components)
         _add!(

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -948,7 +948,7 @@ function _evaluate_at_grid_nodes(dh::DofHandler, u::Vector{T}, fieldname::Symbol
         # Set up CellValues with the local node coords as quadrature points
         CT = getcelltype(sdh)
         ip = getfieldinterpolation(sdh, field_idx)
-        ip_geo = default_interpolation(CT)
+        ip_geo = geometric_interpolation(CT)
         local_node_coords = reference_coordinates(ip_geo)
         qr = QuadratureRule{getrefshape(ip)}(zeros(length(local_node_coords)), local_node_coords)
         if ip isa VectorizedInterpolation

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -1,7 +1,7 @@
-function _default_interpolations(dh::DofHandler)
+function _geometric_interpolations(dh::DofHandler)
     sdhs = dh.subdofhandlers
     getcelltype(i) = typeof(getcells(get_grid(dh), first(sdhs[i].cellset)))
-    ntuple(i -> default_interpolation(getcelltype(i)), length(sdhs))
+    ntuple(i -> geometric_interpolation(getcelltype(i)), length(sdhs))
 end
 
 """
@@ -30,7 +30,7 @@ function apply_analytical!(
     cellset = 1:getncells(get_grid(dh)))
 
     fieldname ∉ getfieldnames(dh) && error("The fieldname $fieldname was not found in the dof handler")
-    ip_geos = _default_interpolations(dh)
+    ip_geos = _geometric_interpolations(dh)
 
     for (sdh, ip_geo) in zip(dh.subdofhandlers, ip_geos)
         isnothing(_find_field(sdh, fieldname)) && continue

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -132,11 +132,11 @@ reference_facets(::Type{<:AbstractRefShape})
 @inline reference_facets(refshape::Type{<:AbstractRefShape{3}}) = reference_faces(refshape)
 
 """
-    Ferrite.default_interpolation(::AbstractCell)::Interpolation
+    Ferrite.geometric_interpolation(::AbstractCell)::Interpolation
 
 Returns the interpolation which defines the geometry of a given cell.
 """
-default_interpolation(::AbstractCell)
+geometric_interpolation(::AbstractCell)
 
 """
     Ferrite.get_node_ids(c::AbstractCell)
@@ -240,25 +240,25 @@ struct QuadraticHexahedron    <: AbstractCell{RefHexahedron}    nodes::NTuple{27
 struct Wedge                  <: AbstractCell{RefPrism}         nodes::NTuple{ 6, Int} end
 struct Pyramid                <: AbstractCell{RefPyramid}       nodes::NTuple{ 5, Int} end
 
-default_interpolation(::Type{Line})                   = Lagrange{RefLine,          1}()
-default_interpolation(::Type{QuadraticLine})          = Lagrange{RefLine,          2}()
-default_interpolation(::Type{Triangle})               = Lagrange{RefTriangle,      1}()
-default_interpolation(::Type{QuadraticTriangle})      = Lagrange{RefTriangle,      2}()
-default_interpolation(::Type{Quadrilateral})          = Lagrange{RefQuadrilateral, 1}()
-default_interpolation(::Type{QuadraticQuadrilateral}) = Lagrange{RefQuadrilateral, 2}()
-default_interpolation(::Type{Tetrahedron})            = Lagrange{RefTetrahedron,   1}()
-default_interpolation(::Type{QuadraticTetrahedron})   = Lagrange{RefTetrahedron,   2}()
-default_interpolation(::Type{Hexahedron})             = Lagrange{RefHexahedron,    1}()
-default_interpolation(::Type{QuadraticHexahedron})    = Lagrange{RefHexahedron,    2}()
-default_interpolation(::Type{Wedge})                  = Lagrange{RefPrism,         1}()
-default_interpolation(::Type{Pyramid})                = Lagrange{RefPyramid,       1}()
+geometric_interpolation(::Type{Line})                   = Lagrange{RefLine,          1}()
+geometric_interpolation(::Type{QuadraticLine})          = Lagrange{RefLine,          2}()
+geometric_interpolation(::Type{Triangle})               = Lagrange{RefTriangle,      1}()
+geometric_interpolation(::Type{QuadraticTriangle})      = Lagrange{RefTriangle,      2}()
+geometric_interpolation(::Type{Quadrilateral})          = Lagrange{RefQuadrilateral, 1}()
+geometric_interpolation(::Type{QuadraticQuadrilateral}) = Lagrange{RefQuadrilateral, 2}()
+geometric_interpolation(::Type{Tetrahedron})            = Lagrange{RefTetrahedron,   1}()
+geometric_interpolation(::Type{QuadraticTetrahedron})   = Lagrange{RefTetrahedron,   2}()
+geometric_interpolation(::Type{Hexahedron})             = Lagrange{RefHexahedron,    1}()
+geometric_interpolation(::Type{QuadraticHexahedron})    = Lagrange{RefHexahedron,    2}()
+geometric_interpolation(::Type{Wedge})                  = Lagrange{RefPrism,         1}()
+geometric_interpolation(::Type{Pyramid})                = Lagrange{RefPyramid,       1}()
 
 # Serendipity interpolation based cells
 struct SerendipityQuadraticQuadrilateral <: AbstractCell{RefQuadrilateral} nodes::NTuple{ 8, Int} end
 struct SerendipityQuadraticHexahedron    <: AbstractCell{RefHexahedron}    nodes::NTuple{20, Int} end
 
-default_interpolation(::Type{SerendipityQuadraticQuadrilateral}) = Serendipity{RefQuadrilateral, 2}()
-default_interpolation(::Type{SerendipityQuadraticHexahedron})    = Serendipity{RefHexahedron,    2}()
+geometric_interpolation(::Type{SerendipityQuadraticQuadrilateral}) = Serendipity{RefQuadrilateral, 2}()
+geometric_interpolation(::Type{SerendipityQuadraticHexahedron})    = Serendipity{RefHexahedron,    2}()
 
 """
     nvertices_on_face(cell::AbstractCell, local_face_index::Int)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -132,9 +132,10 @@ reference_facets(::Type{<:AbstractRefShape})
 @inline reference_facets(refshape::Type{<:AbstractRefShape{3}}) = reference_faces(refshape)
 
 """
-    geometric_interpolation(cell::AbstractCell)::Interpolation
+    geometric_interpolation(::AbstractCell)::Interpolation
 
-Returns the interpolation defining the geometry of the `cell`.
+Each `AbstractCell` type has a unique geometric interpolation describing its geometry.
+This function returns that interpolation.
 """
 geometric_interpolation(::AbstractCell)
 

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -132,9 +132,9 @@ reference_facets(::Type{<:AbstractRefShape})
 @inline reference_facets(refshape::Type{<:AbstractRefShape{3}}) = reference_faces(refshape)
 
 """
-    Ferrite.geometric_interpolation(::AbstractCell)::Interpolation
+    geometric_interpolation(cell::AbstractCell)::Interpolation
 
-Returns the interpolation which defines the geometry of a given cell.
+Returns the interpolation defining the geometry of the `cell`.
 """
 geometric_interpolation(::AbstractCell)
 

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -37,7 +37,7 @@ function L2Projector(
         grid::AbstractGrid;
         qr_lhs::QuadratureRule = _mass_qr(func_ip),
         set = OrderedSet(1:getncells(grid)),
-        geom_ip::Interpolation = default_interpolation(getcelltype(grid, first(set))),
+        geom_ip::Interpolation = geometric_interpolation(getcelltype(grid, first(set))),
     )
 
     # TODO: Maybe this should not be allowed? We always assume to project scalar entries.

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -63,7 +63,7 @@ function _get_cellcoords(points::AbstractVector{Vec{dim,T}}, grid::AbstractGrid,
     for point_idx in 1:length(points)
         cell_found = false
         for (CT, node_cell_dict) in node_cell_dicts
-            geom_interpol = default_interpolation(CT)
+            geom_interpol = geometric_interpolation(CT)
             # loop over points
             for node in nearest_nodes[point_idx]
                 possible_cells = get(node_cell_dict, node, nothing)
@@ -219,7 +219,7 @@ function evaluate_at_points!(out_vals::Vector{T2},
         if ip !== nothing
             dofrange = dof_range(sdh, fname)
             cellset = sdh.cellset
-            ip_geo = default_interpolation(getcelltype(sdh))
+            ip_geo = geometric_interpolation(getcelltype(sdh))
             pv = PointValues(T_ph, ip, ip_geo; update_gradients = false)
             _evaluate_at_points!(out_vals, dof_vals, ph, dh, pv, cellset, dofrange)
         end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -372,3 +372,8 @@ end
 
 getdim(args...) = error("`Ferrite.getdim` is deprecated, use `getrefdim` or `getspatialdim` instead")
 getfielddim(args...) = error("`Ferrite.getfielddim(::AbstractDofHandler, args...) is deprecated, use `n_components` instead")
+
+function default_interpolation(cell::AbstractCell)
+    @warn "Ferrite.default_interpolation is deprecated, use the exported `geometric_interpolation` instead" maxlog=1
+    return geometric_interpolation(cell)
+end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -82,7 +82,7 @@ function add!(dh::DofHandler, name::Symbol, dim::Int)
         "fields. See CHANGELOG for more details.",
         :add!,
     )
-    ip = default_interpolation(celltype)
+    ip = geometric_interpolation(celltype)
     add!(dh, name, dim == 1 ? ip : VectorizedInterpolation{dim}(ip))
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -75,6 +75,7 @@ export
     EdgeIndex,
     VertexIndex,
     FacetIndex,
+    geometric_interpolation,
     ExclusiveTopology,
     getneighborhood,
     faceskeleton,

--- a/test/integration/test_simple_scalar_convergence.jl
+++ b/test/integration/test_simple_scalar_convergence.jl
@@ -1,5 +1,5 @@
 using Ferrite, Test
-import Ferrite: getrefdim, default_interpolation
+import Ferrite: getrefdim, geometric_interpolation
 
 module ConvergenceTestHelper
 
@@ -158,7 +158,7 @@ end # module ConvergenceTestHelper
     )
         # Generate a grid ...
         geometry = ConvergenceTestHelper.get_geometry(interpolation)
-        interpolation_geo = default_interpolation(geometry)
+        interpolation_geo = geometric_interpolation(geometry)
         N = ConvergenceTestHelper.get_num_elements(interpolation)
         grid = generate_grid(geometry, ntuple(x->N, getrefdim(geometry)));
         # ... a suitable quadrature rule ...
@@ -187,7 +187,7 @@ end
     )
         # Generate a grid ...
         geometry = ConvergenceTestHelper.get_geometry(interpolation)
-        interpolation_geo = default_interpolation(geometry)
+        interpolation_geo = geometric_interpolation(geometry)
         # "Coarse case"
         N₁ = ConvergenceTestHelper.get_num_elements(interpolation)
         grid = generate_grid(geometry, ntuple(x->N₁, getrefdim(geometry)));

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -9,7 +9,7 @@
         RefShape = Ferrite.getrefshape(ip)
         return B{RefShape,order}()
     end
-    getcellorder(CT) = Ferrite.getorder(Ferrite.default_interpolation(CT))
+    getcellorder(CT) = Ferrite.getorder(Ferrite.geometric_interpolation(CT))
     getcelltypedim(::Type{<:Ferrite.AbstractCell{shape}}) where {dim, shape <: Ferrite.AbstractRefShape{dim}} = dim
 
     # Functions to create dof handlers for testing
@@ -24,7 +24,7 @@
         end
 
         dh = DofHandler(grid)
-        default_ip = Ferrite.default_interpolation(CT)
+        default_ip = Ferrite.geometric_interpolation(CT)
         try
             add!(dh, :u, change_ip_order(default_ip, ip_order_u)^dim)
             add!(dh, :p, change_ip_order(default_ip, ip_order_p))
@@ -51,8 +51,8 @@
         else
             error("Only dim=1 & 2 supported")
         end
-        default_ip_A = Ferrite.default_interpolation(getcelltype(grid, first(getcellset(grid,"A"))))
-        default_ip_B = Ferrite.default_interpolation(getcelltype(grid, first(getcellset(grid,"B"))))
+        default_ip_A = Ferrite.geometric_interpolation(getcelltype(grid, first(getcellset(grid,"A"))))
+        default_ip_B = Ferrite.geometric_interpolation(getcelltype(grid, first(getcellset(grid,"B"))))
         dh = DofHandler(grid)
         sdh_A = SubDofHandler(dh, getcellset(grid, "A"))
         add!(sdh_A, :u, change_ip_order(default_ip_A, ip_order_u)^dim)

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -56,7 +56,7 @@ end
         # Create a DofHandler, add some things, write to file and
         # then check the resulting sha
         dofhandler = DofHandler(grid)
-        ip = Ferrite.default_interpolation(celltype)
+        ip = Ferrite.geometric_interpolation(celltype)
         add!(dofhandler, :temperature, ip)
         add!(dofhandler, :displacement, ip^dim)
         close!(dofhandler)

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -135,7 +135,7 @@
             cell = getcells(grid, 1)
             geom_ip_facets_indices = Ferrite.facetdof_indices(ip)
             Ferrite.getrefdim(ip) > 1 && (geom_ip_facets_indices = Tuple([facet[collect(facet .∉ Ref(interior))] for (facet, interior) in [(geom_ip_facets_indices[i], Ferrite.facetdof_interior_indices(ip)[i]) for i in 1:Ferrite.nfacets(ip)]]))
-            facets_indices = Ferrite.reference_facets(Ferrite.getrefshape(Ferrite.default_interpolation(typeof(cell))))
+            facets_indices = Ferrite.reference_facets(Ferrite.getrefshape(Ferrite.geometric_interpolation(typeof(cell))))
             node_ids = Ferrite.get_node_ids(cell)
             cellfacets = Ferrite.facets(cell)
             @test getindex.(Ref(node_ids), collect.(facets_indices)) == cellfacets == getindex.(Ref(node_ids), collect.(geom_ip_facets_indices))
@@ -169,7 +169,7 @@
             cell = getcells(grid, 1)
             geom_ip_facets_indices = Ferrite.facetdof_indices(ip)
             Ferrite.getrefdim(ip) > 1 && (geom_ip_facets_indices = Tuple([facet[collect(facet .∉ Ref(interior))] for (facet, interior) in [(geom_ip_facets_indices[i], Ferrite.facedof_interior_indices(ip)[i]) for i in 1:Ferrite.nfaces(ip)]]))
-            facets_indices = Ferrite.reference_facets(Ferrite.getrefshape(Ferrite.default_interpolation(typeof(cell))))
+            facets_indices = Ferrite.reference_facets(Ferrite.getrefshape(Ferrite.geometric_interpolation(typeof(cell))))
             node_ids = Ferrite.get_node_ids(cell)
             @test getindex.(Ref(node_ids), collect.(facets_indices)) == Ferrite.faces(cell) == getindex.(Ref(node_ids), collect.(geom_ip_facets_indices))
         end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -521,7 +521,7 @@ end
 
 function test_celliterator_subdomain()
     for celltype in (Line, Quadrilateral, Hexahedron)
-        ip = Ferrite.default_interpolation(celltype)
+        ip = Ferrite.geometric_interpolation(celltype)
         dim = Ferrite.getrefdim(ip)
         grid = generate_grid(celltype, ntuple(i->i==1 ? 2 : 1, dim)) # 2 cells
         dh = DofHandler(grid)


### PR DESCRIPTION
Ref discussion in #950 

* Exports and documents `geometric_interpolation`
* "soft"-deprecates `default_interpolation` with single warning per session
* Clarifies docstring: Each cell has a unique geometric interpolation, and `geometric_interpolation` returns this. 

Note that `geometric_interpolation(::AbstractValues)` also exists, but this also returns the geometric interpolation, so I think this is fine. 

03039fe263cc7505fc5b50e8af04347844f19c3c contains the pure rename, other fine-tunings etc in remaining commits in case we should add this to git-blame ignored commits, @fredrikekre 
