### PR TITLE
Rename VTKFile to VTKGridFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@ more discussion).
   -     vtk_point_data(vtk, nodal_data, "my node data")
   -     vtk_point_data(vtk, proj, projected_data, "my projected data")
   -     vtk_cell_data(vtk, proj, projected_data, "my projected data")
-  + VTKFile(name, dh) do vtk
+  + VTKGridFile(name, dh) do vtk
   +     write_solution(vtk, dh, a)
   +     write_node_data(vtk, nodal_data, "my node data")
   +     write_projection(vtk, proj, projected_data, "my projected data")
@@ -427,8 +427,8 @@ more discussion).
   omitting type piracy, ([#835][github-835]) implemented `isequal` and `hash` for `BoundaryIndex` datatypes.
 
 - **VTK export**: Ferrite no longer extends methods from `WriteVTK.jl`, instead the new types
-  `VTKFile` and `VTKFileCollection` should be used instead. New methods exists for writing to
-  a `VTKFile`, e.g. `write_solution`, `write_cell_data`, `write_node_data`, and `write_projection`.
+  `VTKGridFile` and `VTKFileCollection` should be used instead. New methods exists for writing to
+  a `VTKGridFile`, e.g. `write_solution`, `write_cell_data`, `write_node_data`, and `write_projection`.
   See [#692][github-692].
 
 - **Definitions**: Previously, `face` and `edge` referred to codimension 1 relative reference shape.

--- a/docs/src/literate-gallery/helmholtz.jl
+++ b/docs/src/literate-gallery/helmholtz.jl
@@ -161,7 +161,7 @@ K, f = doassemble(cellvalues, facetvalues, K, dh);
 apply!(K, f, dbcs)
 u = Symmetric(K) \ f;
 
-vtk = VTKFile("helmholtz", dh)
+vtk = VTKGridFile("helmholtz", dh)
 write_solution(vtk, dh, u)
 close(vtk)
 using Test #src

--- a/docs/src/literate-gallery/landau.jl
+++ b/docs/src/literate-gallery/landau.jl
@@ -114,7 +114,7 @@ end
 
 # utility to quickly save a model
 function save_landau(path, model, dofs=model.dofs)
-    VTKFile(path, model.dofhandler) do vtk
+    VTKGridFile(path, model.dofhandler) do vtk
         write_solution(vtk, model.dofhandler, dofs)
     end
 end

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -504,7 +504,7 @@ function topopt(ra,ρ,n,filename; output=:false)
             i = @sprintf("%3.3i", it)
             filename_it = string(filename, "_", i)
 
-            VTKFile(filename_it, grid) do vtk
+            VTKGridFile(filename_it, grid) do vtk
                 write_cell_data(vtk, χ, "density")
             end
         end
@@ -512,7 +512,7 @@ function topopt(ra,ρ,n,filename; output=:false)
 
     ## export converged results
     if(!output)
-        VTKFile(filename, grid) do vtk
+        VTKGridFile(filename, grid) do vtk
             write_cell_data(vtk, χ, "density")
         end
     end

--- a/docs/src/literate-howto/postprocessing.jl
+++ b/docs/src/literate-howto/postprocessing.jl
@@ -89,7 +89,7 @@ q_projected = project(projector, q_gp, qr);
 # To visualize the heat flux, we export the projected field `q_projected`
 # to a VTK-file, which can be viewed in e.g. [ParaView](https://www.paraview.org/).
 # The result is also visualized in *Figure 1*.
-VTKFile("heat_equation_flux", grid) do vtk
+VTKGridFile("heat_equation_flux", grid) do vtk
     write_projection(vtk, projector, q_projected, "q")
 end;
 

--- a/docs/src/literate-howto/threaded_assembly.jl
+++ b/docs/src/literate-howto/threaded_assembly.jl
@@ -25,7 +25,7 @@ function create_example_2d_grid()
     grid = generate_grid(Quadrilateral, (10, 10), Vec{2}((0.0, 0.0)), Vec{2}((10.0, 10.0)))
     colors_workstream = create_coloring(grid; alg=ColoringAlgorithm.WorkStream)
     colors_greedy = create_coloring(grid; alg=ColoringAlgorithm.Greedy)
-    VTKFile("colored", grid) do vtk
+    VTKGridFile("colored", grid) do vtk
         Ferrite.write_cell_colors(vtk, grid, colors_workstream, "workstream-coloring")
         Ferrite.write_cell_colors(vtk, grid, colors_greedy, "greedy-coloring")
     end

--- a/docs/src/literate-tutorials/computational_homogenization.jl
+++ b/docs/src/literate-tutorials/computational_homogenization.jl
@@ -519,7 +519,7 @@ round.(ev; digits=-8)
 
 uM = zeros(ndofs(dh))
 
-VTKFile("homogenization", dh) do vtk
+VTKGridFile("homogenization", dh) do vtk
     for i in 1:3
         ## Compute macroscopic solution
         apply_analytical!(uM, dh, :u, x -> εᴹ[i] ⋅ x)

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -334,7 +334,7 @@ K, f = assemble_global(cellvalues, facetvalues, interfacevalues, K, dh, order, d
 
 apply!(K, f, ch)
 u = K \ f;
-VTKFile("dg_heat_equation", dh) do vtk
+VTKGridFile("dg_heat_equation", dh) do vtk
     write_solution(vtk, dh, u)
 end;
 

--- a/docs/src/literate-tutorials/heat_equation.jl
+++ b/docs/src/literate-tutorials/heat_equation.jl
@@ -213,7 +213,7 @@ u = K \ f;
 # ### Exporting to VTK
 # To visualize the result we export the grid and our field `u`
 # to a VTK-file, which can be viewed in e.g. [ParaView](https://www.paraview.org/).
-VTKFile("heat_equation", dh) do vtk
+VTKGridFile("heat_equation", dh) do vtk
     write_solution(vtk, dh, u)
 end
 

--- a/docs/src/literate-tutorials/hyperelasticity.jl
+++ b/docs/src/literate-tutorials/hyperelasticity.jl
@@ -408,7 +408,7 @@ function solve()
 
     ## Save the solution
     @timeit "export" begin
-        VTKFile("hyperelasticity", dh) do vtk
+        VTKGridFile("hyperelasticity", dh) do vtk
             write_solution(vtk, dh, u)
         end
     end

--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -271,7 +271,7 @@ function solve(ν, interpolation_u, interpolation_p)
     filename = "cook_" * (interpolation_u == Lagrange{RefTriangle, 1}()^2 ? "linear" : "quadratic") *
                          "_linear"
 
-    VTKFile(filename, grid) do vtk
+    VTKGridFile(filename, grid) do vtk
         write_solution(vtk, dh, u)
         for i in 1:3, j in 1:3
             σij = [x[i, j] for x in σ]

--- a/docs/src/literate-tutorials/linear_shell.jl
+++ b/docs/src/literate-tutorials/linear_shell.jl
@@ -113,7 +113,7 @@ a = K\f
 
 # Output results.
 #+
-VTKFile("linear_shell", dh) do vtk
+VTKGridFile("linear_shell", dh) do vtk
     write_solution(vtk, dh, a)
 end
 

--- a/docs/src/literate-tutorials/plasticity.jl
+++ b/docs/src/literate-tutorials/plasticity.jl
@@ -344,7 +344,7 @@ function solve()
         mises_values[el] /= length(cell_states) # average von Mises stress
         κ_values[el] /= length(cell_states)     # average drag stress
     end
-    VTKFile("plasticity", dh) do vtk
+    VTKGridFile("plasticity", dh) do vtk
         write_solution(vtk, dh, u) # displacement field
         write_cell_data(vtk, mises_values, "von Mises [Pa]")
         write_cell_data(vtk, κ_values, "Drag stress [Pa]")

--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -514,7 +514,7 @@ function main()
     u = K \ f
     apply!(u, ch)
     ## Export the solution
-    VTKFile("stokes-flow", grid) do vtk
+    VTKGridFile("stokes-flow", grid) do vtk
         write_solution(vtk, dh, u)
     end
 

--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -24,7 +24,7 @@ PointLocation
 
 ## VTK Export
 ```@docs
-VTKFile
+VTKGridFile
 VTKFileCollection
 addstep!
 write_solution

--- a/docs/src/topics/export.md
+++ b/docs/src/topics/export.md
@@ -16,7 +16,7 @@ the exporting.
 
 The following structure can be used to write various output to a vtk-file:
 ```@example export
-VTKFile("my_solution", grid) do vtk
+VTKGridFile("my_solution", grid) do vtk
     write_solution(vtk, dh, u)
 end;
 ```
@@ -33,7 +33,7 @@ where `write_solution` is just one example of the following functions that can b
 
 Instead of using the `do`-block, it is also possible to do
 ```@example export
-vtk = VTKFile("my_solution", grid)
+vtk = VTKGridFile("my_solution", grid)
 write_solution(vtk, dh, u)
 # etc.
 close(vtk);
@@ -44,7 +44,7 @@ The data written by `write_solution`, `write_cell_data`, `write_node_data`, and 
 For simulations with multiple time steps, typically one `VTK` (`.vtu`) file is written
 for each time step. In order to connect the actual time with each of these files,
 a `VTKFileCollection` can be used, which will write one paraview datafile (`.pvd`)
-file and one `VTKFile` (`.vtu`) for each time step.
+file and one `VTKGridFile` (`.vtu`) for each time step.
 
 ```@example export
 pvd = VTKFileCollection("my_results", grid)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -26,7 +26,7 @@ VTKGridFile(filename, grid) do vtk
 end
 ```
 """
-struct VTKGridFile{VTK<:WriteVTK.VTKGridFile}
+struct VTKGridFile{VTK<:WriteVTK.DatasetFile}
     vtk::VTK
 end
 function VTKGridFile(filename::String, dh::DofHandler; kwargs...)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -99,7 +99,7 @@ function WriteVTK.vtk_grid(::String, ::Union{AbstractGrid,AbstractDofHandler}; k
     throw(DeprecationError(
         "The vtk interface has been updated in Ferrite v1.0. " *
         "See https://github.com/Ferrite-FEM/Ferrite.jl/pull/692. " *
-        "Use VTKFile to open a vtk file, and the functions " *
+        "Use VTKGridFile to open a vtk file, and the functions " *
         "write_solution, write_cell_data, and write_projection to save data."
     ))
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -433,3 +433,8 @@ export create_sparsity_pattern
 function create_sparsity_pattern(args...)
     throw(DeprecationError("create_sparsity_pattern(args...)" => "allocate_matrix(args...; kwargs...)"))
 end
+
+export VTKFile
+function VTKFile(args...)
+    throw(DeprecationError("VTKFile(args...)" => "VTKGridFile(args...)"))
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -170,7 +170,7 @@ export
     finish_assemble,
 
 # exporting data
-    VTKFile,
+    VTKGridFile,
     write_solution,
     write_cell_data,
     write_projection,

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1553,7 +1553,7 @@ end # testset
             @test norm(u_dbc) ≈ 3.8249286998373586
             @test norm(u_p) ≈ 3.7828270430540893
         end
-        # VTKFile("local_application_azero_$(azero)", grid) do vtk
+        # VTKGridFile("local_application_azero_$(azero)", grid) do vtk
         #     write_solution(vtk, dh, u_dbc, "_dbc")
         #     write_solution(vtk, dh, u_p, "_p")
         # end

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -38,7 +38,7 @@ end
         addnodeset!(grid, "middle-nodes", x -> norm(x) < radius)
 
         gridfilename = "grid-$(repr(celltype))"
-        VTKFile(gridfilename, grid) do vtk
+        VTKGridFile(gridfilename, grid) do vtk
             Ferrite.write_cellset(vtk, grid, "cell-1")
             Ferrite.write_cellset(vtk, grid, "middle-cells")
             Ferrite.write_nodeset(vtk, grid, "middle-nodes")
@@ -78,7 +78,7 @@ end
         apply!(u, ch)
 
         dofhandlerfilename = "dofhandler-$(repr(celltype))"
-        VTKFile(dofhandlerfilename, grid) do vtk
+        VTKGridFile(dofhandlerfilename, grid) do vtk
             Ferrite.write_constraints(vtk, ch)
             write_solution(vtk, dofhandler, u)
         end
@@ -119,7 +119,7 @@ close(csio)
     vector_data = [Vec{3}(ntuple(i->i, 3)) for j=1:8]
 
     filename_3d = "test_vtk_3d"
-    VTKFile(filename_3d, grid) do vtk
+    VTKGridFile(filename_3d, grid) do vtk
         write_node_data(vtk, sym_tensor_data, "symmetric tensor")
         write_node_data(vtk, tensor_data, "tensor")
         write_node_data(vtk, vector_data, "vector")
@@ -134,7 +134,7 @@ close(csio)
     vector_data = [Vec{2}(ntuple(i->i, 2)) for j=1:4]
 
     filename_2d = "test_vtk_2d"
-    VTKFile(filename_2d, grid) do vtk
+    VTKGridFile(filename_2d, grid) do vtk
         write_node_data(vtk, sym_tensor_data, "symmetric tensor")
         write_node_data(vtk, tensor_data, "tensor")
         write_node_data(vtk, tensor_data_1D, "tensor_1d")
@@ -722,7 +722,7 @@ end
                 addstep!(pvd1, t) do io
                     write_cell_data(io, celldata*n, "celldata")
                 end
-                vtk = VTKFile(string(fname, "2_", n), grid)
+                vtk = VTKGridFile(string(fname, "2_", n), grid)
                 write_cell_data(vtk, celldata*n, "celldata")
                 addstep!(pvd2, vtk, t)
                 @test !(isopen(vtk.vtk))

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -406,7 +406,7 @@ function test_export(;subset::Bool)
 
     mktempdir() do tmp
         fname = joinpath(tmp, "projected")
-        VTKFile(fname, grid) do vtk
+        VTKGridFile(fname, grid) do vtk
             write_projection(vtk, p, p_scalar, "p_scalar")
             write_projection(vtk, p, p_vec, "p_vec")
             write_projection(vtk, p, p_tens, "p_tens")

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -357,7 +357,7 @@ function test_2_element_heat_eq()
     gridfilename = "mixed_grid"
     addcellset!(grid, "cell-1", [1,])
     addcellset!(grid, "cell-2", [2,])
-    VTKFile(gridfilename, grid) do vtk
+    VTKGridFile(gridfilename, grid) do vtk
         Ferrite.write_cellset(vtk, grid, "cell-1")
         Ferrite.write_cellset(vtk, grid, "cell-2")
         write_solution(vtk, dh, u)
@@ -651,7 +651,7 @@ function test_vtk_export()
     close!(dh)
     u = collect(1:ndofs(dh))
     filename = "mixed_2d_grid"
-    VTKFile(filename, dh) do vtk
+    VTKGridFile(filename, dh) do vtk
         write_solution(vtk, dh, u)
     end
     sha = bytes2hex(open(SHA.sha1, filename*".vtu"))

--- a/test/test_vtk_export.jl
+++ b/test/test_vtk_export.jl
@@ -1,14 +1,14 @@
-@testset "VTKFile" begin #TODO: Move all vtk tests here
-    @testset "show(::VTKFile)" begin
+@testset "VTKGridFile" begin #TODO: Move all vtk tests here
+    @testset "show(::VTKGridFile)" begin
         mktempdir() do tmp
             grid = generate_grid(Quadrilateral, (2,2))
-            vtk = VTKFile(joinpath(tmp, "showfile"), grid)
+            vtk = VTKGridFile(joinpath(tmp, "showfile"), grid)
             showstring_open = sprint(show, MIME"text/plain"(), vtk)
-            @test startswith(showstring_open, "VTKFile for the open file")
+            @test startswith(showstring_open, "VTKGridFile for the open file")
             @test contains(showstring_open, "showfile.vtu")
             close(vtk)
             showstring_closed = sprint(show, MIME"text/plain"(), vtk)
-            @test startswith(showstring_closed, "VTKFile for the closed file")
+            @test startswith(showstring_closed, "VTKGridFile for the closed file")
             @test contains(showstring_closed, "showfile.vtu")
         end
     end
@@ -17,7 +17,7 @@
             grid = generate_grid(Quadrilateral, (4, 4))
             colors = create_coloring(grid)
             fname = joinpath(tmp, "colors")
-            VTKFile(fname, grid) do vtk
+            VTKGridFile(fname, grid) do vtk
                 Ferrite.write_cell_colors(vtk, grid, colors)
             end
             @test bytes2hex(open(SHA.sha1, fname*".vtu")) == "b804d0b064121b672d8e35bcff8446eda361cac3"
@@ -35,7 +35,7 @@
             add!(ch, Dirichlet(:u, getnodeset(grid, "nodeset"), x -> 0.0))
             close!(ch)
             fname = joinpath(tmp, "constraints")
-            VTKFile(fname, grid) do vtk
+            VTKGridFile(fname, grid) do vtk
                 Ferrite.write_constraints(vtk, ch)
             end
             @test bytes2hex(open(SHA.sha1, fname*".vtu")) == "31b506bd9729b11992f8bcb79a2191eb65d223bf"
@@ -50,10 +50,10 @@
             addcellset!(grid, "set2", 1:4)
             manual = joinpath(tmp, "manual")
             auto = joinpath(tmp, "auto")
-            VTKFile(manual, grid) do vtk
+            VTKGridFile(manual, grid) do vtk
                 Ferrite.write_cellset(vtk, grid, keys(Ferrite.getcellsets(grid)))
             end
-            VTKFile(auto, grid) do vtk
+            VTKGridFile(auto, grid) do vtk
                 Ferrite.write_cellset(vtk, grid)
             end
             @test bytes2hex(open(SHA.sha1, manual*".vtu")) == bytes2hex(open(SHA.sha1, auto*".vtu"))


### PR DESCRIPTION
xref #1004 

Does not solve #1004, but as pointed out by @termi-official, it is clear that having `Ferrite.VTKFile` (concrete type, wrapper of `WriteVTK.DatasetFile`) being something different than `WriteVTK.VTKFile` (abstract supertype of most `WriteVTK` filetypes) can be very confusing. 

