### PR TITLE
Allow geometric_interpolation(::AbstractCell)

### DIFF
--- a/docs/src/devdocs/elements.md
+++ b/docs/src/devdocs/elements.md
@@ -13,7 +13,6 @@ Ferrite.vertices(::Ferrite.AbstractCell)
 Ferrite.edges(::Ferrite.AbstractCell)
 Ferrite.reference_faces(::Ferrite.AbstractRefShape)
 Ferrite.faces(::Ferrite.AbstractCell)
-Ferrite.geometric_interpolation(::Ferrite.AbstractCell)
 ```
 
 ### Common utilities and definitions when working with grids internally.

--- a/docs/src/reference/grid.md
+++ b/docs/src/reference/grid.md
@@ -31,7 +31,8 @@ getvertexset
 transform_coordinates!
 getcoordinates
 getcoordinates!
-Ferrite.get_node_coordinate
+geometric_interpolation(::Ferrite.AbstractCell)
+get_node_coordinate
 Ferrite.getspatialdim(::Ferrite.AbstractGrid)
 Ferrite.getrefdim
 ```

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -132,12 +132,13 @@ reference_facets(::Type{<:AbstractRefShape})
 @inline reference_facets(refshape::Type{<:AbstractRefShape{3}}) = reference_faces(refshape)
 
 """
-    geometric_interpolation(::AbstractCell)::Interpolation
+    geometric_interpolation(::AbstractCell)
+    geometric_interpolation(::Type{<:AbstractCell})
 
 Each `AbstractCell` type has a unique geometric interpolation describing its geometry.
-This function returns that interpolation.
+This function returns that interpolation, which is always a scalar interpolation.
 """
-geometric_interpolation(::AbstractCell)
+geometric_interpolation(cell::AbstractCell) = geometric_interpolation(typeof(cell))
 
 """
     Ferrite.get_node_ids(c::AbstractCell)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -373,7 +373,7 @@ end
 getdim(args...) = error("`Ferrite.getdim` is deprecated, use `getrefdim` or `getspatialdim` instead")
 getfielddim(args...) = error("`Ferrite.getfielddim(::AbstractDofHandler, args...) is deprecated, use `n_components` instead")
 
-function default_interpolation(cell::AbstractCell)
+function default_interpolation(::Type{C}) where {C <: AbstractCell}
     @warn "Ferrite.default_interpolation is deprecated, use the exported `geometric_interpolation` instead" maxlog=1
-    return geometric_interpolation(cell)
+    return geometric_interpolation(C)
 end

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -123,7 +123,7 @@ end
 end
 
 @testset "default_interpolation" begin
-    @test (@test_deprecated Ferrite.default_interpolation(Triangle)) == Lagrange{RefTriangle, 1}()
+    @test Ferrite.default_interpolation(Triangle) == geometric_interpolation(Triangle)
 end
 
 end # testset deprecations

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -122,4 +122,8 @@ end
     @test_throws ErrorException(msg) Ferrite.getfielddim(dh.subdofhandlers[1], :u)
 end
 
+@testset "default_interpolation" begin
+    @test (@test_deprecated Ferrite.default_interpolation(Triangle)) == Lagrange{RefTriangle, 1}
+end
+
 end # testset deprecations

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -123,7 +123,7 @@ end
 end
 
 @testset "default_interpolation" begin
-    @test (@test_deprecated Ferrite.default_interpolation(Triangle)) == Lagrange{RefTriangle, 1}
+    @test (@test_deprecated Ferrite.default_interpolation(Triangle)) == Lagrange{RefTriangle, 1}()
 end
 
 end # testset deprecations

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -56,7 +56,8 @@ end
         # Create a DofHandler, add some things, write to file and
         # then check the resulting sha
         dofhandler = DofHandler(grid)
-        ip = Ferrite.geometric_interpolation(celltype)
+        ip = geometric_interpolation(celltype)
+        @test ip == geometric_interpolation(getcells(grid, 1)) # Test ::AbstractCell dispatch
         add!(dofhandler, :temperature, ip)
         add!(dofhandler, :displacement, ip^dim)
         close!(dofhandler)


### PR DESCRIPTION
Moves docstring to public API (where it should be since the function is exported)
Fixes wrong deprecation dispatch
Closes #978