### PR TITLE
Fix apply_analytical for subdomains

### DIFF
--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -43,6 +43,7 @@ function apply_analytical!(
         else
             intersect(BitSet(sdh.cellset), BitSet(cellset))
         end
+        isempty(set_intersection) && continue
         _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)
     end
     return a

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -145,6 +145,12 @@
                     f(x) = ones(Vec{dim})
                     apply_analytical!(a, dh, :u, f)
                     @test sum(a)/length(a) ≈ num_udofs/(num_udofs+num_pdofs)
+
+                    # Repeat test with calls for both subdomains separately
+                    a = zeros(ndofs(dh))
+                    apply_analytical!(a, dh, :u, f, getcellset(dh.grid, "A"))
+                    apply_analytical!(a, dh, :u, f, getcellset(dh.grid, "B"))
+                    @test sum(a)/length(a) ≈ num_udofs/(num_udofs+num_pdofs)
                 end
             end
         end


### PR DESCRIPTION
Fixed an issue when using a cell set with an empty intersection with the cells of a `SubDofHandler`
Also added tests to cover this case.