### PR TITLE
Add init_sparsity_pattern docstring to docs

### DIFF
--- a/docs/src/reference/sparsity_pattern.md
+++ b/docs/src/reference/sparsity_pattern.md
@@ -11,6 +11,7 @@ The following applies to all subtypes of `AbstractSparsityPattern`:
 
 ```@docs
 Ferrite.AbstractSparsityPattern
+init_sparsity_pattern
 add_sparsity_entries!
 add_cell_entries!
 add_interface_entries!


### PR DESCRIPTION
Realized this was missing when the links didn't work...