### PR TITLE
Fix wrong function to save pvd files in examples and docs

### DIFF
--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -339,7 +339,7 @@ function solve(interpolation_u, interpolation_p)
             pvd[t] = vtk
         end
     end;
-    close(pvd);
+    vtk_save(pvd);
     vol_def = calculate_volume_deformed_mesh(w, dh, cellvalues_u);
     print("Deformed volume is $vol_def")
     return vol_def;

--- a/docs/src/literate-tutorials/ns_vs_diffeq.jl
+++ b/docs/src/literate-tutorials/ns_vs_diffeq.jl
@@ -583,7 +583,7 @@ for (step, (u,t)) in enumerate(intervals(integrator))
         pvd[t] = vtk
     end
 end
-close(pvd);
+vtk_save(pvd);
 
 
 using Test                                                                      #hide

--- a/docs/src/literate-tutorials/porous_media.jl
+++ b/docs/src/literate-tutorials/porous_media.jl
@@ -354,7 +354,7 @@ function solve(dh, ch, domains; Δt=0.025, t_total=1.0)
             pvd[t] = vtk
         end
     end
-    close(pvd);
+    vtk_save(pvd);
 end;
 
 # Finally we call the functions to actually run the code

--- a/docs/src/literate-tutorials/reactive_surface.jl
+++ b/docs/src/literate-tutorials/reactive_surface.jl
@@ -313,7 +313,7 @@ function gray_scott_on_sphere(material::GrayScottMaterial, Δt::Real, T::Real, r
         uₜ₋₁ .= uₜ
     end
 
-    close(pvd);
+    vtk_save(pvd);
 end
 
 ## This parametrization gives the spot pattern shown in the gif above.

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -217,7 +217,7 @@ for (step, t) in enumerate(Δt:Δt:T)
     uₙ .= u
 end
 # In order to use the .pvd file we need to store it to the disk, which is done by:
-close(pvd);
+vtk_save(pvd);
 
 #md # ## [Plain program](@id transient_heat_equation-plain-program)
 #md #

--- a/docs/src/topics/export.md
+++ b/docs/src/topics/export.md
@@ -56,6 +56,6 @@ for (step, t) in enumerate(range(0, 1, 5))
         pvd[t] = vtk
     end
 end
-close(pvd);
+vtk_save(pvd);
 ```
 See [Transient heat equation](@ref tutorial-transient-heat-equation) for an example


### PR DESCRIPTION
This was a mistake in #1015, `close` is not defined for `pvd` files by `WriteVTK`, so users have to use `vtk_save` instead for saving `pvd` files. 