### PR TITLE
WIP: Topologies using CollectionOfVectors

### DIFF
--- a/src/CollectionOfVectors.jl
+++ b/src/CollectionOfVectors.jl
@@ -4,6 +4,9 @@ struct CollectionOfVectors{IT<:Union{AbstractArray{UnitRange{Int}}, AbstractDict
 end
 
 Base.getindex(cv::CollectionOfVectors, index) = view(cv.data, cv.indices[index])
+Base.keys(cv::CollectionOfVectors) = keys(cv.indcies)
+Base.values(cv::CollectionOfVectors) = (view(cv.data, idx) for idx in values(cv.indices))
+nonempty_values(cv::CollectionOfVectors) = (view(cv.data, idx) for idx in values(cv.indices) if !isempty(idx))
 
 # Structure for building this efficiently
 struct AdaptiveRange

--- a/src/CollectionOfVectors.jl
+++ b/src/CollectionOfVectors.jl
@@ -21,9 +21,12 @@ struct ConstructionBuffer{IT, DT}
     sizehint::Int
 end
 
+# Note: Workaround since ndims(Vector) or (Array{T, N} where T) doesn't work on julia 1.6
+_ndims(::Type{<:Array{T, N} where T}) where N = N
+
 function ConstructionBuffer(IT::Type{<:Array}, data::Vector; dims = nothing, sizehint)
     dims === nothing && error("dims must be given when indexed by an $IT")
-    ndims(IT) == length(dims) || error("The number of dims must match IT's number of dimensions")
+    _ndims(IT) == length(dims) || error("The number of dims must match IT's number of dimensions")
 
     indices = fill(AdaptiveRange(0, 0, 0), dims)
     return ConstructionBuffer(indices, data, sizehint)

--- a/src/CollectionOfVectors.jl
+++ b/src/CollectionOfVectors.jl
@@ -1,0 +1,129 @@
+struct CollectionOfVectors{IT<:Union{AbstractArray{UnitRange{Int}}, AbstractDict{<:Any, UnitRange{Int}}}, DT}
+    indices::IT
+    data::Vector{DT}
+end
+
+Base.getindex(cv::CollectionOfVectors, index) = view(cv.data, cv.indices[index])
+
+# Structure for building this efficiently
+struct AdaptiveRange
+    start::Int
+    ncurrent::Int   # These two could be UInt8 or similar in
+    nmax::Int       # many applications, but probably not worth.
+end
+
+struct ConstructionBuffer{IT, DT}
+    indices::IT # eltype = AdaptiveRange
+    data::Vector{DT}
+    sizehint::Int
+end
+
+function ConstructionBuffer(::Type{<:Array}, data::Vector; dims = nothing, sizehint)
+    dims === nothing && error("dims must be given when indexed by an $IT")
+    ndims(IT) == length(dims) || error("The number of dims must match IT's number of dimensions")
+
+    indices = fill(AdaptiveRange(0, 0, 0), dims)
+    return ConstructionBuffer(indices, data, sizehint)
+end
+function ConstructionBuffer(::Type{<:OrderedDict{K}}, data::Vector; sizehint::Int) where K
+    return ConstructionBuffer(OrderedDict{K, AdaptiveRange}(), data, sizehint)
+end
+
+function Base.setindex!(b::ConstructionBuffer{<:Array}, val, indices...)
+    r = getindex(b.indices, indices...)
+    n = length(b.data)
+    if r.start == 0 # Not previously added
+        resize!(b.data, n + b.sizehint)
+        b.data[n+1] = val
+        setindex!(b.indices, AdaptiveRange(n + 1, 1, b.sizehint), indices...)
+    elseif r.ncurrent == r.nmax # We have used up our space, move data to the end of the vector.
+        resize!(b.data, n + r.nmax + sizehint)
+        for i in 1:r.ncurrent
+            b.data[n + i] = b.data[r.start + i - 1]
+        end
+        b.data[n + r.ncurrent + 1] = val
+        b.indices[item] = AdaptiveRange(n + 1, r.ncurrent + 1, r.nmax + sizehint)
+    else # We have space in an already allocated section
+        b.data[r.start + r.ncurrent] = val
+        b.indices[item] = AdaptiveRange(r.start, r.ncurrent + 1, r.nmax)
+    end
+    return b
+end
+
+function Base.setindex!(b::ConstructionBuffer{<:AbstractDict}, val, key)
+    n = length(b.data)
+    added_range = AdaptiveRange(n + 1, 1, b.sizehint)
+    r = get!(b.indices, key) do
+        # Enters only if key is not in b.indices
+        resize!(b.data, n + b.sizehint)
+        b.data[n + 1] = val
+        added_range
+    end
+    r === added_range && return gni # We added `added_range` and can exit
+
+    # Otherwise, `added_range` already exists in `b.indices` and we
+    # need to add more elements to this index.
+
+    if r.ncurrent == r.nmax # Need to move to the end of the vector
+        b.indices[key] = AdaptiveRange(n + 1, r.ncurrent + 1, r.nmax + b.sizehint)
+        resize!(b.data, n + r.nmax + sizehint)
+        for i in 1:r.ncurrent
+            b.data[n + i] = b.data[r.start + i - 1]
+        end
+        b.data[n + r.ncurrent + 1] = val
+    else
+        b.indices[key] = AdaptiveRange(r.start, r.ncurrent + 1, r.nmax)
+        b.data[r.start + r.ncurrent] = val
+    end
+    return b
+end
+
+function compress_data!(data, indices, sorted_iterator, buffer_indices)
+    for (index, r) in enumerate(sorted_iterator)
+        nstop = r.start + r.ncurrent - 1
+        for (iold, inew) in zip(nstop:-1:r.start, n .+ (r.ncurrent:-1:1))
+            @assert inew ≤ iold # To not overwrite
+            data[inew] = data[iold]
+        end
+        indices[index] = (n + 1):(n + r.ncurrent)
+        n += r.ncurrent
+    end
+    resize!(data, n)
+    sizehint!(data, n)      # Free memory
+    empty!(buffer_indices)
+    sizehint!(buffer_indices, 0) # Free memory
+    return data, indices
+end
+
+function CollectionOfVectors(f!::Function, IT, DT; sizehint = nothing, kwargs...)
+    sizehint === nothing && error("Providing sizehint is mandatory")
+    b = ConstructionBuffer(c, DT[]; sizehint, kwargs...)
+    f!(b)
+    return CollectionOfVectors(b)
+end
+
+function CollectionOfVectors(b::ConstructionBuffer{<:Array})
+    I = sortperm(reshape(b.indices, :); by = x -> x.start)
+    sorted_iterator = enumerate(b.indices[idx] for idx in I if b.indices[idx].start != 0)
+    indices = fill(1:0, size(b.indices))
+    compress_data!(data, indices, sorted_iterator, b.indices)
+    return CollectionOfVectors(indices, data)
+end
+
+
+# Efficient creation of a new OrderedDict with new types of values
+function _withnewvalues(d::OrderedDict{K}, vals::Vector{V}) where {K, V}
+    if d.ndel > 0
+        OrderedCollections.rehash!(d)
+    end
+    @assert d.ndel == 0
+    length(d.vals) == length(vals) || error("Length of new vals must match old")
+    OrderedDict{K,V}(copy(d.slots), copy(d.keys), vals, 0, d.maxprobe, false)
+end
+
+function CollectionOfVectors(b::ConstructionBuffer{<:OrderedDict})
+    sort!(b.indices; byvalue=true, by = r -> r.start)
+    indices = _withnewvalues(b.indices, fill(1:0, length(b.indices)))
+    compress_data!(data, indices, b.indices, b.indices)
+    return CollectionOfVectors(indices, data)
+end

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -13,7 +13,7 @@ using LinearAlgebra:
 using NearestNeighbors:
     NearestNeighbors, KDTree, knn
 using OrderedCollections:
-    OrderedSet
+    OrderedSet, OrderedDict
 using SparseArrays:
     SparseArrays, SparseMatrixCSC, nonzeros, nzrange, rowvals, sparse
 using StaticArrays:
@@ -158,5 +158,7 @@ include("PointEvalHandler.jl")
 # Other
 include("deprecations.jl")
 include("docs.jl")
+
+include("grid/topology2.jl")
 
 end # module

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -159,6 +159,6 @@ include("PointEvalHandler.jl")
 include("deprecations.jl")
 include("docs.jl")
 
-include("grid/topology2.jl")
+include("Grid/topology2.jl")
 
 end # module

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -43,6 +43,7 @@ get_coordinate_eltype(::Node{dim,T}) where {dim,T} = T
 # abstract type AbstractCell{refshape <: AbstractRefShape} end
 
 getrefshape(::AbstractCell{refshape}) where refshape = refshape
+getrefshape(::Type{<:AbstractCell{refshape}}) where refshape = refshape
 
 nvertices(c::AbstractCell) = length(vertices(c))
 nedges(   c::AbstractCell) = length(edges(c))

--- a/src/Grid/topology2.jl
+++ b/src/Grid/topology2.jl
@@ -1,0 +1,197 @@
+"Unique representation of a face"
+struct Face
+    vertices::NTuple{3, Int}
+    function Face(vertices::Union{NTuple{3, Int}, NTuple{4, Int}})
+        return new(sortface_fast(vertices))
+    end
+end
+function Face(grid::AbstractGrid, idx::FaceIndex)
+    vertices = faces(getcells(grid, idx[1]))[idx[2]]
+    return Face(vertices)
+end
+
+"Unique representation of an edge"
+struct Edge
+    vertices::NTuple{2, Int}
+    function Edge(vertices::NTuple{2, Int})
+        return new(sortedge_fast(vertices))
+    end
+end
+function Edge(grid::AbstractGrid, idx::EdgeIndex)
+    vertices = edges(getcells(grid, idx[1]))[idx[2]]
+    return Edge(vertices)
+end
+
+# A Vertex uniquely represented by its node number.
+
+Base.hash(x::Union{Face, Edge}, h::UInt) = hash(x.vertices, h)
+Base.isequal(x::E, y::E) where {E <: Union{Face, Edge}} = x.vertices == y.vertices
+
+# Helper to keep track of the current allocated space in `neighbors::Vector`
+# in GlobalNeighborInformation during construction.
+struct AdaptiveRange
+    start::Int
+    ncurrent::Int   # Could be UInt8
+    nmax::Int       # Could be UInt8
+end
+
+struct GlobalNeighborInformation{ET, BI, CT}
+    neighbors::Vector{BI}
+    indices::CT             # ngbs = neighbors[indices[item]], where item is the unique representation of the entity.
+    function GlobalNeighborInformation(neighbors::Vector{VertexIndex}, indices::Vector{UnitRange{Int}})
+        return new{Int, VertexIndex, typeof(indices)}(neighbors, indices)
+    end
+    function GlobalNeighborInformation(neighbors::Vector{BI}, indices::OrderedDict{ET, UnitRange{Int}}) where {BI<:BoundaryIndex, ET}
+        return new{ET, BI, typeof(indices)}(neighbors, indices)
+    end
+end
+
+getneighbors(gni::GlobalNeighborInformation{ET}, idx::ET) where ET = (gni.neighbors[i] for i in gni.indices[idx])
+
+_getsizehint(::AbstractGrid, ::Type{FaceIndex}) = 2
+_getsizehint(::AbstractGrid{dim}, ::Type{EdgeIndex}) where dim = dim^2
+_getsizehint(::AbstractGrid{dim}, ::Type{VertexIndex}) where dim = 2^dim
+
+function GlobalNeighborInformation(grid, IdxType::Type{<:BoundaryIndex}, ::Type{ET}; sizehint=_getsizehint(grid, IdxType)) where {ET<:Union{Edge, Face}}
+    gni = GlobalNeighborInformation(IdxType[], OrderedDict{ET, UnitRange{Int}}())
+    indices_buffer = OrderedDict{ET, AdaptiveRange}()
+    # Fill the information
+    for (cellnr, cell) in enumerate(getcells(grid))
+        for (entitynr, entity_vertices) in enumerate(boundaryfunction(IdxType)(cell))
+            e = ET(entity_vertices)
+            addneighbor!(gni, indices_buffer, e, IdxType(cellnr, entitynr), sizehint)
+        end
+    end
+    # Compress the information by shifting all items in the vector to the beginning, and deleting unused space.
+    compress_data!(gni, indices_buffer)
+    return gni
+end
+
+function GlobalNeighborInformation(grid, IdxType::Type{VertexIndex}, ::Type{Int}; sizehint=_getsizehint(grid, IdxType))
+    indices = Vector{UnitRange{Int}}(undef, getnnodes(grid))
+    gni = GlobalNeighborInformation(IdxType[], indices)
+    indices_buffer = fill(AdaptiveRange(0, 0, 0), getnnodes(grid))
+    # Fill the information
+    for (cellnr, cell) in enumerate(getcells(grid))
+        for (vertexnr, global_vertex) in enumerate(vertices(cell))
+            addneighbor!(gni, indices_buffer, global_vertex, VertexIndex(cellnr, vertexnr), sizehint)
+        end
+    end
+    # Compress the information
+    compress_data!(gni, indices_buffer)
+    return gni
+end
+
+function addneighbor!(gni::GlobalNeighborInformation{ET}, indices_buffer, item::ET, idx::BoundaryIndex, sizehint::Int) where {ET<:Union{Edge, Face}}
+    n = length(gni.neighbors)
+    added_range = AdaptiveRange(n + 1, 1, sizehint)
+    r = get!(indices_buffer, item) do
+        # Enters only if item is not in indices_buffer
+        resize!(gni.neighbors, n + sizehint)
+        gni.neighbors[n+1] = idx
+        added_range
+    end
+    r === added_range && return gni # We added a new unique entity, can exit
+    # Otherwise, we need to add more neighbors to an existing entity:
+
+    if r.ncurrent == r.nmax # Need to move to the end of the vector
+        indices_buffer[item] = AdaptiveRange(n + 1, r.ncurrent + 1, r.nmax + sizehint)
+        resize!(gni.neighbors, n + r.nmax + sizehint)
+        for i in 1:r.ncurrent # TODO: Iterator for AdaptiveRange
+            gni.neighbors[n + i] = gni.neighbors[r.start + i - 1]
+        end
+        gni.neighbors[n + r.ncurrent + 1] = idx
+    else
+        indices_buffer[item] = AdaptiveRange(r.start, r.ncurrent + 1, r.nmax)
+        gni.neighbors[r.start + r.ncurrent] = idx
+    end
+    return gni
+end
+
+function compress_data!(gni::GlobalNeighborInformation{ET}, indices_buffer) where {ET<:Union{Edge, Face}}
+    # indices_buffer values are of type AdaptiveRange and these are not overlapping. Sort by their first value.
+    sort!(indices_buffer; byvalue=true, by = r -> r.start)
+    sizehint!(gni.indices, length(indices_buffer))
+    # NOTE: gni.indices and indices_buffer have the same keys, this could probably be optimized
+    # as rehash etc. is taking some time...
+    n = 0
+    cnt = 1
+    for (entity, r) in indices_buffer
+        nstop = r.start + r.ncurrent - 1
+        for (iold, inew) in zip(nstop:-1:r.start, n .+ (r.ncurrent:-1:1))
+            @assert inew ≤ iold # To not overwrite
+            gni.neighbors[inew] = gni.neighbors[iold]
+        end
+        gni.indices[entity] = (n + 1):(n + r.ncurrent)
+        n += r.ncurrent
+        cnt += 1
+    end
+    empty!(indices_buffer)
+    resize!(gni.neighbors, n)
+    return gni
+end
+
+function addneighbor!(gni::GlobalNeighborInformation{Int}, indices_buffer, item::Int, idx::VertexIndex, sizehint::Int)
+    r = indices_buffer[item]
+    n = length(gni.neighbors)
+    if r.start == 0 # Not previously added
+        resize!(gni.neighbors, n + sizehint)
+        gni.neighbors[n+1] = idx
+        indices_buffer[item] = AdaptiveRange(n + 1, 1, sizehint)
+    elseif r.ncurrent == r.nmax # We have used up our space, move data to the end of the vector.
+        resize!(gni.neighbors, n + r.nmax + sizehint)
+        for i in 1:r.ncurrent
+            gni.neighbors[n + i] = gni.neighbors[r.start + i - 1]
+        end
+        gni.neighbors[n + r.ncurrent + 1] = idx
+        indices_buffer[item] = AdaptiveRange(n + 1, r.ncurrent + 1, r.nmax + sizehint)
+    else # We have space in an already allocated section
+        gni.neighbors[r.start + r.ncurrent] = idx
+        indices_buffer[item] = AdaptiveRange(r.start, r.ncurrent + 1, r.nmax)
+    end
+    return gni
+end
+
+function compress_data!(gni::GlobalNeighborInformation{Int}, indices_buffer)
+    # indices_buffer contain AdaptiveRange and these are not overlapping. Sort by their first value.
+    sort!(indices_buffer; by = r -> r.start)
+    n = 0
+    for (entity, r) in enumerate(indices_buffer)
+        r.start == 0 && continue # E.g. a node not being a vertex.
+        nstop = r.start + r.ncurrent - 1
+        for (iold, inew) in zip(nstop:-1:r.start, n .+ (r.ncurrent:-1:1))
+            @assert inew ≤ iold # To not overwrite
+            gni.neighbors[inew] = gni.neighbors[iold]
+        end
+        gni.indices[entity] = (n + 1):(n + r.ncurrent)
+        n += r.ncurrent
+    end
+    empty!(indices_buffer)
+    resize!(gni.neighbors, n)
+    return gni
+end
+
+struct MaterializedTopology <: AbstractTopology
+    faceneighbors::GlobalNeighborInformation{Face, FaceIndex, OrderedDict{Face, UnitRange{Int}}}
+    edgesneighbors::GlobalNeighborInformation{Edge, EdgeIndex, OrderedDict{Edge, UnitRange{Int}}}
+    vertexneighbors::GlobalNeighborInformation{Int, VertexIndex, Vector{UnitRange{Int}}}
+end
+
+function MaterializedTopology(grid::AbstractGrid)
+    return MaterializedTopology(
+        GlobalNeighborInformation(grid,   FaceIndex, Face), #TODO: Skip in 1d and 2d
+        GlobalNeighborInformation(grid,   EdgeIndex, Edge), #TODO: Skip in 1d
+        GlobalNeighborInformation(grid, VertexIndex, Int))
+end
+
+function getneighborhood(top::MaterializedTopology, grid::AbstractGrid, idx::FaceIndex)
+    return getneighbors(top.faceneighbors, Face(grid, idx))
+end
+
+function getneighborhood(top::MaterializedTopology, grid::AbstractGrid, idx::EdgeIndex)
+    return getneighbors(top.edgeneighbors, Edge(grid, idx))
+end
+
+function getneighborhood(top::MaterializedTopology, grid::AbstractGrid, idx::VertexIndex)
+    return getneighbors(top.vertexneighbors, toglobal(grid, idx))
+end

--- a/src/Grid/topology2.jl
+++ b/src/Grid/topology2.jl
@@ -173,7 +173,7 @@ end
 
 struct MaterializedTopology <: AbstractTopology
     faceneighbors::GlobalNeighborInformation{Face, FaceIndex, OrderedDict{Face, UnitRange{Int}}}
-    edgesneighbors::GlobalNeighborInformation{Edge, EdgeIndex, OrderedDict{Edge, UnitRange{Int}}}
+    edgeneighbors::GlobalNeighborInformation{Edge, EdgeIndex, OrderedDict{Edge, UnitRange{Int}}}
     vertexneighbors::GlobalNeighborInformation{Int, VertexIndex, Vector{UnitRange{Int}}}
 end
 

--- a/src/Grid/topology2.jl
+++ b/src/Grid/topology2.jl
@@ -217,3 +217,15 @@ end
 function getneighborhood(top::MaterializedTopology, grid::AbstractGrid, idx::VertexIndex)
     return top.vertexneighbors[toglobal(grid, idx)]
 end
+
+function faceskeleton(top::MaterializedTopology, ::AbstractGrid)
+    return (first(n) for n in nonempty_values(top.faceneighbors))
+end
+
+function edgeskeleton(top::MaterializedTopology, ::AbstractGrid)
+    return (first(n) for n in nonempty_values(top.edgeneighbors))
+end
+
+function vertexskeleton(top::MaterializedTopology, ::AbstractGrid)
+    return (first(n) for n in nonempty_values(top.vertexneighbors))
+end

--- a/test/CollectionOfVectors.jl
+++ b/test/CollectionOfVectors.jl
@@ -1,0 +1,22 @@
+using Test
+
+getview(vals, inds::Ferrite.AdaptiveRange) = view(vals, inds.start:(inds.start + inds.ncurrent - 1))
+
+@testset "CompareWithExclusiveTop" begin
+    for CT in (Line, Quadrilateral, Tetrahedron)
+        @testset "$CT" begin
+            grid = generate_grid(CT, ntuple(Returns(3), Ferrite.getrefdim(CT)))
+            top = ExclusiveTopology(grid)
+            top2 = Ferrite.ExclusiveTopology2(grid)
+            for field in (:vertex_to_cell, :cell_neighbor, :face_face_neighbor, :edge_edge_neighbor, :vertex_vertex_neighbor)
+                @testset "$field" begin
+                    nbh = getproperty(top, field)
+                    nbh2 = getproperty(top2, field)
+                    for idx in eachindex(nbh)
+                        @test Set(nbh[idx]) == Set(nbh2[idx])
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/CollectionOfVectors.jl
+++ b/test/CollectionOfVectors.jl
@@ -5,7 +5,7 @@ getview(vals, inds::Ferrite.AdaptiveRange) = view(vals, inds.start:(inds.start +
 @testset "CompareWithExclusiveTop" begin
     for CT in (Line, Quadrilateral, Tetrahedron)
         @testset "$CT" begin
-            grid = generate_grid(CT, ntuple(Returns(3), Ferrite.getrefdim(CT)))
+            grid = generate_grid(CT, ntuple(i -> 3, Ferrite.getrefdim(CT)))
             top = ExclusiveTopology(grid)
             top2 = Ferrite.ExclusiveTopology2(grid)
             for field in (:vertex_to_cell, :cell_neighbor, :face_face_neighbor, :edge_edge_neighbor, :vertex_vertex_neighbor)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
 include("test_utils.jl")
 
 # Unit tests
+include("CollectionOfVectors.jl") # TODO: temp: Move to topology testing and extend testing
 include("test_interpolations.jl")
 include("test_cellvalues.jl")
 include("test_facevalues.jl")


### PR DESCRIPTION
Introduces the type `CollectionOfVectors` which basically allows you to either indexing via a hash like for an `OrderedDict` or with `Int`s or `CartesianIndex` into an `Array` of predefined size, to get data stored in a linear Vector as a view. Each entry can have different lengths.

Then use this to create topologies, for now demonstrated by the following topologies
* `ExclusiveTopology2`: Same as `ExclusiveTopology`, but storage by `CollectionOfVectors` to reduce the number of small vectors 
* `CoverTopology`: Same as `CoverTopology` in `FerriteDistributed` (not tested, but just to check that reuse is possible)
* `EntityTopology`: Another test where the instances `BoundaryIndex`es of a unique entity is indexed by looking up the unique entity, e.g. by indexing with the tuple `sortface_fast`.

(Not all methods implemented yet, but that should be relatively straight forward)

Timing showing stable construction time 

```julia
grid = generate_grid(Hexahedron, (80, 80, 80));

# ExclusiveTopology2 (pr)
@time Ferrite.ExclusiveTopology2(grid);
# 4.298167 seconds (940.02 k allocations: 2.392 GiB, 10.48% gc time, 15.64% compilation time)
@time Ferrite.ExclusiveTopology2(grid);
# 3.457271 seconds (114 allocations: 2.330 GiB, 7.15% gc time)
@time Ferrite.ExclusiveTopology2(grid);
# 3.385843 seconds (114 allocations: 2.330 GiB, 5.49% gc time)
@time Ferrite.ExclusiveTopology2(grid);
# 3.441457 seconds (114 allocations: 2.330 GiB, 5.87% gc time)

# ExclusiveTopology (master)
@time Ferrite.ExclusiveTopology(grid);
# 8.255457 seconds (33.44 M allocations: 3.703 GiB, 51.47% gc time, 3.15% compilation time)
@time Ferrite.ExclusiveTopology(grid);
# 11.470123 seconds (33.02 M allocations: 3.675 GiB, 66.44% gc time)
@time Ferrite.ExclusiveTopology(grid);
# 23.333075 seconds (33.02 M allocations: 3.675 GiB, 81.44% gc time)
```

<details> <summary> Difference from ArrayOfArrays </summary> 

The difference from `ArrayOfArrays.VectorOfArrays` is that the content is always an `AbstractVector` (specifically a `view(::Vector{Float64}, ::UnitRange{Int})`), but the outer type can act as a `Vector`, `Matrix`, `Array`, or `OrderedDict` allowing different indexing.
</details>

<details> <summary> Old notes </summary> 

While following the discussion on Slack today, I played around with this idea which doesn't allocate many small vectors. It also uses the unique representations of entities to get the indices.

It is also a bit fast on construction, but slower in usage since it uses hashes to lookup. But the main point is that has much fewer allocations, and `ExclusiveTopology` brings my computer to a halt due to when creating it twice for a large grid...
```julia
julia> grid = generate_grid(Hexahedron, (100,100,100));

julia> @time Ferrite.MaterializedTopology(grid);
  6.347230 seconds (1.31 M allocations: 1.912 GiB, 8.60% gc time, 15.09% compilation time)

julia> @time Ferrite.MaterializedTopology(grid);
  5.112349 seconds (302 allocations: 1.827 GiB, 4.45% gc time)

julia> @time Ferrite.MaterializedTopology(grid);
  5.114099 seconds (302 allocations: 1.827 GiB, 4.57% gc time)

julia> @time ExclusiveTopology(grid);
 17.979864 seconds (65.02 M allocations: 7.223 GiB, 51.87% gc time, 1.43% compilation time)

julia> @time ExclusiveTopology(grid);
214.620891 seconds (64.58 M allocations: 7.195 GiB, 75.27% gc time)
```

`ExclusiveTopology2` and `CoverTopology` have similar time for construction. 

</details> 

xrefs: https://github.com/Ferrite-FEM/Ferrite.jl/discussions/827
