### PR TITLE
Replace `shape_value` etc for interpolations with `reference_shape_value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,12 +308,13 @@ more discussion).
   `FacetQuadratureRule{RefTriangle}(order)` (similar to how `QuadratureRule` is constructed).
   ([#716][github-716])
 
-- New methods `shape_value(::Interpolation, ξ::Vec, i::Int)` and
-  `shape_gradient(::Interpolation, ξ::Vec, i::Int)` for evaluating the value/gradient of the
-  `i`th shape function of an interpolation in local reference coordinate `ξ`. Note that
-  these methods return the value/gradient wrt. the reference coordinate `ξ`, whereas the
-  corresponding methods for `CellValues` etc return the value/gradient wrt the spatial
-  coordinate `x`. ([#721][github-721])
+- New functions `Ferrite.reference_shape_value(::Interpolation, ξ::Vec, i::Int)` and
+  `Ferrite.reference_shape_gradient(::Interpolation, ξ::Vec, i::Int)` for evaluating the
+  value/gradient of the `i`th shape function of an interpolation in local reference
+  coordinate `ξ`. These methods are public but not exported. (Note that these methods return
+  the value/gradient wrt. the reference coordinate `ξ`, whereas the corresponding methods
+  for `CellValues` etc return the value/gradient wrt the spatial coordinate `x`.)
+  ([#721][github-721])
 
 - `FacetIterator` and `FacetCache` have been added. These work similarly to `CellIterator` and
   `CellCache` but are used to iterate over (boundary) face sets instead. These simplify

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -15,7 +15,7 @@ Ferrite.shape_gradient(::Interpolation, ::Vec, ::Int)
 Ferrite.shape_gradient_and_value
 Ferrite.boundarydof_indices
 Ferrite.dirichlet_boundarydof_indices
-Ferrite.shape_values!
+Ferrite.reference_shape_values!
 Ferrite.shape_gradients!
 Ferrite.shape_gradients_and_values!
 ```

--- a/docs/src/topics/SimpleCellValues_literate.jl
+++ b/docs/src/topics/SimpleCellValues_literate.jl
@@ -42,10 +42,10 @@ function SimpleCellValues(qr::QuadratureRule, ip_fun::Interpolation, ip_geo::Int
     ## Precalculate function and geometric shape values and gradients
     for (qp, ξ) in pairs(Ferrite.getpoints(qr))
         for i in 1:n_func_basefuncs
-            dNdξ[i, qp], N[i, qp] = Ferrite.shape_gradient_and_value(ip_fun, ξ, i)
+            dNdξ[i, qp], N[i, qp] = Ferrite.reference_shape_gradient_and_value(ip_fun, ξ, i)
         end
         for i in 1:n_geom_basefuncs
-            dMdξ[i, qp], M[i, qp] = Ferrite.shape_gradient_and_value(ip_geo, ξ, i)
+            dMdξ[i, qp], M[i, qp] = Ferrite.reference_shape_gradient_and_value(ip_geo, ξ, i)
         end
     end
 

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -206,7 +206,7 @@ function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interp
 
     for n_boundary_entity in 1:n_boundary_entities
         for (qp, ξ) in pairs(qrs[n_boundary_entity].points)
-            shape_values!(@view(M[:, qp, n_boundary_entity]), geom_interpol, ξ)
+            reference_shape_values!(@view(M[:, qp, n_boundary_entity]), geom_interpol, ξ)
         end
         nqp[n_boundary_entity] = length(qrs[n_boundary_entity].points)
     end

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -89,13 +89,13 @@ function FunctionValues{DiffOrder}(::Type{T}, ip::Interpolation, qr::QuadratureR
 end
 
 function precompute_values!(fv::FunctionValues{0}, qr_points::Vector{<:Vec})
-    shape_values!(fv.Nξ, fv.ip, qr_points)
+    reference_shape_values!(fv.Nξ, fv.ip, qr_points)
 end
 function precompute_values!(fv::FunctionValues{1}, qr_points::Vector{<:Vec})
-    shape_gradients_and_values!(fv.dNdξ, fv.Nξ, fv.ip, qr_points)
+    reference_shape_gradients_and_values!(fv.dNdξ, fv.Nξ, fv.ip, qr_points)
 end
 function precompute_values!(fv::FunctionValues{2}, qr_points::Vector{<:Vec})
-    shape_hessians_gradients_and_values!(fv.d2Ndξ2, fv.dNdξ, fv.Nξ, fv.ip, qr_points)
+    reference_shape_hessians_gradients_and_values!(fv.d2Ndξ2, fv.dNdξ, fv.Nξ, fv.ip, qr_points)
 end
 
 function Base.copy(v::FunctionValues)

--- a/src/FEValues/GeometryMapping.jl
+++ b/src/FEValues/GeometryMapping.jl
@@ -85,13 +85,13 @@ function GeometryMapping{2}(::Type{T}, ip::ScalarInterpolation, qr::QuadratureRu
 end
 
 function precompute_values!(gm::GeometryMapping{0}, qr_points::Vector{<:Vec})
-    shape_values!(gm.M, gm.ip, qr_points)
+    reference_shape_values!(gm.M, gm.ip, qr_points)
 end
 function precompute_values!(gm::GeometryMapping{1}, qr_points::Vector{<:Vec})
-    shape_gradients_and_values!(gm.dMdξ, gm.M, gm.ip, qr_points)
+    reference_shape_gradients_and_values!(gm.dMdξ, gm.M, gm.ip, qr_points)
 end
 function precompute_values!(gm::GeometryMapping{2}, qr_points::Vector{<:Vec})
-    shape_hessians_gradients_and_values!(gm.d2Mdξ2, gm.dMdξ, gm.M, gm.ip, qr_points)
+    reference_shape_hessians_gradients_and_values!(gm.d2Mdξ2, gm.dMdξ, gm.M, gm.ip, qr_points)
 end
 
 function Base.copy(v::GeometryMapping)

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -347,20 +347,20 @@ end
 _copy_or_nothing(x) = copy(x)
 _copy_or_nothing(::Nothing) = nothing
 
-function shape_values!(values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+function reference_shape_values!(values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
     for (qp, ξ) in pairs(qr_points)
-        shape_values!(@view(values[:, qp]), ip, ξ)
+        reference_shape_values!(@view(values[:, qp]), ip, ξ)
     end
 end
 
-function shape_gradients_and_values!(gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+function reference_shape_gradients_and_values!(gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
     for (qp, ξ) in pairs(qr_points)
-        shape_gradients_and_values!(@view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
+        reference_shape_gradients_and_values!(@view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
     end
 end
 
-function shape_hessians_gradients_and_values!(hessians::AbstractMatrix, gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
+function reference_shape_hessians_gradients_and_values!(hessians::AbstractMatrix, gradients::AbstractMatrix, values::AbstractMatrix, ip, qr_points::Vector{<:Vec})
     for (qp, ξ) in pairs(qr_points)
-        shape_hessians_gradients_and_values!(@view(hessians[:, qp]), @view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
+        reference_shape_hessians_gradients_and_values!(@view(hessians[:, qp]), @view(gradients[:, qp]), @view(values[:, qp]), ip, ξ)
     end
 end

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -127,7 +127,7 @@ function find_local_coordinate(interpolation, cell_coordinates::Vector{<:Vec{dim
         J = zero(Tensor{2, dim, T})
         # TODO batched eval after 764 is merged.
         for j in 1:n_basefuncs
-            dNdξ, N = shape_gradient_and_value(interpolation, local_guess, j)
+            dNdξ, N = reference_shape_gradient_and_value(interpolation, local_guess, j)
             global_guess += N * cell_coordinates[j]
             J += cell_coordinates[j] ⊗ dNdξ
         end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -339,9 +339,9 @@ function Base.show(io::IO, ::CrouzeixRaviart{shape, order}) where {shape, order}
     print(io, "CrouzeixRaviart{$(shape), $(order)}()")
 end
 
-@deprecate value(ip::Interpolation, ξ::Vec) [shape_value(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
-@deprecate derivative(ip::Interpolation, ξ::Vec) [shape_gradient(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
-@deprecate value(ip::Interpolation, i::Int, ξ::Vec) shape_value(ip, ξ, i) false
+@deprecate value(ip::Interpolation, ξ::Vec) [reference_shape_value(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
+@deprecate derivative(ip::Interpolation, ξ::Vec) [reference_shape_gradient(ip, ξ, i) for i in 1:getnbasefunctions(ip)] false
+@deprecate value(ip::Interpolation, i::Int, ξ::Vec) reference_shape_value(ip, ξ, i) false
 
 export MixedDofHandler
 function MixedDofHandler(::AbstractGrid)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -143,63 +143,63 @@ getnbasefunctions(::Interpolation)
 #   celldof: dof that is local to the element
 
 """
-    shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec)
+    reference_shape_values!(values::AbstractArray{T}, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape functions of `ip` at once at the reference point `ξ` and store them in
 `values`.
 """
-@propagate_inbounds function shape_values!(values::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
+@propagate_inbounds function reference_shape_values!(values::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
     @boundscheck checkbounds(values, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        values[i] = shape_value(ip, ξ, i)
+        values[i] = reference_shape_value(ip, ξ, i)
     end
 end
 
 """
-    shape_gradients!(gradients::AbstractArray, ip::Interpolation, ξ::Vec)
+    reference_shape_gradients!(gradients::AbstractArray, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape function gradients of `ip` at once at the reference point `ξ` and store
 them in `gradients`.
 """
-function shape_gradients!(gradients::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
+function reference_shape_gradients!(gradients::AT, ip::IP, ξ::Vec) where {IP <: Interpolation, AT <: AbstractArray}
     @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        gradients[i] = shape_gradient(ip, ξ, i)
+        gradients[i] = reference_shape_gradient(ip, ξ, i)
     end
 end
 
 """
-    shape_gradients_and_values!(gradients::AbstractArray, values::AbstractArray, ip::Interpolation, ξ::Vec)
+    reference_shape_gradients_and_values!(gradients::AbstractArray, values::AbstractArray, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape function gradients and values of `ip` at once at the reference point `ξ`
 and store them in `values`.
 """
-function shape_gradients_and_values!(gradients::GAT, values::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray}
+function reference_shape_gradients_and_values!(gradients::GAT, values::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray}
     @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
     @boundscheck checkbounds(values, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        gradients[i], values[i] = shape_gradient_and_value(ip, ξ, i)
+        gradients[i], values[i] = reference_shape_gradient_and_value(ip, ξ, i)
     end
 end
 
 """
-    shape_hessians_gradients_and_values!(hessians::AbstractVector, gradients::AbstractVector, values::AbstractVector, ip::Interpolation, ξ::Vec)
+    reference_shape_hessians_gradients_and_values!(hessians::AbstractVector, gradients::AbstractVector, values::AbstractVector, ip::Interpolation, ξ::Vec)
 
 Evaluate all shape function hessians, gradients and values of `ip` at once at the reference point `ξ`
 and store them in `hessians`, `gradients`, and `values`.
 """
-@propagate_inbounds function shape_hessians_gradients_and_values!(hessians::AbstractVector, gradients::AbstractVector, values::AbstractVector, ip::Interpolation, ξ::Vec)
+@propagate_inbounds function reference_shape_hessians_gradients_and_values!(hessians::AbstractVector, gradients::AbstractVector, values::AbstractVector, ip::Interpolation, ξ::Vec)
     @boundscheck checkbounds(hessians, 1:getnbasefunctions(ip))
     @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
     @boundscheck checkbounds(values, 1:getnbasefunctions(ip))
     @inbounds for i in 1:getnbasefunctions(ip)
-        hessians[i], gradients[i], values[i] = shape_hessian_gradient_and_value(ip, ξ, i)
+        hessians[i], gradients[i], values[i] = reference_shape_hessian_gradient_and_value(ip, ξ, i)
     end
 end
 
 
 """
-    shape_value(ip::Interpolation, ξ::Vec, i::Int)
+    reference_shape_value(ip::Interpolation, ξ::Vec, i::Int)
 
 Evaluate the value of the `i`th shape function of the interpolation `ip`
 at a point `ξ` on the reference element. The index `i` must
@@ -209,36 +209,36 @@ match the index in [`vertices(::Interpolation)`](@ref), [`faces(::Interpolation)
 For nodal interpolations the indices also must match the
 indices of [`reference_coordinates(::Interpolation)`](@ref).
 """
-shape_value(ip::Interpolation, ξ::Vec, i::Int)
+reference_shape_value(ip::Interpolation, ξ::Vec, i::Int)
 
 """
-    shape_gradient(ip::Interpolation, ξ::Vec, i::Int)
+    reference_shape_gradient(ip::Interpolation, ξ::Vec, i::Int)
 
 Evaluate the gradient of the `i`th shape function of the interpolation `ip` in
 reference coordinate `ξ`.
 """
-function shape_gradient(ip::Interpolation, ξ::Vec, i::Int)
-    return Tensors.gradient(x -> shape_value(ip, x, i), ξ)
+function reference_shape_gradient(ip::Interpolation, ξ::Vec, i::Int)
+    return Tensors.gradient(x -> reference_shape_value(ip, x, i), ξ)
 end
 
 """
-    shape_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
+    reference_shape_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
 
-Optimized version combining the evaluation [`Ferrite.shape_value(::Interpolation)`](@ref)
-and [`Ferrite.shape_gradient(::Interpolation)`](@ref).
+Optimized version combining the evaluation [`Ferrite.reference_shape_value(::Interpolation)`](@ref)
+and [`Ferrite.reference_shape_gradient(::Interpolation)`](@ref).
 """
-function shape_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
-    return gradient(x -> shape_value(ip, x, i), ξ, :all)
+function reference_shape_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
+    return gradient(x -> reference_shape_value(ip, x, i), ξ, :all)
 end
 
 """
-    shape_hessian_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
+    reference_shape_hessian_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
 
-Optimized version combining the evaluation [`Ferrite.shape_value(::Interpolation)`](@ref),
-[`Ferrite.shape_gradient(::Interpolation)`](@ref), and the gradient of the latter.
+Optimized version combining the evaluation [`Ferrite.reference_shape_value(::Interpolation)`](@ref),
+[`Ferrite.reference_shape_gradient(::Interpolation)`](@ref), and the gradient of the latter.
 """
-function shape_hessian_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
-    return hessian(x -> shape_value(ip, x, i), ξ, :all)
+function reference_shape_hessian_gradient_and_value(ip::Interpolation, ξ::Vec, i::Int)
+    return hessian(x -> reference_shape_value(ip, x, i), ξ, :all)
 end
 
 
@@ -450,8 +450,8 @@ dirichlet_vertexdof_indices(ip::DiscontinuousLagrange{shape, order}) where {shap
 function reference_coordinates(ip::DiscontinuousLagrange{shape, order}) where {shape, order}
     return reference_coordinates(Lagrange{shape,order}())
 end
-function shape_value(::DiscontinuousLagrange{shape, order}, ξ::Vec{dim}, i::Int) where {dim, shape <: AbstractRefShape{dim}, order}
-    return shape_value(Lagrange{shape, order}(), ξ, i)
+function reference_shape_value(::DiscontinuousLagrange{shape, order}, ξ::Vec{dim}, i::Int) where {dim, shape <: AbstractRefShape{dim}, order}
+    return reference_shape_value(Lagrange{shape, order}(), ξ, i)
 end
 
 # Excepting the L0 element.
@@ -467,7 +467,7 @@ function reference_coordinates(ip::DiscontinuousLagrange{RefTetrahedron,0})
    return [Vec{3,Float64}((1/4,1/4,1/4))]
 end
 
-function shape_value(ip::DiscontinuousLagrange{shape, 0}, ::Vec{dim, T}, i::Int) where {dim, shape <: AbstractRefShape{dim}, T}
+function reference_shape_value(ip::DiscontinuousLagrange{shape, 0}, ::Vec{dim, T}, i::Int) where {dim, shape <: AbstractRefShape{dim}, T}
     i > 1 && throw(ArgumentError("no shape function $i for interpolation $ip"))
     return one(T)
 end
@@ -511,7 +511,7 @@ function reference_coordinates(::Lagrange{RefLine,1})
             Vec{1, Float64}(( 1.0,))]
 end
 
-function shape_value(ip::Lagrange{RefLine, 1}, ξ::Vec{1}, i::Int)
+function reference_shape_value(ip::Lagrange{RefLine, 1}, ξ::Vec{1}, i::Int)
     ξ_x = ξ[1]
     i == 1 && return (1 - ξ_x) / 2
     i == 2 && return (1 + ξ_x) / 2
@@ -532,7 +532,7 @@ function reference_coordinates(::Lagrange{RefLine,2})
             Vec{1, Float64}(( 0.0,))]
 end
 
-function shape_value(ip::Lagrange{RefLine, 2}, ξ::Vec{1}, i::Int)
+function reference_shape_value(ip::Lagrange{RefLine, 2}, ξ::Vec{1}, i::Int)
     ξ_x = ξ[1]
     i == 1 && return ξ_x * (ξ_x - 1) / 2
     i == 2 && return ξ_x * (ξ_x + 1) / 2
@@ -555,7 +555,7 @@ function reference_coordinates(::Lagrange{RefQuadrilateral,1})
             Vec{2, Float64}((-1.0,  1.0,))]
 end
 
-function shape_value(ip::Lagrange{RefQuadrilateral, 1}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange{RefQuadrilateral, 1}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return (1 - ξ_x) * (1 - ξ_y) / 4
@@ -587,7 +587,7 @@ function reference_coordinates(::Lagrange{RefQuadrilateral,2})
             Vec{2, Float64}(( 0.0,  0.0))]
 end
 
-function shape_value(ip::Lagrange{RefQuadrilateral, 2}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange{RefQuadrilateral, 2}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return (ξ_x^2 - ξ_x) * (ξ_y^2 - ξ_y) / 4
@@ -631,7 +631,7 @@ function reference_coordinates(::Lagrange{RefQuadrilateral, 3})
             Vec{2, Float64}(( 1/3,  1/3))]
 end
 
-function shape_value(ip::Lagrange{RefQuadrilateral, 3}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange{RefQuadrilateral, 3}, ξ::Vec{2}, i::Int)
     # See https://defelement.com/elements/examples/quadrilateral-Q-3.html
     # Transform domain from [-1, 1] × [-1, 1] to [0, 1] × [0, 1]
     ξ_x = (ξ[1]+1)/2
@@ -669,7 +669,7 @@ function reference_coordinates(::Lagrange{RefTriangle,1})
             Vec{2, Float64}((0.0, 0.0))]
 end
 
-function shape_value(ip::Lagrange{RefTriangle, 1}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange{RefTriangle, 1}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return ξ_x
@@ -696,7 +696,7 @@ function reference_coordinates(::Lagrange{RefTriangle,2})
             Vec{2, Float64}((0.5, 0.0))]
 end
 
-function shape_value(ip::Lagrange{RefTriangle, 2}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange{RefTriangle, 2}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     γ = 1 - ξ_x - ξ_y
@@ -775,7 +775,7 @@ function reference_coordinates(ip::Lagrange2Tri345)
     return permute!(coordpts, permdof2DLagrange2Tri345[order])
 end
 
-function shape_value(ip::Lagrange2Tri345, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Lagrange2Tri345, ξ::Vec{2}, i::Int)
     if !(0 < i <= getnbasefunctions(ip))
         throw(ArgumentError("no shape function $i for interpolation $ip"))
     end
@@ -821,7 +821,7 @@ function reference_coordinates(::Lagrange{RefTetrahedron,1})
             Vec{3, Float64}((0.0, 0.0, 1.0))]
 end
 
-function shape_value(ip::Lagrange{RefTetrahedron, 1}, ξ::Vec{3}, i::Int)
+function reference_shape_value(ip::Lagrange{RefTetrahedron, 1}, ξ::Vec{3}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     ξ_z = ξ[3]
@@ -856,7 +856,7 @@ end
 
 # http://www.colorado.edu/engineering/CAS/courses.d/AFEM.d/AFEM.Ch09.d/AFEM.Ch09.pdf
 # http://www.colorado.edu/engineering/CAS/courses.d/AFEM.d/AFEM.Ch10.d/AFEM.Ch10.pdf
-function shape_value(ip::Lagrange{RefTetrahedron, 2}, ξ::Vec{3}, i::Int)
+function reference_shape_value(ip::Lagrange{RefTetrahedron, 2}, ξ::Vec{3}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     ξ_z = ξ[3]
@@ -892,7 +892,7 @@ function reference_coordinates(::Lagrange{RefHexahedron,1})
             Vec{3, Float64}((-1.0,  1.0,  1.0))]
 end
 
-function shape_value(ip::Lagrange{RefHexahedron, 1}, ξ::Vec{3}, i::Int)
+function reference_shape_value(ip::Lagrange{RefHexahedron, 1}, ξ::Vec{3}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     ξ_z = ξ[3]
@@ -980,7 +980,7 @@ function reference_coordinates(::Lagrange{RefHexahedron,2})
             ]
 end
 
-function shape_value(ip::Lagrange{RefHexahedron, 2}, ξ::Vec{3, T}, i::Int) where {T}
+function reference_shape_value(ip::Lagrange{RefHexahedron, 2}, ξ::Vec{3, T}, i::Int) where {T}
     # Some local helpers.
     @inline φ₁(x::T) = -x*(1-x)/2
     @inline φ₂(x::T) = (1+x)*(1-x)
@@ -1039,7 +1039,7 @@ function reference_coordinates(::Lagrange{RefPrism,1})
             Vec{3, Float64}((0.0, 1.0, 1.0))]
 end
 
-function shape_value(ip::Lagrange{RefPrism,1}, ξ::Vec{3}, i::Int)
+function reference_shape_value(ip::Lagrange{RefPrism,1}, ξ::Vec{3}, i::Int)
     (x,y,z) = ξ
     i == 1 && return 1-x-y -z*(1-x-y)
     i == 2 && return x*(1-z)
@@ -1119,7 +1119,7 @@ function reference_coordinates(::Lagrange{RefPrism,2})
             Vec{3, Float64}((1/2, 1/2, 1/2)),]
 end
 
-function shape_value(ip::Lagrange{RefPrism, 2}, ξ::Vec{3}, i::Int)
+function reference_shape_value(ip::Lagrange{RefPrism, 2}, ξ::Vec{3}, i::Int)
     (x,y,z) = ξ
     x² = x*x
     y² = y*y
@@ -1161,7 +1161,7 @@ function reference_coordinates(::Lagrange{RefPyramid,1})
             Vec{3, Float64}((0.0, 0.0, 1.0))]
 end
 
-function shape_value(ip::Lagrange{RefPyramid,1}, ξ::Vec{3,T}, i::Int) where T
+function reference_shape_value(ip::Lagrange{RefPyramid,1}, ξ::Vec{3,T}, i::Int) where T
     (x,y,z) = ξ
     zzero = z ≈ one(T)
     i == 1 && return zzero ? zero(T) : (-x*y+(z-1)*(-x-y-z+1))/(z-1)
@@ -1231,7 +1231,7 @@ function reference_coordinates(::Lagrange{RefPyramid,2})
             Vec{3, Float64}((0.5, 0.5, 0.0))]
 end
 
-function shape_value(ip::Lagrange{RefPyramid,2}, ξ::Vec{3,T}, i::Int) where T
+function reference_shape_value(ip::Lagrange{RefPyramid,2}, ξ::Vec{3,T}, i::Int) where T
     (x,y,z) = ξ
     x² = x*x
     y² = y*y
@@ -1285,7 +1285,7 @@ function reference_coordinates(::BubbleEnrichedLagrange{RefTriangle,1})
             Vec{2, Float64}((1/3, 1/3)),]
 end
 
-function shape_value(ip::BubbleEnrichedLagrange{RefTriangle, 1}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::BubbleEnrichedLagrange{RefTriangle, 1}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return ξ_x*(9ξ_y^2 + 9ξ_x*ξ_y - 9ξ_y + 1)
@@ -1335,7 +1335,7 @@ function reference_coordinates(::Serendipity{RefQuadrilateral,2})
             Vec{2, Float64}((-1.0,  0.0))]
 end
 
-function shape_value(ip::Serendipity{RefQuadrilateral,2}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::Serendipity{RefQuadrilateral,2}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return (1 - ξ_x) * (1 - ξ_y) * (-ξ_x - ξ_y - 1) / 4
@@ -1407,18 +1407,18 @@ function reference_coordinates(::Serendipity{RefHexahedron,2})
 end
 
 # Inlined to resolve the recursion properly
-@inline function shape_value(ip::Serendipity{RefHexahedron, 2}, ξ::Vec{3}, i::Int)
+@inline function reference_shape_value(ip::Serendipity{RefHexahedron, 2}, ξ::Vec{3}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     ξ_z = ξ[3]
-    i == 1 && return (1 - ξ_x) * (1 - ξ_y) * (1 - ξ_z) / 8 - (shape_value(ip, ξ, 12) + shape_value(ip, ξ, 9) + shape_value(ip, ξ, 17)) / 2
-    i == 2 && return (1 + ξ_x) * (1 - ξ_y) * (1 - ξ_z) / 8 - (shape_value(ip, ξ, 9) + shape_value(ip, ξ, 10) + shape_value(ip, ξ, 18)) / 2
-    i == 3 && return (1 + ξ_x) * (1 + ξ_y) * (1 - ξ_z) / 8 - (shape_value(ip, ξ, 10) + shape_value(ip, ξ, 11) + shape_value(ip, ξ, 19)) / 2
-    i == 4 && return (1 - ξ_x) * (1 + ξ_y) * (1 - ξ_z) / 8 - (shape_value(ip, ξ, 11) + shape_value(ip, ξ, 12) + shape_value(ip, ξ, 20)) / 2
-    i == 5 && return (1 - ξ_x) * (1 - ξ_y) * (1 + ξ_z) / 8 - (shape_value(ip, ξ, 16) + shape_value(ip, ξ, 13) + shape_value(ip, ξ, 17)) / 2
-    i == 6 && return (1 + ξ_x) * (1 - ξ_y) * (1 + ξ_z) / 8 - (shape_value(ip, ξ, 13) + shape_value(ip, ξ, 14) + shape_value(ip, ξ, 18)) / 2
-    i == 7 && return (1 + ξ_x) * (1 + ξ_y) * (1 + ξ_z) / 8 - (shape_value(ip, ξ, 14) + shape_value(ip, ξ, 15) + shape_value(ip, ξ, 19)) / 2
-    i == 8 && return (1 - ξ_x) * (1 + ξ_y) * (1 + ξ_z) / 8 - (shape_value(ip, ξ, 15) + shape_value(ip, ξ, 16) + shape_value(ip, ξ, 20)) / 2
+    i == 1 && return (1 - ξ_x) * (1 - ξ_y) * (1 - ξ_z) / 8 - (reference_shape_value(ip, ξ, 12) + reference_shape_value(ip, ξ, 9) + reference_shape_value(ip, ξ, 17)) / 2
+    i == 2 && return (1 + ξ_x) * (1 - ξ_y) * (1 - ξ_z) / 8 - (reference_shape_value(ip, ξ, 9) + reference_shape_value(ip, ξ, 10) + reference_shape_value(ip, ξ, 18)) / 2
+    i == 3 && return (1 + ξ_x) * (1 + ξ_y) * (1 - ξ_z) / 8 - (reference_shape_value(ip, ξ, 10) + reference_shape_value(ip, ξ, 11) + reference_shape_value(ip, ξ, 19)) / 2
+    i == 4 && return (1 - ξ_x) * (1 + ξ_y) * (1 - ξ_z) / 8 - (reference_shape_value(ip, ξ, 11) + reference_shape_value(ip, ξ, 12) + reference_shape_value(ip, ξ, 20)) / 2
+    i == 5 && return (1 - ξ_x) * (1 - ξ_y) * (1 + ξ_z) / 8 - (reference_shape_value(ip, ξ, 16) + reference_shape_value(ip, ξ, 13) + reference_shape_value(ip, ξ, 17)) / 2
+    i == 6 && return (1 + ξ_x) * (1 - ξ_y) * (1 + ξ_z) / 8 - (reference_shape_value(ip, ξ, 13) + reference_shape_value(ip, ξ, 14) + reference_shape_value(ip, ξ, 18)) / 2
+    i == 7 && return (1 + ξ_x) * (1 + ξ_y) * (1 + ξ_z) / 8 - (reference_shape_value(ip, ξ, 14) + reference_shape_value(ip, ξ, 15) + reference_shape_value(ip, ξ, 19)) / 2
+    i == 8 && return (1 - ξ_x) * (1 + ξ_y) * (1 + ξ_z) / 8 - (reference_shape_value(ip, ξ, 15) + reference_shape_value(ip, ξ, 16) + reference_shape_value(ip, ξ, 20)) / 2
     i ==  9 && return (1 - ξ_x^2) * (1 - ξ_y) * (1 - ξ_z) / 4
     i == 10 && return (1 + ξ_x) * (1 - ξ_y^2) * (1 - ξ_z) / 4
     i == 11 && return (1 - ξ_x^2) * (1 + ξ_y) * (1 - ξ_z) / 4
@@ -1465,7 +1465,7 @@ function reference_coordinates(::CrouzeixRaviart)
             Vec{2, Float64}((0.5, 0.0))]
 end
 
-function shape_value(ip::CrouzeixRaviart{RefTriangle, 1}, ξ::Vec{2}, i::Int)
+function reference_shape_value(ip::CrouzeixRaviart{RefTriangle, 1}, ξ::Vec{2}, i::Int)
     ξ_x = ξ[1]
     ξ_y = ξ[2]
     i == 1 && return 2*ξ_x + 2*ξ_y - 1
@@ -1508,38 +1508,38 @@ InterpolationInfo(ip::VectorizedInterpolation) = InterpolationInfo(ip.ip, get_n_
 function getnbasefunctions(ipv::VectorizedInterpolation{vdim}) where vdim
     return vdim * getnbasefunctions(ipv.ip)
 end
-function shape_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::Vec{refdim, T}, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T}
+function reference_shape_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::Vec{refdim, T}, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T}
     i0, c0 = divrem(I - 1, vdim)
     i = i0 + 1
     c = c0 + 1
-    v = shape_value(ipv.ip, ξ, i)
+    v = reference_shape_value(ipv.ip, ξ, i)
     return Vec{vdim, T}(j -> j == c ? v : zero(v))
 end
 
 # vdim == refdim
-function shape_gradient_and_value(ipv::VectorizedInterpolation{dim, shape}, ξ::Vec{dim}, I::Int) where {dim, shape <: AbstractRefShape{dim}}
-    return invoke(shape_gradient_and_value, Tuple{Interpolation, Vec, Int}, ipv, ξ, I)
+function reference_shape_gradient_and_value(ipv::VectorizedInterpolation{dim, shape}, ξ::Vec{dim}, I::Int) where {dim, shape <: AbstractRefShape{dim}}
+    return invoke(reference_shape_gradient_and_value, Tuple{Interpolation, Vec, Int}, ipv, ξ, I)
 end
 # vdim != refdim
-function shape_gradient_and_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
+function reference_shape_gradient_and_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
     tosvec(v::Vec) = SVector((v...,))
     tovec(sv::SVector) = Vec((sv...))
-    val = shape_value(ipv, ξ, I)
-    grad = ForwardDiff.jacobian(sv -> tosvec(shape_value(ipv, tovec(sv), I)), tosvec(ξ))
+    val = reference_shape_value(ipv, ξ, I)
+    grad = ForwardDiff.jacobian(sv -> tosvec(reference_shape_value(ipv, tovec(sv), I)), tosvec(ξ))
     return grad, val
 end
 
 # vdim == refdim
-function shape_hessian_gradient_and_value(ipv::VectorizedInterpolation{dim, shape}, ξ::Vec{dim}, I::Int) where {dim, shape <: AbstractRefShape{dim}}
-    return invoke(shape_hessian_gradient_and_value, Tuple{Interpolation, Vec, Int}, ipv, ξ, I)
+function reference_shape_hessian_gradient_and_value(ipv::VectorizedInterpolation{dim, shape}, ξ::Vec{dim}, I::Int) where {dim, shape <: AbstractRefShape{dim}}
+    return invoke(reference_shape_hessian_gradient_and_value, Tuple{Interpolation, Vec, Int}, ipv, ξ, I)
 end
 # vdim != refdim
-function shape_hessian_gradient_and_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
-    _shape_hessian_gradient_and_value_static_array(ipv, ξ, I)
+function reference_shape_hessian_gradient_and_value(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
+    _reference_shape_hessian_gradient_and_value_static_array(ipv, ξ, I)
 end
-function _shape_hessian_gradient_and_value_static_array(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
+function _reference_shape_hessian_gradient_and_value_static_array(ipv::VectorizedInterpolation{vdim, shape}, ξ::V, I::Int) where {vdim, refdim, shape <: AbstractRefShape{refdim}, T, V <: Vec{refdim, T}}
     # Load with dual numbers and compute the value
-    f = x -> shape_value(ipv, x, I)
+    f = x -> reference_shape_value(ipv, x, I)
     ξd =  Tensors._load(Tensors._load(ξ, ForwardDiff.Tag(f, V)), ForwardDiff.Tag(f, V))
     value_hess = f(ξd)
     # Extract the value and gradient

--- a/test/test_deprecations.jl
+++ b/test/test_deprecations.jl
@@ -83,9 +83,9 @@ end
 @testset "Ferrite.value and Ferrite.derivative" begin
     ip = Lagrange{RefQuadrilateral, 1}()
     ξ = zero(Vec{2})
-    @test (@test_deprecated Ferrite.value(ip, ξ)) == [shape_value(ip, ξ, i) for i in 1:getnbasefunctions(ip)]
-    @test (@test_deprecated Ferrite.derivative(ip, ξ)) == [shape_gradient(ip, ξ, i) for i in 1:getnbasefunctions(ip)]
-    @test (@test_deprecated Ferrite.value(ip, 1, ξ)) == shape_value(ip, ξ, 1)
+    @test (@test_deprecated Ferrite.value(ip, ξ)) == [Ferrite.reference_shape_value(ip, ξ, i) for i in 1:getnbasefunctions(ip)]
+    @test (@test_deprecated Ferrite.derivative(ip, ξ)) == [Ferrite.reference_shape_gradient(ip, ξ, i) for i in 1:getnbasefunctions(ip)]
+    @test (@test_deprecated Ferrite.value(ip, 1, ξ)) == Ferrite.reference_shape_value(ip, ξ, 1)
 end
 
 @testset "facesets" begin

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -1,3 +1,5 @@
+using Ferrite: reference_shape_value, reference_shape_gradient
+
 @testset "interpolations" begin
 
 @testset "Value Type $value_type" for value_type in (Float32, Float64)
@@ -72,7 +74,7 @@
         n_basefuncs = getnbasefunctions(interpolation)
         coords = Ferrite.reference_coordinates(interpolation)
         @test length(coords) == n_basefuncs
-        f(x) = [shape_value(interpolation, Tensor{1, ref_dim}(x), i) for i in 1:n_basefuncs]
+        f(x) = [reference_shape_value(interpolation, Tensor{1, ref_dim}(x), i) for i in 1:n_basefuncs]
 
         #TODO prefer this test style after 1.6 is removed from CI
         # @testset let x = sample_random_point(ref_shape) # not compatible with Julia 1.6
@@ -80,13 +82,13 @@
         random_point_testset = @testset "Random point test" begin
             # Check gradient evaluation
             @test vec(ForwardDiff.jacobian(f, Array(x))') ≈
-                reinterpret(value_type, [shape_gradient(interpolation, x, i) for i in 1:n_basefuncs])
+                reinterpret(value_type, [reference_shape_gradient(interpolation, x, i) for i in 1:n_basefuncs])
             # Check partition of unity at random point.
-            @test sum([shape_value(interpolation, x, i) for i in 1:n_basefuncs]) ≈ 1.0
+            @test sum([reference_shape_value(interpolation, x, i) for i in 1:n_basefuncs]) ≈ 1.0
             # Check if the important functions are consistent
-            @test_throws ArgumentError shape_value(interpolation, x, n_basefuncs+1)
+            @test_throws ArgumentError reference_shape_value(interpolation, x, n_basefuncs+1)
             # Idempotency test
-            @test shape_value(interpolation, x, n_basefuncs) == shape_value(interpolation, x, n_basefuncs)
+            @test reference_shape_value(interpolation, x, n_basefuncs) == reference_shape_value(interpolation, x, n_basefuncs)
         end
         # Remove after 1.6 is removed from CI (see above)
         # Show coordinate in case failure (see issue #811)
@@ -118,14 +120,14 @@
 
         # Check for evaluation type correctness of interpolation
         @testset "return type correctness dof $dof" for dof in 1:n_basefuncs
-            @test (@inferred shape_value(interpolation, x, dof)) isa value_type
-            @test (@inferred shape_gradient(interpolation, x, dof)) isa Vec{ref_dim, value_type}
+            @test (@inferred reference_shape_value(interpolation, x, dof)) isa value_type
+            @test (@inferred reference_shape_gradient(interpolation, x, dof)) isa Vec{ref_dim, value_type}
         end
 
         # Check for dirac delta property of interpolation
         @testset "dirac delta property of dof $dof" for dof in 1:n_basefuncs
             for k in 1:n_basefuncs
-                N_dof = shape_value(interpolation, coords[dof], k)
+                N_dof = reference_shape_value(interpolation, coords[dof], k)
                 if k == dof
                     @test N_dof ≈ 1.0
                 else
@@ -196,8 +198,8 @@
         # Check for evaluation type correctness of vectorized interpolation
         v_interpolation_3 = interpolation^ref_dim
         @testset "vectorized case of return type correctness of dof $dof" for dof in 1:n_basefuncs
-            @test @inferred(shape_value(v_interpolation_1, x, dof)) isa Vec{2, value_type}
-            @test @inferred(shape_gradient(v_interpolation_3, x, dof)) isa Tensor{2, ref_dim, value_type}
+            @test @inferred(reference_shape_value(v_interpolation_1, x, dof)) isa Vec{2, value_type}
+            @test @inferred(reference_shape_gradient(v_interpolation_3, x, dof)) isa Tensor{2, ref_dim, value_type}
         end
     end # correctness testset
 
@@ -224,9 +226,9 @@ end
     ξ = rand(Vec{3,Float64})
     for I in 1:getnbasefunctions(ip)
         #Call StaticArray-version
-        H_sa, G_sa, V_sa = Ferrite._shape_hessian_gradient_and_value_static_array(ip, ξ, I)
+        H_sa, G_sa, V_sa = Ferrite._reference_shape_hessian_gradient_and_value_static_array(ip, ξ, I)
         #Call tensor AD version
-        H, G, V = Ferrite.shape_hessian_gradient_and_value(ip, ξ, I)
+        H, G, V = Ferrite.reference_shape_hessian_gradient_and_value(ip, ξ, I)
 
         @test V ≈ V_sa
         @test G ≈ G_sa
@@ -239,8 +241,8 @@ end
     ξ = rand(Vec{2, Float64})
     for ipv_ind in 1:getnbasefunctions(ipv)
         ips_ind, v_ind = fldmod1(ipv_ind, vdim)
-        H, G, V = Ferrite.shape_hessian_gradient_and_value(ipv, ξ, ipv_ind)
-        h, g, v = Ferrite.shape_hessian_gradient_and_value(ips, ξ, ips_ind)
+        H, G, V = Ferrite.reference_shape_hessian_gradient_and_value(ipv, ξ, ipv_ind)
+        h, g, v = Ferrite.reference_shape_hessian_gradient_and_value(ips, ξ, ips_ind)
         @test h ≈ H[v_ind, :, :]
         @test g ≈ G[v_ind, :]
         @test v ≈ V[v_ind]

--- a/test/test_quadrules.jl
+++ b/test/test_quadrules.jl
@@ -1,3 +1,5 @@
+using Ferrite: reference_shape_value
+
 @testset "Quadrature testing" begin
     ref_tet_vol(dim) = 1 / factorial(dim)
     ref_square_vol(dim) = 2^dim
@@ -87,12 +89,12 @@
 
                     xface = zero(Vec_t)
                     for i in 1:getnbasefunctions(ipface)
-                        xface += Ferrite.shape_value(ipface, ξface, i) * fcoords[i]
+                        xface += reference_shape_value(ipface, ξface, i) * fcoords[i]
                     end
 
                     xcell = zero(Vec_t)
                     for i in 1:getnbasefunctions(ipcell)
-                        xcell += shape_value(ipcell, ξcell, i) * ccoords[i]
+                        xcell += reference_shape_value(ipcell, ξcell, i) * ccoords[i]
                     end
 
                     @test xcell ≈ xface

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,5 +1,7 @@
 # Some utility functions for testing Ferrite.jl
 
+using Ferrite: reference_shape_value
+
 #####################################
 # Volume for the reference elements #
 #####################################
@@ -303,9 +305,9 @@ function function_value_from_physical_coord(interpolation::Interpolation, cell_c
     scalar_ip = interpolation isa Ferrite.ScalarInterpolation ? interpolation : interpolation.ip
     @assert length(ue) == n_basefuncs
     _, ξ = Ferrite.find_local_coordinate(scalar_ip, cell_coordinates, X; tol_norm=1e-16)
-    u = zero(shape_value(interpolation, ξ, 1))
+    u = zero(reference_shape_value(interpolation, ξ, 1))
     for j in 1:n_basefuncs
-        N = shape_value(interpolation, ξ, j)
+        N = reference_shape_value(interpolation, ξ, j)
         u += N * ue[j]
     end
     return u


### PR DESCRIPTION
This patch is a follow up to #721 and replaces `shape_value`, `shape_gradient` etc for interpolations, which return evaluations in the reference domain, with new functions `reference_shape_value`, `reference_shape_gradient`, etc. The new functions are public but not exported.

Separating these functions make it possible to support `reference_shape_value` etc for `CellValues` too in the future.