### PR TITLE
Require Julia 1.9 and remove ScalarWrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
-        julia-version: ['1.6', '1', 'nightly']
+        julia-version: ['1.9', '1', 'nightly']
         os: ['ubuntu-latest']
         include:
           - os: windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ Preferences = "1"
 Reexport = "1"
 Tensors = "1.14"
 WriteVTK = "1.13"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/Dofs/DofRenumbering.jl
+++ b/src/Dofs/DofRenumbering.jl
@@ -108,7 +108,7 @@ function _renumber!(ch::ConstraintHandler, perm::AbstractVector{<:Integer})
         pdofs[i] = perm[pdofs[i]]
     end
     empty!(ch.dofmapping)
-    ch.closed[] = false
+    ch.closed = false
     close!(ch)
     return ch
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,14 +35,6 @@ else
     end
 end
 
-mutable struct ScalarWrapper{T}
-    x::T
-end
-
-@inline Base.getindex(s::ScalarWrapper) = s.x
-@inline Base.setindex!(s::ScalarWrapper, v) = s.x = v
-Base.copy(s::ScalarWrapper{T}) where {T} = ScalarWrapper{T}(copy(s.x))
-
 convert_to_orderedset(set::AbstractVector{T}) where T = OrderedSet{T}(set)
 convert_to_orderedset(set::AbstractSet{T}) where T = convert(OrderedSet{T}, set)
 

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -163,18 +163,15 @@ for (scalar_interpol, quad_rule) in (
                     end
                 end
             end
-            # Test that qr, detJdV, normals, and current_facet are copied as expected.
+            # Test that fqr, detJdV, and normals, are copied as expected.
             # Note that qr remain aliased, as defined by `copy(qr)=qr`, see quadrature.jl.
-            # Make it easy to test scalar wrapper equality
-            _mock_isequal(a, b) = a == b
-            _mock_isequal(a::T, b::T) where {T<:Ferrite.ScalarWrapper} = a[] == b[]
-            for fname in (:fqr, :detJdV, :normals, :current_facet)
+            for fname in (:fqr, :detJdV, :normals)
                 v = getfield(fv, fname)
                 vc = getfield(fvc, fname)
                 if fname !== :fqr # Test unaliased
                     @test v !== vc
                 end
-                @test _mock_isequal(v, vc)
+                @test v == vc
             end
         end
     end

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -234,7 +234,6 @@
     @test typeof(iv) == typeof(ivc)
     for fname in fieldnames(typeof(iv))
         v = getfield(iv, fname)
-        v isa Ferrite.ScalarWrapper && continue
         vc = getfield(ivc, fname)
         if hasmethod(pointer, Tuple{typeof(v)})
             @test pointer(v) != pointer(vc)
@@ -242,7 +241,6 @@
         v isa FacetValues && continue
         for fname in fieldnames(typeof(vc))
             v2 = getfield(v, fname)
-            v2 isa Ferrite.ScalarWrapper && continue
             vc2 = getfield(vc, fname)
             if hasmethod(pointer, Tuple{typeof(v2)})
                 @test pointer(v2) != pointer(vc2)


### PR DESCRIPTION
This patch sets the Julia compat to 1.9. This make it possible to use `const` struct fields in `mutable structs` and therefore the `ScalarWrapper` struct can be removed.

TODO: Benchmarks.