### PR TITLE
Add updated function names in devdocs

### DIFF
--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -11,13 +11,15 @@ parametrized by the reference element and its characteristic order.
 Ferrite.getrefdim(::Interpolation)
 Ferrite.getrefshape(::Interpolation)
 Ferrite.getorder(::Interpolation)
-Ferrite.shape_gradient(::Interpolation, ::Vec, ::Int)
-Ferrite.shape_gradient_and_value
+Ferrite.reference_shape_gradient(::Interpolation, ::Vec, ::Int)
+Ferrite.reference_shape_gradient_and_value(::Interpolation, ::Vec, ::Int)
+Ferrite.reference_shape_hessian_gradient_and_value(::Interpolation, ::Vec, ::Int)
 Ferrite.boundarydof_indices
 Ferrite.dirichlet_boundarydof_indices
 Ferrite.reference_shape_values!
-Ferrite.shape_gradients!
-Ferrite.shape_gradients_and_values!
+Ferrite.reference_shape_gradients!
+Ferrite.reference_shape_gradients_and_values!
+Ferrite.reference_shape_hessians_gradients_and_values!
 ```
 
 ### Required methods to implement for all subtypes of `Interpolation` to define a new finite element


### PR DESCRIPTION
Fixes devdocs to consider #997, and adds the hessian functions from #938 