### PR TITLE
reduce chunk size of Hessian in Landau example to improve latency and performance

### DIFF
--- a/docs/src/literate-gallery/landau.jl
+++ b/docs/src/literate-gallery/landau.jl
@@ -68,7 +68,7 @@ function ThreadCache(dpc::Int, nodespercell, cvP::CellValues, modelparams, elpot
     element_coords   = zeros(Vec{3, Float64}, nodespercell)
     potfunc          = x -> elpotential(x, cvP, modelparams)
     gradconf         = GradientConfig(potfunc, zeros(dpc), Chunk{12}())
-    hessconf         = HessianConfig(potfunc, zeros(dpc), Chunk{12}())
+    hessconf         = HessianConfig(potfunc, zeros(dpc), Chunk{4}())
     return ThreadCache(cvP, element_indices, element_dofs, element_gradient, element_hessian, element_coords, potfunc, gradconf, hessconf)
 end
 


### PR DESCRIPTION
12 is a very big chunk size for a hessian because you end up with Duals of 12^2 + 12 + 1 numbers in them.

Running with the following model

```julia
model = LandauModel(α, G, (10, 10, 2), left, right, element_potential);
```

this changes the times from

```
First run
 36.561361 seconds (16.29 M allocations: 1.118 GiB, 1.40% gc time, 90.71% compilation time)
Second run
  2.889448 seconds (63.62 k allocations: 321.635 MiB, 1.80% gc time)
```

to
```
First run:
  4.490308 seconds (6.43 M allocations: 494.372 MiB, 1.63% gc time, 63.58% compilation time)
Second run
  1.673789 seconds (90.01 k allocations: 118.406 MiB, 0.73% gc time)
```

so both a latency and a perf improvement.
