### PR TITLE
cache neighborhood information in topology example

### DIFF
--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -185,19 +185,19 @@ function compute_densities(states, dh)
 end
 #md nothing # hide
 
-# Now we calculate the Laplacian. For this purpose, we will later create the grid topology of
-# the grid by using the function `ExclusiveTopology`. Then we iterate through each face of each element,
+# For the Laplacian we need some neighboorhood information which is constant throughout the analysis so we compute it once and cache it.
+# We iterate through each face of each element,
 # obtaining the neighboring element by using the `getneighborhood` function. For boundary faces,
 # the function call will return an empty object. In that case we use the dictionary to instead find the opposite
-# face, as discussed in the introduction. Then, the approximation of the Laplacian reduces to the sum below.
+# face, as discussed in the introduction.
 
-function approximate_laplacian(dh, topology, χn, Δh)
-    ∇²χ = zeros(getncells(dh.grid))
+function cache_neighborhood(dh, topology)
+    nbgs = Vector{Vector{Int}}(undef, getncells(dh.grid))
     _nfacets = nfacets(dh.grid.cells[1])
     opp = Dict(1=>3, 2=>4, 3=>1, 4=>2)
-    nbg = zeros(Int,_nfacets)
 
     for element in CellIterator(dh)
+        nbg = zeros(Int,_nfacets)
         i = cellid(element)
         for j in 1:_nfacets
             nbg_cellid = getcells(getneighborhood(topology, dh.grid, FacetIndex(i,j)))
@@ -208,6 +208,18 @@ function approximate_laplacian(dh, topology, χn, Δh)
             end
         end
 
+        nbgs[i] = nbg
+    end
+
+    return nbgs
+end
+#md nothing # hide
+
+# Now we calculate the Laplacian using the previously cached neighboorhood information.
+function approximate_laplacian(nbgs, χn, Δh)
+    ∇²χ = zeros(length(nbgs))
+    for i in 1:length(nbgs)
+        nbg = nbgs[i]
         ∇²χ[i] = (χn[nbg[1]]+χn[nbg[2]]+χn[nbg[3]]+χn[nbg[4]]-4*χn[i])/(Δh^2)
     end
 
@@ -234,7 +246,7 @@ function compute_χn1(χn, Δχ, ρ, ηs, χ_min)
     while(abs(ρ-ρ_trial)>1e-7)
         for i in 1:n_el
             Δχt = 1/ηs * (Δχ[i] - λ_trial)
-            χ_trial[i] = maximum([χ_min, minimum([1.0, χn[i]+Δχt])])
+            χ_trial[i] = max(χ_min, min(1.0, χn[i]+Δχt))
         end
 
         ρ_trial = 0.0
@@ -275,13 +287,13 @@ end
 # Finally, we put everything together to update the density. The loop ensures the stability of the
 # updated solution.
 
-function update_density(dh, states, mp, ρ, topology, Δh)
+function update_density(dh, states, mp, ρ,  neighboorhoods, Δh)
     n_j = Int(ceil(6*mp.β/(mp.η*Δh^2))) # iterations needed for stability
     χn = compute_densities(states, dh) # old density field
     χn1 = zeros(length(χn))
 
     for j in 1:n_j
-        ∇²χ = approximate_laplacian(dh, topology, χn, Δh) # Laplacian
+        ∇²χ = approximate_laplacian(neighboorhoods, χn, Δh) # Laplacian
         pΨ = compute_driving_forces(states, mp, dh, χn) # driving forces
         p_Ω = compute_average_driving_force(mp, pΨ, χn) # average driving force
 
@@ -426,6 +438,7 @@ function topopt(ra,ρ,n,filename; output=:false)
     conv = :false
 
     topology = ExclusiveTopology(grid)
+    neighboorhoods = cache_neighborhood(dh, topology)
 
     ## Newton-Raphson loop
     NEWTON_TOL = 1e-8
@@ -478,7 +491,7 @@ function topopt(ra,ρ,n,filename; output=:false)
         end
 
         ## update density
-        χ = update_density(dh, states, mp, ρ, topology, Δh)
+        χ = update_density(dh, states, mp, ρ, neighboorhoods, Δh)
 
         ## update old displacement, density and compliance
         un .= u
@@ -513,9 +526,9 @@ end
 # complete output with all iteration steps, it is possible to set the output
 # parameter to `true`.
 
-topopt(0.02, 0.5, 60, "small_radius"; output=:false);
-topopt(0.03, 0.5, 60, "large_radius"; output=:false);
-##topopt(0.02, 0.5, 60, "topopt_animation"; output=:true); # can be used to create animations
+# grid, χ =topopt(0.02, 0.5, 60, "small_radius"; output=:false);
+@time topopt(0.03, 0.5, 60, "large_radius"; output=:false);
+#topopt(0.02, 0.5, 60, "topopt_animation"; output=:true); # can be used to create animations
 
 # We observe, that the stiffness for the lower value of $ra$ is higher,
 # but also requires more iterations until convergence and finer structures to be manufactured, as can be seen in Figure 2:

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -144,13 +144,13 @@ end
 # `MaterialState`. We add a constructor to initialize the struct. The function `update_material_states!`
 # updates the density values once we calculated the new values.
 
-mutable struct MaterialState{T, S <: AbstractArray{SymmetricTensor{2, 2, T}, 1}}
+mutable struct MaterialState{T, S <: AbstractArray{SymmetricTensor{2, 2, T, 3}, 1}}
     χ::T # density
     ε::S # strain in each quadrature point
 end
 
 function MaterialState(ρ, n_qp)
-    return MaterialState(ρ, Array{SymmetricTensor{2,2,Float64},1}(undef, n_qp))
+    return MaterialState(ρ, Array{SymmetricTensor{2,2,Float64,3},1}(undef, n_qp))
 end
 
 function update_material_states!(χn1, states, dh)
@@ -339,7 +339,6 @@ function elmt!(Ke, re, element, cellvalues, facetvalues, grid, mp, ue, state)
 
         for i in 1:n_basefuncs
             δεi = shape_symmetric_gradient(cellvalues, q_point, i)
-            δu = shape_value(cellvalues, q_point, i)
             for j in 1:i
                 δεj = shape_symmetric_gradient(cellvalues, q_point, j)
                 Ke[i,j] += (χ)^(mp.p) * (δεi ⊡ mp.C ⊡ δεj) * dΩ


### PR DESCRIPTION
`getneighborhood` is a quite expensive function that allocates quite a bit and it is called a huge number of times in this example. The neighborhood information is the same in every iteration though so it makes sense to cache it. I don't think it makes the example code much uglier and it is probably more instructive.

```julia
@time topopt(0.03, 0.5, 60, "large_radius"; output=:false);
# Before
#  6.227020 seconds (170.44 M allocations: 12.847 GiB, 14.20% gc time)
# After
#  2.443282 seconds (2.40 M allocations: 2.076 GiB, 1.12% gc time)
```

After this the profile look "clean" (assembly + linear solving is dominating) and the GC time is at least not 10+%.