### PR TITLE
use concrete types in `MaterialState` in topology example

### DIFF
--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -144,13 +144,13 @@ end
 # `MaterialState`. We add a constructor to initialize the struct. The function `update_material_states!`
 # updates the density values once we calculated the new values.
 
-mutable struct MaterialState{T, S <: AbstractArray{SymmetricTensor{2, 2, T}, 1}}
+mutable struct MaterialState{T, S <: AbstractArray{SymmetricTensor{2, 2, T, 3}, 1}}
     χ::T # density
     ε::S # strain in each quadrature point
 end
 
 function MaterialState(ρ, n_qp)
-    return MaterialState(ρ, Array{SymmetricTensor{2,2,Float64},1}(undef, n_qp))
+    return MaterialState(ρ, Array{SymmetricTensor{2,2,Float64,3},1}(undef, n_qp))
 end
 
 function update_material_states!(χn1, states, dh)
@@ -339,7 +339,6 @@ function elmt!(Ke, re, element, cellvalues, facetvalues, grid, mp, ue, state)
 
         for i in 1:n_basefuncs
             δεi = shape_symmetric_gradient(cellvalues, q_point, i)
-            δu = shape_value(cellvalues, q_point, i)
             for j in 1:i
                 δεj = shape_symmetric_gradient(cellvalues, q_point, j)
                 Ke[i,j] += (χ)^(mp.p) * (δεi ⊡ mp.C ⊡ δεj) * dΩ


### PR DESCRIPTION

```julia
julia> @time topopt(0.03, 0.5, 60, "large_radius"; output=:false);
# before
#  10.199698 seconds (419.33 M allocations: 19.371 GiB, 23.67% gc time, 0.05% compilation time)
# after
#  6.227020 seconds (170.44 M allocations: 12.847 GiB, 14.20% gc time)
```