### PR TITLE
speed up adding sparsity pattern entries with coupling

### DIFF
--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -625,11 +625,14 @@ function _add_interface_entries!(
                     neighbor_dofs = celldofs(sdh_idx == 2 ? ic.a : ic.b)
                     neighbor_field_dofs = @view neighbor_dofs[dofrange2]
                     # Typical coupling procedure
-                    for (j, dof_j) in pairs(dofrange2), (i, dof_i) in pairs(dofrange1)
-                        # This line to avoid coupling the shared dof in continuous interpolations as cross-element. They're coupled in the local coupling matrix.
-                        (cell_field_dofs[i] ∈ neighbor_dofs || neighbor_field_dofs[j] ∈ cell_dofs) && continue
-                        _add_interface_entry(sp, coupling_sdh, dof_i, dof_j, cell_field_dofs, neighbor_field_dofs, i, j, keep_constrained, ch)
-                        _add_interface_entry(sp, coupling_sdh, dof_j, dof_i, neighbor_field_dofs, cell_field_dofs, j, i, keep_constrained, ch)
+                    for (j, dof_j) in pairs(dofrange2)
+                        # Avoid coupling the shared dof in continuous interpolations as cross-element. They're coupled in the local coupling matrix.
+                        neighbor_field_dofs[j] ∈ cell_dofs && continue
+                        for (i, dof_i) in pairs(dofrange1)
+                            cell_field_dofs[i] ∈ neighbor_dofs && continue
+                            _add_interface_entry(sp, coupling_sdh, dof_i, dof_j, cell_field_dofs, neighbor_field_dofs, i, j, keep_constrained, ch)
+                            _add_interface_entry(sp, coupling_sdh, dof_j, dof_i, neighbor_field_dofs, cell_field_dofs, j, i, keep_constrained, ch)
+                        end
                     end
                 end
             end


### PR DESCRIPTION
Ref https://github.com/Ferrite-FEM/Ferrite.jl/issues/993

As written then `in` check for `j` was performed on every iteration over `i`.

```
Before:
julia> @time allocate_matrix(dh; topology=top, interface_coupling = interface_coupling)
 25.123126 seconds (217.41 k allocations: 1.820 GiB, 0.87% gc time)


After:
julia> @time allocate_matrix(dh; topology=top, interface_coupling = interface_coupling)
 12.786278 seconds (217.84 k allocations: 1.821 GiB, 1.79% gc time)
```

I think the approach here of doing this `in` check like this has to be rethought do.