### PR TITLE
Flip the sign in the definition of jump for interface values

### DIFF
--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -239,13 +239,13 @@ function assemble_interface!(Ki::Matrix, iv::InterfaceValues, μ::Float64)
         dΓ = getdetJdV(iv, q_point)
         ## Loop over test shape functions
         for i in 1:getnbasefunctions(iv)
-            ## Multiply the jump by the normal, as the definition used in Ferrite doesn't include the normals.
-            δu_jump = shape_value_jump(iv, q_point, i) * normal
+            ## Multiply the jump by the negative normal to get the definition from the theory section.
+            δu_jump = shape_value_jump(iv, q_point, i) * (-normal)
             ∇δu_avg = shape_gradient_average(iv, q_point, i)
             ## Loop over trial shape functions
             for j in 1:getnbasefunctions(iv)
-                ## Multiply the jump by the normal, as the definition used in Ferrite doesn't include the normals.
-                u_jump = shape_value_jump(iv, q_point, j) * normal
+                ## Multiply the jump by the negative normal to get the definition from the theory section.
+                u_jump = shape_value_jump(iv, q_point, j) * (-normal)
                 ∇u_avg = shape_gradient_average(iv, q_point, j)
                 ## Add contribution to Ki
                 Ki[i, j] += -(δu_jump ⋅ ∇u_avg + ∇δu_avg ⋅ u_jump)*dΓ +  μ * (δu_jump ⋅ u_jump) * dΓ

--- a/src/FEValues/InterfaceValues.jl
+++ b/src/FEValues/InterfaceValues.jl
@@ -272,7 +272,7 @@ for (func,                      f_,               is_avg) in (
         function $(func)(iv::InterfaceValues, qp::Int, i::Int)
             f_here = $(f_)(iv, qp, i; here = true)
             f_there = $(f_)(iv, qp, i; here = false)
-            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_there - f_here))
         end
     end
 end
@@ -365,7 +365,7 @@ for (func,                          f_,                     is_avg) in (
             dof_range_there = (1:getnbasefunctions(iv.there)) .+ getnbasefunctions(iv.here)
             f_here = $(f_)(iv.here, qp, @view(u[dof_range_here]))
             f_there = $(f_)(iv.there, qp, @view(u[dof_range_there]))
-            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_there - f_here))
         end
         function $(func)(
                 iv::InterfaceValues, qp::Int,
@@ -374,7 +374,7 @@ for (func,                          f_,                     is_avg) in (
             )
             f_here = $(f_)(iv.here, qp, u, dof_range_here)
             f_there = $(f_)(iv.there, qp, u, dof_range_there)
-            return $(is_avg ? :((f_here + f_there) / 2) : :(f_here - f_there))
+            return $(is_avg ? :((f_here + f_there) / 2) : :(f_there - f_here))
         end
     end
 end

--- a/src/FEValues/InterfaceValues.jl
+++ b/src/FEValues/InterfaceValues.jl
@@ -211,13 +211,11 @@ function shape_value_average end
 """
     shape_value_jump(iv::InterfaceValues, qp::Int, i::Int)
 
-Compute the jump of the value of shape function `i` at quadrature point `qp` across the
-interface.
+Compute the jump of the value of shape function `i` at quadrature point `qp` across the interface in the default normal direction.
 
-This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
-``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
-multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
-
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} -\\vec{v}^\\text{here}``. To obtain the form,
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} \\cdot \\vec{n}^\\text{there} + \\vec{v}^\\text{here} \\cdot \\vec{n}^\\text{here}``,
+multiply by minus the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
 """
 function shape_value_jump end
 
@@ -232,12 +230,11 @@ function shape_gradient_average end
 """
     shape_gradient_jump(iv::InterfaceValues, qp::Int, i::Int)
 
-Compute the jump of the gradient of shape function `i` at quadrature point `qp` across the
-interface.
+Compute the jump of the gradient of shape function `i` at quadrature point `qp` across the interface in the default normal direction.
 
-This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
-``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
-multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} -\\vec{v}^\\text{here}``. To obtain the form,
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``,
+multiply by minus the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
 """
 function shape_gradient_jump end
 
@@ -292,11 +289,11 @@ function function_value_average end
     function_value_jump(iv::InterfaceValues, q_point::Int, u)
     function_value_jump(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
 
-Compute the jump of the function value at the quadrature point over the interface.
+Compute the jump of the function value at the quadrature point over the interface along the default normal direction.
 
-This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
-``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
-multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} -\\vec{v}^\\text{here}``. To obtain the form,
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``,
+multiply by minus the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
 """
 function function_value_jump end
 
@@ -312,11 +309,11 @@ function function_gradient_average end
     function_gradient_jump(iv::InterfaceValues, q_point::Int, u)
     function_gradient_jump(iv::InterfaceValues, q_point::Int, u, dof_range_here, dof_range_there)
 
-Compute the jump of the function gradient at the quadrature point over the interface.
+Compute the jump of the function gradient at the quadrature point over the interface along the default normal direction.
 
-This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{here} -\\vec{v}^\\text{there}``. to obtain the form
-``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``
-multiply by the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
+This function uses the definition ``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} -\\vec{v}^\\text{here}``. To obtain the form,
+``\\llbracket \\vec{v} \\rrbracket=\\vec{v}^\\text{there} ⋅ \\vec{n}^\\text{there} + \\vec{v}^\\text{here} ⋅ \\vec{n}^\\text{here}``,
+multiply by minus the outward facing normal to the first element's side of the interface (which is the default normal for [`getnormal`](@ref) with [`InterfaceValues`](@ref)).
 """
 function function_gradient_jump end
 

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -33,15 +33,15 @@
                         @test shapevalue ≈ shape_value(iv.there, qp, i - getnbasefunctions(iv.here))
                         @test shapegrad ≈ shape_gradient(iv.there, qp, i - getnbasefunctions(iv.here))
 
-                        @test shape_jump ≈ -shapevalue
-                        @test shapegrad_jump ≈ -shapegrad
+                        @test shape_jump ≈ shapevalue
+                        @test shapegrad_jump ≈ shapegrad
                     else
                         normal = getnormal(iv, qp)
                         @test shapevalue ≈ shape_value(iv.here, qp, i)
                         @test shapegrad ≈ shape_gradient(iv.here, qp, i)
 
-                        @test shape_jump ≈ shapevalue
-                        @test shapegrad_jump ≈ shapegrad
+                        @test shape_jump ≈ -shapevalue
+                        @test shapegrad_jump ≈ -shapegrad
                     end
 
                     @test shape_avg ≈ 0.5 * shapevalue


### PR DESCRIPTION
As discussed on [slack](https://julialang.slack.com/archives/C01R8JU271D/p1718911945839659), this makes the definitions consistent for interface elements (FerriteInterfaceElements.jl).