### PR TITLE
Remove self-qualified names

### DIFF
--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -27,7 +27,7 @@ jobs:
         shell: julia {0}
         run: |
           using Pkg
-          Pkg.add("ExplicitImports")
+          Pkg.add(name = "ExplicitImports", version = "1.6")
       - name: ExplicitImports.jl code checks
         shell: julia --project {0}
         run: |
@@ -36,3 +36,4 @@ jobs:
           check_no_implicit_imports(Ferrite; allow_unanalyzable)
           check_no_stale_explicit_imports(Ferrite; allow_unanalyzable)
           check_all_qualified_accesses_via_owners(Ferrite)
+          check_no_self_qualified_accesses(Ferrite)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -182,7 +182,7 @@ nodes_to_vtkorder(cell::QuadraticHexahedron) = [
 function create_vtk_griddata(grid::Grid{dim,C,T}) where {dim,C,T}
     cls = WriteVTK.MeshCell[]
     for cell in getcells(grid)
-        celltype = Ferrite.cell_to_vtkcell(typeof(cell))
+        celltype = cell_to_vtkcell(typeof(cell))
         push!(cls, WriteVTK.MeshCell(celltype, nodes_to_vtkorder(cell)))
     end
     coords = reshape(reinterpret(T, getnodes(grid)), (dim, getnnodes(grid)))
@@ -248,7 +248,7 @@ Use `write_node_data` directly when exporting values that are already
 sorted by the nodes in the grid.
 """
 function write_solution(vtk::VTKFile, dh::AbstractDofHandler, u::Vector, suffix="")
-    fieldnames = Ferrite.getfieldnames(dh)  # all primary fields
+    fieldnames = getfieldnames(dh)  # all primary fields
     for name in fieldnames
         data = _evaluate_at_grid_nodes(dh, u, name, #=vtk=# Val(true))
         _vtk_write_node_data(vtk.vtk, data, string(name, suffix))

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -181,10 +181,10 @@ struct BCValues{T}
     current_entity::ScalarWrapper{Int}
 end
 
-BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex} = Ferrite.FaceIndex) =
+BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex} = FaceIndex) =
     BCValues(Float64, func_interpol, geom_interpol, boundary_type)
 
-function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex} = Ferrite.FaceIndex) where {T,dim,refshape <: AbstractRefShape{dim}}
+function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex} = FaceIndex) where {T,dim,refshape <: AbstractRefShape{dim}}
     # set up quadrature rules for each boundary entity with dof-positions
     # (determined by func_interpol) as the quadrature points
     interpolation_coords = reference_coordinates(func_interpol)

--- a/src/Grid/grid_generators.jl
+++ b/src/Grid/grid_generators.jl
@@ -329,7 +329,7 @@ function generate_grid(::Type{Pyramid}, nel::NTuple{3,Int}, left::Vec{3,T}=Vec{3
     return Grid(cells, nodes, facetsets=facetsets)
 end
 
-function Ferrite.generate_grid(::Type{SerendipityQuadraticHexahedron}, nel::NTuple{3,Int}, left::Vec{3,T}=Vec{3}((-1.0,-1.0,-1.0)), right::Vec{3,T}=Vec{3}((1.0,1.0,1.0))) where {T}
+function generate_grid(::Type{SerendipityQuadraticHexahedron}, nel::NTuple{3,Int}, left::Vec{3,T}=Vec{3}((-1.0,-1.0,-1.0)), right::Vec{3,T}=Vec{3}((1.0,1.0,1.0))) where {T}
     nel_x = nel[1]; nel_y = nel[2]; nel_z = nel[3]; nel_tot = nel_x*nel_y*nel_z
     nnode_x = 2nel_x + 1; nnode_y = 2nel_y + 1; nnode_z = 2nel_z + 1 #Note: not the actually number of nodes in x/y/z, just a temporary variables
 

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -80,7 +80,7 @@ end
 
 function _assemble_L2_matrix(fe_values, set, dh)
 
-    n = Ferrite.getnbasefunctions(fe_values)
+    n = getnbasefunctions(fe_values)
     M = create_symmetric_sparsity_pattern(dh)
     assembler = start_assemble(M)
 

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -50,7 +50,7 @@ end
 
 Assembles the matrix `Ke` into `a` according to the dofs specified by `rowdofs` and `coldofs`.
 """
-function assemble!(a::Ferrite.Assembler{T}, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix{T}) where {T}
+function assemble!(a::Assembler{T}, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix{T}) where {T}
     nrows = length(rowdofs)
     ncols = length(coldofs)
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -378,15 +378,15 @@ Helper function to generically dispatch on the correct dof sets of a boundary en
 """
 boundarydof_indices(::Type{<:BoundaryIndex})
 
-boundarydof_indices(::Type{FaceIndex}) = Ferrite.facedof_indices
-boundarydof_indices(::Type{EdgeIndex}) = Ferrite.edgedof_indices
-boundarydof_indices(::Type{VertexIndex}) = Ferrite.vertexdof_indices
+boundarydof_indices(::Type{FaceIndex}) = facedof_indices
+boundarydof_indices(::Type{EdgeIndex}) = edgedof_indices
+boundarydof_indices(::Type{VertexIndex}) = vertexdof_indices
 
-facetdof_indices(ip::InterpolationByDim{3}) = Ferrite.facedof_indices(ip)
-facetdof_indices(ip::InterpolationByDim{2}) = Ferrite.edgedof_indices(ip)
-facetdof_indices(ip::InterpolationByDim{1}) = Ferrite.vertexdof_indices(ip)
-facetdof_interior_indices(ip::InterpolationByDim{3}) = Ferrite.facedof_interior_indices(ip)
-facetdof_interior_indices(ip::InterpolationByDim{2}) = Ferrite.edgedof_interior_indices(ip)
+facetdof_indices(ip::InterpolationByDim{3}) = facedof_indices(ip)
+facetdof_indices(ip::InterpolationByDim{2}) = edgedof_indices(ip)
+facetdof_indices(ip::InterpolationByDim{1}) = vertexdof_indices(ip)
+facetdof_interior_indices(ip::InterpolationByDim{3}) = facedof_interior_indices(ip)
+facetdof_interior_indices(ip::InterpolationByDim{2}) = edgedof_interior_indices(ip)
 facetdof_interior_indices(ip::InterpolationByDim{1}) = ntuple(_ -> (), nvertices(ip))
 dirichlet_facetdof_indices(ip::InterpolationByDim{3}) = dirichlet_facedof_indices(ip)
 dirichlet_facetdof_indices(ip::InterpolationByDim{2}) = dirichlet_edgedof_indices(ip)
@@ -413,9 +413,9 @@ Used internally in [`ConstraintHandler`](@ref) and defaults to [`boundarydof_ind
 """
 dirichlet_boundarydof_indices(::Type{<:BoundaryIndex})
 
-dirichlet_boundarydof_indices(::Type{FaceIndex}) = Ferrite.dirichlet_facedof_indices
-dirichlet_boundarydof_indices(::Type{EdgeIndex}) = Ferrite.dirichlet_edgedof_indices
-dirichlet_boundarydof_indices(::Type{VertexIndex}) = Ferrite.dirichlet_vertexdof_indices
+dirichlet_boundarydof_indices(::Type{FaceIndex}) = dirichlet_facedof_indices
+dirichlet_boundarydof_indices(::Type{EdgeIndex}) = dirichlet_edgedof_indices
+dirichlet_boundarydof_indices(::Type{VertexIndex}) = dirichlet_vertexdof_indices
 dirichlet_boundarydof_indices(::Type{FacetIndex}) = dirichlet_facetdof_indices
 
 #########################


### PR DESCRIPTION
This patch removes all self-qualified names (i.e. `Ferrite.` within the Ferrite module) and adds the new `check_no_self_qualified_accesses` check (new in ExplicitImports version 1.6) to CI.