### PR TITLE
Throw when asking for dof indices of vectorized interpolations

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -404,28 +404,29 @@ function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_ind
     ip_infos = InterpolationInfo[]
     for interpolation in sdh.field_interpolations
         ip_info = InterpolationInfo(interpolation)
+        base_ip = get_base_interpolation(interpolation)
         begin
             next_dof_index = 1
-            for vdofs ∈ vertexdof_indices(interpolation)
+            for vdofs ∈ vertexdof_indices(base_ip)
                 for dof_index ∈ vdofs
                     @assert dof_index == next_dof_index "Vertex dof ordering not supported. Please consult the dev docs."
                     next_dof_index += 1
                 end
             end
-            for vdofs ∈ edgedof_interior_indices(interpolation)
+            for vdofs ∈ edgedof_interior_indices(base_ip)
                 for dof_index ∈ vdofs
                     @assert dof_index == next_dof_index "Edge dof ordering not supported. Please consult the dev docs."
                     next_dof_index += 1
                 end
             end
-            for vdofs ∈ facedof_interior_indices(interpolation)
+            for vdofs ∈ facedof_interior_indices(base_ip)
                 for dof_index ∈ vdofs
                     @assert dof_index == next_dof_index "Face dof ordering not supported. Please consult the dev docs."
                     next_dof_index += 1
                 end
             end
-            for dof_index ∈ volumedof_interior_indices(interpolation)
-                @assert next_dof_index <= dof_index <= getnbasefunctions(interpolation) "Cell dof ordering not supported. Please consult the dev docs."
+            for dof_index ∈ volumedof_interior_indices(base_ip)
+                @assert next_dof_index <= dof_index <= getnbasefunctions(base_ip) "Cell dof ordering not supported. Please consult the dev docs."
             end
         end
         push!(ip_infos, ip_info)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1505,6 +1505,18 @@ end
 get_n_copies(::VectorizedInterpolation{vdim}) where vdim = vdim
 InterpolationInfo(ip::VectorizedInterpolation) = InterpolationInfo(ip.ip, get_n_copies(ip))
 
+# Error when trying to get dof indicies from vectorized interpolations.
+# Currently, this should only be done for the scalar interpolation.
+function _entitydof_indices_vectorized_ip_error(f::Symbol)
+    throw(ArgumentError(string(f, " is not implemented for VectorizedInterpolations and should be called on the scalar base interpolation")))
+end
+vertexdof_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:vertexdof_indices)
+edgedof_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:edgedof_indices)
+facedof_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:facedof_indices)
+edgedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:edgedof_interior_indices)
+facedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:facedof_interior_indices)
+volumedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:volumedof_interior_indices)
+
 function getnbasefunctions(ipv::VectorizedInterpolation{vdim}) where vdim
     return vdim * getnbasefunctions(ipv.ip)
 end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1517,6 +1517,9 @@ edgedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectori
 facedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:facedof_interior_indices)
 volumedof_interior_indices(::VectorizedInterpolation) = _entitydof_indices_vectorized_ip_error(:volumedof_interior_indices)
 
+get_base_interpolation(ip::Interpolation) = ip
+get_base_interpolation(ip::VectorizedInterpolation) = ip.ip
+
 function getnbasefunctions(ipv::VectorizedInterpolation{vdim}) where vdim
     return vdim * getnbasefunctions(ipv.ip)
 end

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -249,4 +249,18 @@ end
     end
 end
 
+@testset "Errors for entitydof_indices on VectorizedInterpolations" begin
+    ip = Lagrange{RefQuadrilateral,2}()^2
+    @test_throws ArgumentError Ferrite.vertexdof_indices(ip)
+    @test_throws ArgumentError Ferrite.edgedof_indices(ip)
+    @test_throws ArgumentError Ferrite.facedof_indices(ip)
+    @test_throws ArgumentError Ferrite.facetdof_indices(ip)
+
+    @test_throws ArgumentError Ferrite.edgedof_interior_indices(ip)
+    @test_throws ArgumentError Ferrite.facedof_interior_indices(ip)
+    @test_throws ArgumentError Ferrite.volumedof_interior_indices(ip)
+    @test_throws ArgumentError Ferrite.facetdof_interior_indices(ip)
+end
+
+
 end # testset


### PR DESCRIPTION
Master
```julia
ip = Lagrange{RefQuadrilateral,2}()
Ferrite.facedof_indices(ip)   # ((1, 2, 3, 4, 5, 6, 7, 8, 9),)
Ferrite.facedof_indices(ip^2) # ((),)
```
The last call errors with this PR. 
This works for `<entity>dof_indices`, `dirichlet_<entity>dof_indices`, and `<entity>dof_interior_indices`.

Example for when this behavior gives a problem,
```julia
julia> Ferrite.BCValues(ip, ip, FacetIndex)
Ferrite.BCValues{Float64}([1.0 0.0 0.0; 0.0 1.0 0.0; … ; 0.0 0.0 0.0; 0.0 0.0 0.0;;; 0.0 0.0 0.0; 1.0 0.0 0.0; … ; 0.0 0.0 0.0; 0.0 0.0 0.0;;; 0.0 0.0 0.0; 0.0 0.0 0.0; … ; 0.0 0.0 0.0; 0.0 0.0 0.0;;; 0.0 1.0 0.0; 0.0 0.0 0.0; … ; 0.0 0.0 1.0; 0.0 0.0 0.0], [3, 3, 3, 3], 0)

julia> Ferrite.BCValues(ip^2, ip^2, FacetIndex)
Ferrite.BCValues{Float64}(Array{Float64, 3}(undef, 18, 0, 4), [0, 0, 0, 0], 0)
```
The last call errors with this PR.

Of course, it could be discussed if these calls should work and return the correct indices as a "true" vector interpolation should (that does make sense to me), but there are some performance pitfalls that could occur if that is passed around, so for now I suggest erroring, and then we can add support for this in the future if desired. 