### PR TITLE
Type-stable construction of AbstractValues

### DIFF
--- a/docs/src/devdocs/FEValues.md
+++ b/docs/src/devdocs/FEValues.md
@@ -24,6 +24,7 @@ Ferrite.BCValues
 Ferrite.embedding_det
 Ferrite.shape_value_type
 Ferrite.shape_gradient_type
+Ferrite.ValuesUpdateFlags
 ```
 
 ## Custom FEValues

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -17,6 +17,8 @@ values of nodal functions, gradients and divergences of nodal functions etc. in 
 * `update_hessians`: Specifies if the hessians of the shape functions should be updated (default false)
 * `update_detJdV`: Specifies if the volume associated with each quadrature point should be updated (default true)
 
+*Internal: Providing the keyword arguments as `Val(::Bool)` gives type-stable constructor*
+
 **Common methods:**
 
 * [`reinit!`](@ref)
@@ -40,14 +42,14 @@ function default_geometric_interpolation(::Interpolation{shape}) where {dim, sha
     return VectorizedInterpolation{dim}(Lagrange{shape, 1}())
 end
 
-struct CellValues{FV, GM, QR, detT} <: AbstractCellValues
+struct CellValues{FV<:FunctionValues, GM<:GeometryMapping, QR, detT} <: AbstractCellValues
     fun_values::FV # FunctionValues
     geo_mapping::GM # GeometryMapping
     qr::QR         # QuadratureRule
     detJdV::detT   # AbstractVector{<:Number} or Nothing
 end
 function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation,
-        update_flags::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV} = ValuesUpdateFlags{1, required_geo_diff_order(mapping_type(ip_fun), 1), true}()
+        update_flags::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV}
         ) where {T, FunDiffOrder, GeoDiffOrder, DetJdV}
 
     geo_mapping = GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr)

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -17,8 +17,6 @@ values of nodal functions, gradients and divergences of nodal functions etc. in 
 * `update_hessians`: Specifies if the hessians of the shape functions should be updated (default false)
 * `update_detJdV`: Specifies if the volume associated with each quadrature point should be updated (default true)
 
-*Internal: Providing the keyword arguments as `Val(::Bool)` gives type-stable constructor*
-
 **Common methods:**
 
 * [`reinit!`](@ref)

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -40,7 +40,7 @@ function default_geometric_interpolation(::Interpolation{shape}) where {dim, sha
     return VectorizedInterpolation{dim}(Lagrange{shape, 1}())
 end
 
-struct CellValues{FV<:FunctionValues, GM<:GeometryMapping, QR, detT} <: AbstractCellValues
+struct CellValues{FV, GM, QR, detT} <: AbstractCellValues
     fun_values::FV # FunctionValues
     geo_mapping::GM # GeometryMapping
     qr::QR         # QuadratureRule

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -49,8 +49,7 @@ struct CellValues{FV<:FunctionValues, GM<:GeometryMapping, QR, detT} <: Abstract
     detJdV::detT   # AbstractVector{<:Number} or Nothing
 end
 function CellValues(::Type{T}, qr::QuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation,
-        update_flags::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV}
-        ) where {T, FunDiffOrder, GeoDiffOrder, DetJdV}
+        ::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV}) where {T, FunDiffOrder, GeoDiffOrder, DetJdV}
 
     geo_mapping = GeometryMapping{GeoDiffOrder}(T, ip_geo.ip, qr)
     fun_values = FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo)

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -59,12 +59,12 @@ function FacetValues(::Type{T}, fqr::FacetQuadratureRule, ip_fun::Interpolation,
     return FacetValues(fun_values, geo_mapping, fqr, detJdV, normals, ScalarWrapper(1))
 end
 
-FacetValues(qr::FacetQuadratureRule, ip::Interpolation, args...; kwargs...) = FacetValues(Float64, qr, ip, args...; kwargs...)
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation, args...; kwargs...) where T
-    return FacetValues(T, qr, ip, VectorizedInterpolation(ip_geo), args...; kwargs...)
+FacetValues(qr::FacetQuadratureRule, ip::Interpolation, args...) = FacetValues(Float64, qr, ip, args...)
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation, args...) where T
+    return FacetValues(T, qr, ip, VectorizedInterpolation(ip_geo), args...)
 end
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip); kwargs...) where T
-    return FacetValues(T, qr, ip, ip_geo, ValuesUpdateFlags(ip; kwargs...))
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip), args...) where T
+    return FacetValues(T, qr, ip, ip_geo, args...)
 end
 
 function Base.copy(fv::FacetValues)

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -46,8 +46,7 @@ struct FacetValues{FV, GM, FQR, detT, nT, V_FV<:AbstractVector{FV}, V_GM<:Abstra
 end
 
 function FacetValues(::Type{T}, fqr::FacetQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim},
-        update_flags::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder} = ValuesUpdateFlags{1, required_geo_diff_order(mapping_type(ip_fun), 1), true}()
-        ) where {T, sdim, FunDiffOrder, GeoDiffOrder}
+        ::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder}) where {T, sdim, FunDiffOrder, GeoDiffOrder}
 
     # max(GeoDiffOrder, 1) ensures that we get the jacobian needed to calculate the normal.
     geo_mapping = map(qr -> GeometryMapping{max(GeoDiffOrder, 1)}(T, ip_geo.ip, qr), fqr.face_rules)
@@ -59,12 +58,12 @@ function FacetValues(::Type{T}, fqr::FacetQuadratureRule, ip_fun::Interpolation,
     return FacetValues(fun_values, geo_mapping, fqr, detJdV, normals, ScalarWrapper(1))
 end
 
-FacetValues(qr::FacetQuadratureRule, ip::Interpolation, args...) = FacetValues(Float64, qr, ip, args...)
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation, args...) where T
-    return FacetValues(T, qr, ip, VectorizedInterpolation(ip_geo), args...)
+FacetValues(qr::FacetQuadratureRule, ip::Interpolation, args...; kwargs...) = FacetValues(Float64, qr, ip, args...; kwargs...)
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation; kwargs...) where T
+    return FacetValues(T, qr, ip, VectorizedInterpolation(ip_geo); kwargs...)
 end
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip), args...) where T
-    return FacetValues(T, qr, ip, ip_geo, args...)
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip); kwargs...) where T
+    return FacetValues(T, qr, ip, ip_geo, ValuesUpdateFlags(ip; kwargs...))
 end
 
 function Base.copy(fv::FacetValues)

--- a/src/FEValues/PointValues.jl
+++ b/src/FEValues/PointValues.jl
@@ -28,19 +28,25 @@ function PointValues(cv::CellValues)
     T = typeof(getdetJdV(cv, 1))
     ip_fun = function_interpolation(cv)
     ip_geo = geometric_interpolation(cv)
-    update_gradients = function_difforder(cv) == 1
-    return PointValues(T, ip_fun, ip_geo; update_gradients)
+    uf = ValuesUpdateFlags(ip_fun;
+        update_gradients = function_difforder(cv) ≥ 1,
+        update_hessians = function_difforder(cv) ≥ 2,
+        update_detJdV = false)
+
+    return PointValues(T, ip_fun, ip_geo, uf)
 end
-function PointValues(ip::Interpolation, ipg::Interpolation = default_geometric_interpolation(ip); kwargs...)
-    return PointValues(Float64, ip, ipg; kwargs...)
+function PointValues(ip::Interpolation, ipg::Interpolation = default_geometric_interpolation(ip), args...)
+    return PointValues(Float64, ip, ipg, args...)
 end
-function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolation(ip); kwargs...) where {
+
+function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolation(ip),
+    uf::ValuesUpdateFlags = ValuesUpdateFlags{1, required_geo_diff_order(mapping_type(ip), 1), false}()) where {
     T, dim, shape <: AbstractRefShape{dim},
     IP  <: Interpolation{shape},
     GIP <: Interpolation{shape}
 }
     qr = QuadratureRule{shape, T}([one(T)], [zero(Vec{dim, T})])
-    cv = CellValues(T, qr, ip, ipg; update_detJdV = false, kwargs...)
+    cv = CellValues(T, qr, ip, ipg, uf)
     return PointValues{typeof(cv)}(cv)
 end
 

--- a/src/FEValues/PointValues.jl
+++ b/src/FEValues/PointValues.jl
@@ -28,25 +28,20 @@ function PointValues(cv::CellValues)
     T = typeof(getdetJdV(cv, 1))
     ip_fun = function_interpolation(cv)
     ip_geo = geometric_interpolation(cv)
-    uf = ValuesUpdateFlags(ip_fun;
-        update_gradients = function_difforder(cv) ≥ 1,
-        update_hessians = function_difforder(cv) ≥ 2,
-        update_detJdV = false)
-
-    return PointValues(T, ip_fun, ip_geo, uf)
+    update_gradients = Val(function_difforder(cv) ≥ 1)
+    update_hessians  = Val(function_difforder(cv) ≥ 2)
+    return PointValues(T, ip_fun, ip_geo; update_gradients, update_hessians)
 end
-function PointValues(ip::Interpolation, ipg::Interpolation = default_geometric_interpolation(ip), args...)
-    return PointValues(Float64, ip, ipg, args...)
+function PointValues(ip::Interpolation, ipg::Interpolation = default_geometric_interpolation(ip); kwargs...)
+    return PointValues(Float64, ip, ipg; kwargs...)
 end
-
-function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolation(ip),
-    uf::ValuesUpdateFlags = ValuesUpdateFlags{1, required_geo_diff_order(mapping_type(ip), 1), false}()) where {
+function PointValues(::Type{T}, ip::IP, ipg::GIP = default_geometric_interpolation(ip); kwargs...) where {
     T, dim, shape <: AbstractRefShape{dim},
     IP  <: Interpolation{shape},
     GIP <: Interpolation{shape}
 }
     qr = QuadratureRule{shape, T}([one(T)], [zero(Vec{dim, T})])
-    cv = CellValues(T, qr, ip, ipg, uf)
+    cv = CellValues(T, qr, ip, ipg; update_detJdV = Val(false), kwargs...)
     return PointValues{typeof(cv)}(cv)
 end
 

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -25,14 +25,19 @@ end
     ))
 end
 
-struct ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV} end
 """
     ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = true, update_hessians = false, update_detJdV = true)
 
 Creates a singelton type for specifying what parts of the AbstractValues should be updated. Note that this is internal
 API used to get type-stable construction.
 """
-function ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = true, update_hessians = false, update_detJdV = true)
+function ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = Val(true), update_hessians = Val(false), update_detJdV = Val(true))
+    toval(v::Bool) = Val(v)
+    toval(V::Val) = V
+    return ValuesUpdateFlags(ip_fun, toval(update_gradients), toval(update_hessians), toval(update_detJdV))
+end
+function ValuesUpdateFlags(ip_fun::Interpolation, ::Val{update_gradients}, ::Val{update_hessians}, ::Val{update_detJdV}
+        ) where {update_gradients, update_hessians, update_detJdV}
     FunDiffOrder = update_hessians ? 2 : (update_gradients ? 1 : 0)
     GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), update_detJdV)
     return ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, update_detJdV}()

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -25,6 +25,19 @@ end
     ))
 end
 
+struct ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV} end
+"""
+    ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = true, update_hessians = false, update_detJdV = true)
+
+Creates a singelton type for specifying what parts of the AbstractValues should be updated. Note that this is internal
+API used to get type-stable construction.
+"""
+function ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = true, update_hessians = false, update_detJdV = true)
+    FunDiffOrder = update_hessians ? 2 : (update_gradients ? 1 : 0)
+    GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), update_detJdV)
+    return ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, update_detJdV}()
+end
+
 """
     reinit!(cv::CellValues, cell::AbstractCell, x::Vector)
     reinit!(cv::CellValues, x::Vector)

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -26,10 +26,11 @@ end
 end
 
 """
-    ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = true, update_hessians = false, update_detJdV = true)
+    ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = Val(true), update_hessians = Val(false), update_detJdV = Val(true))
 
 Creates a singelton type for specifying what parts of the AbstractValues should be updated. Note that this is internal
-API used to get type-stable construction.
+API used to get type-stable construction. Keyword arguments in `AbstractValues` constructors are forwarded, and the public API
+is passing these as `Bool`, while the `ValuesUpdateFlags` method supports both boolean and `Val(::Bool)` keyword args.
 """
 function ValuesUpdateFlags(ip_fun::Interpolation; update_gradients = Val(true), update_hessians = Val(false), update_detJdV = Val(true))
     toval(v::Bool) = Val(v)

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -118,6 +118,7 @@ include("interpolations.jl")
 include("Quadrature/quadrature.jl")
 
 # FEValues
+struct ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, DetJdV} end # Default constructor in common_values.jl
 include("FEValues/GeometryMapping.jl")
 include("FEValues/FunctionValues.jl")
 include("FEValues/CellValues.jl")

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -185,7 +185,7 @@ function evaluate_at_points(ph::PointEvalHandler{<:Any, dim, T1}, dh::AbstractDo
     npoints = length(ph.cells)
     # Figure out the value type by creating a dummy PointValues
     ip = getfieldinterpolation(dh, find_field(dh, fname))
-    pv = PointValues(T1, ip; update_gradients = false)
+    pv = PointValues(T1, ip, ValuesUpdateFlags(ip; update_gradients = false))
     zero_val = function_value_init(pv, dof_vals)
     # Allocate the output as NaNs
     nanv = convert(typeof(zero_val), NaN * zero_val)
@@ -220,7 +220,8 @@ function evaluate_at_points!(out_vals::Vector{T2},
             dofrange = dof_range(sdh, fname)
             cellset = sdh.cellset
             ip_geo = geometric_interpolation(getcelltype(sdh))
-            pv = PointValues(T_ph, ip, ip_geo; update_gradients = false)
+
+            pv = PointValues(T_ph, ip, ip_geo, ValuesUpdateFlags(ip; update_gradients = false, update_detJdV = false))
             _evaluate_at_points!(out_vals, dof_vals, ph, dh, pv, cellset, dofrange)
         end
     end

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -185,7 +185,7 @@ function evaluate_at_points(ph::PointEvalHandler{<:Any, dim, T1}, dh::AbstractDo
     npoints = length(ph.cells)
     # Figure out the value type by creating a dummy PointValues
     ip = getfieldinterpolation(dh, find_field(dh, fname))
-    pv = PointValues(T1, ip, ValuesUpdateFlags(ip; update_gradients = false))
+    pv = PointValues(T1, ip; update_gradients = Val(false))
     zero_val = function_value_init(pv, dof_vals)
     # Allocate the output as NaNs
     nanv = convert(typeof(zero_val), NaN * zero_val)
@@ -221,7 +221,7 @@ function evaluate_at_points!(out_vals::Vector{T2},
             cellset = sdh.cellset
             ip_geo = geometric_interpolation(getcelltype(sdh))
 
-            pv = PointValues(T_ph, ip, ip_geo, ValuesUpdateFlags(ip; update_gradients = false, update_detJdV = false))
+            pv = PointValues(T_ph, ip, ip_geo; update_gradients = Val(false))
             _evaluate_at_points!(out_vals, dof_vals, ph, dh, pv, cellset, dofrange)
         end
     end

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -22,7 +22,7 @@
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         update_gradients = true
         update_hessians = (DiffOrder==2 && Ferrite.getorder(func_interpol) > 1)
-        cv = CellValues(quad_rule, func_interpol, geom_interpol, Ferrite.ValuesUpdateFlags(func_interpol; update_gradients, update_hessians))
+        cv = CellValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
         if update_gradients && !update_hessians # Check correct and type-stable default constructor
             cv_default = @inferred CellValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(cv) === typeof(cv_default)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -22,7 +22,7 @@
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         update_gradients = true
         update_hessians = (DiffOrder==2 && Ferrite.getorder(func_interpol) > 1)
-        cv = CellValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
+        cv = CellValues(quad_rule, func_interpol, geom_interpol, Ferrite.ValuesUpdateFlags(func_interpol; update_gradients, update_hessians))
         if update_gradients && !update_hessians # Check correct and type-stable default constructor
             cv_default = @inferred CellValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(cv) === typeof(cv_default)

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -26,6 +26,7 @@
         if update_gradients && !update_hessians # Check correct and type-stable default constructor
             cv_default = @inferred CellValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(cv) === typeof(cv_default)
+            @inferred CellValues(quad_rule, func_interpol, geom_interpol; update_gradients=Val(false), update_detJdV=Val(false))
         end
         rdim = Ferrite.getrefdim(func_interpol)
         n_basefuncs = getnbasefunctions(func_interpol)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -19,8 +19,7 @@ for (scalar_interpol, quad_rule) in (
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         update_gradients = true
         update_hessians = (DiffOrder==2 && Ferrite.getorder(func_interpol) > 1)
-
-        fv = FacetValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
+        fv = FacetValues(quad_rule, func_interpol, geom_interpol, Ferrite.ValuesUpdateFlags(func_interpol; update_gradients, update_hessians))
         if update_gradients && !update_hessians && VERSION ≥ v"1.9" # Check correct and type-stable default constructor
             fv_default = @inferred FacetValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(fv) === typeof(fv_default)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -19,8 +19,8 @@ for (scalar_interpol, quad_rule) in (
         n_basefunc_base = getnbasefunctions(scalar_interpol)
         update_gradients = true
         update_hessians = (DiffOrder==2 && Ferrite.getorder(func_interpol) > 1)
-        fv = FacetValues(quad_rule, func_interpol, geom_interpol, Ferrite.ValuesUpdateFlags(func_interpol; update_gradients, update_hessians))
-        if update_gradients && !update_hessians && VERSION ≥ v"1.9" # Check correct and type-stable default constructor
+        fv = FacetValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
+        if update_gradients && !update_hessians # Check correct and type-stable default constructor
             fv_default = @inferred FacetValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(fv) === typeof(fv_default)
         end

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -23,6 +23,7 @@ for (scalar_interpol, quad_rule) in (
         if update_gradients && !update_hessians # Check correct and type-stable default constructor
             fv_default = @inferred FacetValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(fv) === typeof(fv_default)
+            @inferred FacetValues(quad_rule, func_interpol, geom_interpol; update_hessians=Val(true))
         end
 
         rdim = Ferrite.getrefdim(func_interpol)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -22,7 +22,7 @@ for (scalar_interpol, quad_rule) in (
 
         fv = FacetValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
         if update_gradients && !update_hessians && VERSION ≥ v"1.9" # Check correct and type-stable default constructor
-            fv_default = FacetValues(quad_rule, func_interpol, geom_interpol)
+            fv_default = @inferred FacetValues(quad_rule, func_interpol, geom_interpol)
             @test typeof(fv) === typeof(fv_default)
         end
 


### PR DESCRIPTION
Solves type-stable construction for AbstractValues by introducing the singelton type `ValuesUpdateFlags`. In this PR, it is now also possible to have type-stable construction of `CellValues`, `PointValues`, and `FacetValues` with custom update specifications by providing kwargs as `Val` types. Using booleans still works and remain the documented way, but won't be type-stable.

Closes #960 

