### PR TITLE
Iterate only over cells in subdomain of dof handler

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -254,20 +254,30 @@ struct CellIterator{CC<:CellCache, IC<:IntegerCollection}
     set::IC
 end
 
-function CellIterator(gridordh::Union{Grid,DofHandler},
+function CellIterator(grid::Grid,
                       set::Union{IntegerCollection,Nothing}=nothing,
                       flags::UpdateFlags=UpdateFlags())
     if set === nothing
-        grid = gridordh isa DofHandler ? get_grid(gridordh) : gridordh
         set = 1:getncells(grid)
     end
-    if gridordh isa DofHandler
-        # TODO: Since the CellCache is resizeable this is not really necessary to check
-        #       here, but might be useful to catch slow code paths?
-        _check_same_celltype(get_grid(gridordh), set)
-    end
-    return CellIterator(CellCache(gridordh, flags), set)
+
+    return CellIterator(CellCache(grid, flags), set)
 end
+
+function CellIterator(dh::DofHandler,
+                      set::Union{IntegerCollection,Nothing}=nothing,
+                      flags::UpdateFlags=UpdateFlags())
+    if set === nothing
+        set = dh.cellset
+    end
+
+    # TODO: Since the CellCache is resizeable this is not really necessary to check
+    #       here, but might be useful to catch slow code paths?
+    _check_same_celltype(get_grid(dh), set)
+
+    return CellIterator(CellCache(dh, flags), set)
+end
+
 function CellIterator(gridordh::Union{Grid,DofHandler}, flags::UpdateFlags)
     return CellIterator(gridordh, nothing, flags)
 end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -661,11 +661,7 @@ function test_celliterator_on_true_subdomain_smoketest()
     end
 
     for cell in CellIterator(dh)
-        if cellid(cell) <= 3
-            @test length(celldofs(cell)) == getnbasefunctions(ip)
-        else
-            @test length(celldofs(cell)) == 0
-        end
+        @test cellid(cell) in [1,2,3]
     end
 end
 


### PR DESCRIPTION
Possibly resolves #976 on master.

I've added a new field `cellset` to DofHandler that should behave the same as the `cellset` field for SubDofsHandler.
CellIterator now uses this field to determine which cells to iterate over.