### PR TITLE
Clean up doc remaints of old face definition

### DIFF
--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -141,7 +141,7 @@ function create_dofhandler(grid, ipu, ipp)
 end;
 
 # We are simulating a uniaxial tensile loading of a unit cube. Hence we apply a displacement field (`:u`) in `x` direction on the right face.
-# The left, bottom and back faces are fixed in the `x`, `y` and `z` components of the displacement so as to emulate the uniaxial nature
+# The left, bottom and back facets are fixed in the `x`, `y` and `z` components of the displacement so as to emulate the uniaxial nature
 # of the loading.
 function create_bc(dh)
     dbc = ConstraintHandler(dh)

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -67,7 +67,7 @@
 # First we load all necessary packages.
 using Ferrite, SparseArrays, LinearAlgebra, Tensors, Printf
 # Next, we create a simple square grid of the size 2x1. We apply a fixed Dirichlet boundary condition
-# to the left face set, called `clamped`. On the right face, we create a small set `traction`, where we
+# to the left facet set, called `clamped`. On the right facet, we create a small set `traction`, where we
 # will later apply a force in negative y-direction.
 
 function create_grid(n)
@@ -186,10 +186,10 @@ end
 #md nothing # hide
 
 # For the Laplacian we need some neighboorhood information which is constant throughout the analysis so we compute it once and cache it.
-# We iterate through each face of each element,
-# obtaining the neighboring element by using the `getneighborhood` function. For boundary faces,
+# We iterate through each facet of each element,
+# obtaining the neighboring element by using the `getneighborhood` function. For boundary facets,
 # the function call will return an empty object. In that case we use the dictionary to instead find the opposite
-# face, as discussed in the introduction.
+# facet, as discussed in the introduction.
 
 function cache_neighborhood(dh, topology)
     nbgs = Vector{Vector{Int}}(undef, getncells(dh.grid))
@@ -202,8 +202,8 @@ function cache_neighborhood(dh, topology)
         for j in 1:_nfacets
             nbg_cellid = getneighborhood(topology, dh.grid, FacetIndex(i,j))
             if(!isempty(nbg_cellid))
-                nbg[j] = first(nbg_cellid)[1] # assuming only one face neighbor per cell
-            else # boundary face
+                nbg[j] = first(nbg_cellid)[1] # assuming only one facet neighbor per cell
+            else # boundary facet
                 nbg[j] = first(getneighborhood(topology, dh.grid, FacetIndex(i,opp[j])))[1]
             end
         end

--- a/docs/src/literate-tutorials/computational_homogenization.jl
+++ b/docs/src/literate-tutorials/computational_homogenization.jl
@@ -241,8 +241,8 @@ close!(ch_dirichlet)
 update!(ch_dirichlet, 0.0)
 
 # For periodic boundary conditions we use the [`PeriodicDirichlet`](@ref) constraint type,
-# which is very similar to the `Dirichlet` type, but instead of a passing a faceset we pass
-# a vector with "face pairs", i.e. the mapping between mirror and image parts of the
+# which is very similar to the `Dirichlet` type, but instead of a passing a facetset we pass
+# a vector with "facet pairs", i.e. the mapping between mirror and image parts of the
 # boundary. In this example the `"left"` and `"bottom"` boundaries are mirrors, and the
 # `"right"` and `"top"` boundaries are the mirrors.
 

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -177,7 +177,7 @@ add!(ch, Dirichlet(:u, getfacetset(grid, "right"), (x, t) -> 1.0))
 add!(ch, Dirichlet(:u, getfacetset(grid, "left"), (x, t) -> -1.0))
 close!(ch);
 
-# Furthermore, we define $\partial \Omega_N$ as the `union` of the face sets with Neumann boundary conditions for later use
+# Furthermore, we define $\partial \Omega_N$ as the `union` of the facet sets with Neumann boundary conditions for later use
 ∂Ωₙ = union(
     getfacetset(grid, "top"),
     getfacetset(grid, "bottom"),
@@ -189,7 +189,7 @@ close!(ch);
 # Now we have all the pieces needed to assemble the linear system, $K u = f$. Assembling of
 # the global system is done by looping over i) all the elements in order to compute the
 # element contributions ``K_e`` and ``f_e``, ii) all the interfaces to compute their
-# contributions ``K_i``, and iii) all the Neumann boundary faces to compute their
+# contributions ``K_i``, and iii) all the Neumann boundary facets to compute their
 # contributions ``f_e``. All these local contributions are then assembled into the
 # appropriate place in the global ``K`` and ``f``.
 #
@@ -200,7 +200,7 @@ close!(ch);
 # * `assemble_interface!` to compute the contribution ``K_i`` of surface integrals over an
 #   interface using `interfacevalues`.
 # * `assemble_boundary!` to compute the contribution ``f_e`` of surface integrals over a
-#   boundary face using `FacetValues`.
+#   boundary facet using `FacetValues`.
 
 function assemble_element!(Ke::Matrix, fe::Vector, cellvalues::CellValues)
     n_basefuncs = getnbasefunctions(cellvalues)
@@ -233,7 +233,7 @@ function assemble_interface!(Ki::Matrix, iv::InterfaceValues, μ::Float64)
     fill!(Ki, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(iv)
-        ## Get the normal to face A
+        ## Get the normal to facet A
         normal = getnormal(iv, q_point)
         ## Get the quadrature weight
         dΓ = getdetJdV(iv, q_point)
@@ -260,7 +260,7 @@ function assemble_boundary!(fe::Vector, fv::FacetValues)
     fill!(fe, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(fv)
-        ## Get the normal to face A
+        ## Get the normal to facet A
         normal = getnormal(fv, q_point)
         ## Get the quadrature weight
         ∂Ω = getdetJdV(fv, q_point)
@@ -277,8 +277,8 @@ end
 
 # #### Global assembly
 #
-# We define the function `assemble_global` to loop over all elements and internal faces
-# (interfaces), as well as the external faces involved in Neumann boundary conditions.
+# We define the function `assemble_global` to loop over all elements and internal facets
+# (interfaces), as well as the external facets involved in Neumann boundary conditions.
 
 function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, interfacevalues::InterfaceValues, K::SparseMatrixCSC, dh::DofHandler, order::Int, dim::Int)
     ## Allocate the element stiffness matrix and element force vector
@@ -315,9 +315,9 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
     end
     ## Loop over domain boundaries with Neumann boundary conditions
     for fc in FacetIterator(dh, ∂Ωₙ)
-        ## Reinitialize face_values_a for this boundary face
+        ## Reinitialize facetvalues for this boundary facet
         reinit!(facetvalues, fc)
-        ## Compute boundary face surface integrals contribution
+        ## Compute boundary facet surface integrals contribution
         assemble_boundary!(fe, facetvalues)
         ## Assemble fe into f
         assemble!(f, celldofs(fc), fe)

--- a/docs/src/literate-tutorials/heat_equation.jl
+++ b/docs/src/literate-tutorials/heat_equation.jl
@@ -82,7 +82,7 @@ ch = ConstraintHandler(dh);
 
 # Next we need to add constraints to `ch`. For this problem we define
 # homogeneous Dirichlet boundary conditions on the whole boundary, i.e.
-# the `union` of all the face sets on the boundary.
+# the `union` of all the facet sets on the boundary.
 ∂Ω = union(
     getfacetset(grid, "left"),
     getfacetset(grid, "right"),
@@ -91,7 +91,7 @@ ch = ConstraintHandler(dh);
 );
 
 # Now we are set up to define our constraint. We specify which field
-# the condition is for, and our combined face set `∂Ω`. The last
+# the condition is for, and our combined facet set `∂Ω`. The last
 # argument is a function of the form $f(\textbf{x})$ or $f(\textbf{x}, t)$,
 # where $\textbf{x}$ is the spatial coordinate and
 # $t$ the current time, and returns the prescribed value. Since the boundary condition in

--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -65,7 +65,7 @@ function create_dofhandler(grid, ipu, ipp)
     return dh
 end;
 
-# We also need to add Dirichlet boundary conditions on the `"clamped"` faceset.
+# We also need to add Dirichlet boundary conditions on the `"clamped"` facetset.
 # We specify a homogeneous Dirichlet bc on the displacement field, `:u`.
 function create_bc(dh)
     dbc = ConstraintHandler(dh)

--- a/docs/src/literate-tutorials/linear_elasticity.jl
+++ b/docs/src/literate-tutorials/linear_elasticity.jl
@@ -113,7 +113,7 @@ FerriteGmsh.Gmsh.finalize(); #hide
 # The generated grid lacks the facetsets for the boundaries, so we add them by using Ferrite's
 # [`addfacetset!`](@ref). It allows us to add facetsets to the grid based on coordinates.
 # Note that approximate comparison to 0.0 doesn't work well, so we use a tolerance instead.
-addfacetset!(grid, "top",    x -> x[2] ≈ 1.0) # faces for which x[2] ≈ 1.0 for all nodes
+addfacetset!(grid, "top",    x -> x[2] ≈ 1.0) # facets for which x[2] ≈ 1.0 for all nodes
 addfacetset!(grid, "left",   x -> abs(x[1]) < 1e-6)
 addfacetset!(grid, "bottom", x -> abs(x[2]) < 1e-6);
 
@@ -173,13 +173,13 @@ traction(x) = Vec(0.0, 20e3 * x[1]);
 function assemble_external_forces!(f_ext, dh, facetset, facetvalues, prescribed_traction)
     ## Create a temporary array for the facet's local contributions to the external force vector
     fe_ext = zeros(getnbasefunctions(facetvalues))
-    for face in FacetIterator(dh, facetset)
+    for facet in FacetIterator(dh, facetset)
         ## Update the facetvalues to the correct facet number
-        reinit!(facetvalues, face)
+        reinit!(facetvalues, facet)
         ## Reset the temporary array for the next facet
         fill!(fe_ext, 0.0)
         ## Access the cell's coordinates
-        cell_coordinates = getcoordinates(face)
+        cell_coordinates = getcoordinates(facet)
         for qp in 1:getnquadpoints(facetvalues)
             ## Calculate the global coordinate of the quadrature point.
             x = spatial_coordinate(facetvalues, qp, cell_coordinates)
@@ -192,7 +192,7 @@ function assemble_external_forces!(f_ext, dh, facetset, facetvalues, prescribed_
             end
         end
         ## Add the local contributions to the correct indices in the global external force vector
-        assemble!(f_ext, celldofs(face), fe_ext)
+        assemble!(f_ext, celldofs(facet), fe_ext)
     end
     return f_ext
 end

--- a/docs/src/literate-tutorials/plasticity.jl
+++ b/docs/src/literate-tutorials/plasticity.jl
@@ -229,10 +229,10 @@ function symmetrize_lower!(K)
     end
 end;
 
-function doassemble_neumann!(r, dh, faceset, facetvalues, t)
+function doassemble_neumann!(r, dh, facetset, facetvalues, t)
     n_basefuncs = getnbasefunctions(facetvalues)
     re = zeros(n_basefuncs)                      # element residual vector
-    for fc in FacetIterator(dh, faceset)
+    for fc in FacetIterator(dh, facetset)
         ## Add traction as a negative contribution to the element residual `re`:
         reinit!(facetvalues, fc)
         fill!(re, 0)

--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -211,15 +211,6 @@ function setup_grid(h=0.05)
     ## Finalize the Gmsh library
     Gmsh.finalize()
 
-    ## Temp fix for FerriteGmsh
-    ## for setname in ["Γ1", "Γ2", "Γ3", "Γ4"]
-    ##    faceset = grid.facesets[setname]
-    ##    edgeset = Set([EdgeIndex(f[1], f[2]) for f in faceset])
-    ##    grid.edgesets[setname] = edgeset
-    ##    delete!(grid.facesets, setname)
-    ## end
-    ## =#
-
     return grid
 end
 #md nothing #hide
@@ -232,7 +223,7 @@ end
 # velocity and `ipp` for the pressure. Note that we specify linear geometric mapping
 # (`ipg`) for both the velocity and pressure because our grid contains linear
 # triangles. However, since linear mapping is default this could have been skipped.
-# We also construct face-values for the pressure since we need to integrate along
+# We also construct facet-values for the pressure since we need to integrate along
 # the boundary when assembling the constraint matrix ``\underline{\underline{C}}``.
 
 function setup_fevalues(ipu, ipp, ipg)
@@ -267,7 +258,7 @@ end
 # Let's first discuss the assembly of the constraint matrix ``\underline{\underline{C}}``
 # and how to create an `AffineConstraint` from it. This is done in the
 # `setup_mean_constraint` function below. Assembling this is not so different from standard
-# assembly in Ferrite: we loop over all the faces, loop over the quadrature points, and loop
+# assembly in Ferrite: we loop over all the facets, loop over the quadrature points, and loop
 # over the shape functions. Note that since there is only one constraint the matrix will
 # only have one row.
 # After assembling `C` we construct an `AffineConstraint` from it. We select the constrained
@@ -339,14 +330,14 @@ end
 
 # We now setup all the boundary conditions in the `setup_constraints` function below.
 # Since the periodicity constraint for this example is between two boundaries which are not
-# parallel to each other we need to i) compute the mapping between each mirror face and the
-# corresponding image face (on the element level) and ii) describe the dof relation between
-# dofs on these two faces. In Ferrite this is done by defining a transformation of entities
+# parallel to each other we need to i) compute the mapping between each mirror facet and the
+# corresponding image facet (on the element level) and ii) describe the dof relation between
+# dofs on these two facets. In Ferrite this is done by defining a transformation of entities
 # on the image boundary such that they line up with the matching entities on the mirror
 # boundary. In this example we consider the inlet ``\Gamma_1`` to be the image, and the
 # outlet ``\Gamma_3`` to be the mirror. The necessary transformation to apply then becomes a
 # rotation of ``\pi/2`` radians around the out-of-plane axis. We set up the rotation matrix
-# `R`, and then compute the mapping between mirror and image faces using
+# `R`, and then compute the mapping between mirror and image facets using
 # [`collect_periodic_facets`](@ref) where the rotation is applied to the coordinates. In the
 # next step we construct the constraint using the [`PeriodicDirichlet`](@ref) constructor.
 # We pass the constructor the computed mapping, and also the rotation matrix. This matrix is

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -37,12 +37,12 @@ dbc1 = Dirichlet(
 ```
 
 The field name is given as a symbol, just like when the field was added to the dof handler,
-the part of the boundary where this constraint is active is given as a face set, and the
+the part of the boundary where this constraint is active is given as a facet set, and the
 function computing the prescribed value should be of the form `f(x)` or `f(x, t)`
 (coordinate `x` and time `t`) and return the prescribed value(s).
 
 !!! note "Multiple sets"
-    To apply a constraint on multiple face sets in the grid you can use `union` to join
+    To apply a constraint on multiple facet sets in the grid you can use `union` to join
     them, for example
     ```julia
     left_right = union(getfacetset(grid, "left"), getfacetset(grid, "right"))
@@ -156,12 +156,12 @@ for facet in 1:nfacets(cell)
 end
 ```
 
-We start by looping over all the faces of the cell, next we check if this particular face is
-located on our faceset of interest called `"Neumann Boundary"`. If we have determined
-that the current face is indeed on the boundary and in our faceset, then we
-reinitialize `FacetValues` for this face, using [`reinit!`](@ref). When `reinit!`ing
-`FacetValues` we also need to give the face number in addition to the cell.
-Next we simply loop over the quadrature points of the face, and then loop over
+We start by looping over all the facets of the cell, next we check if this particular facet is
+located on our facetset of interest called `"Neumann Boundary"`. If we have determined
+that the current facet is indeed on the boundary and in our facetset, then we
+reinitialize `FacetValues` for this facet, using [`reinit!`](@ref). When `reinit!`ing
+`FacetValues` we also need to give the facet number in addition to the cell.
+Next we simply loop over the quadrature points of the facet, and then loop over
 all the test functions and assemble the contribution to the force vector.
 
 
@@ -209,7 +209,7 @@ simply a translation (e.g. sides of a cube) this matrix will be the identity mat
 
 In `Ferrite` this type of periodic Dirichlet boundary conditions can be added to the
 `ConstraintHandler` by constructing an instance of [`PeriodicDirichlet`](@ref). This is
-usually done it two steps. First we compute the mapping between mirror and image faces using
+usually done it two steps. First we compute the mapping between mirror and image facets using
 [`collect_periodic_facets`](@ref). Here we specify the mirror set and image sets (the sets
 are usually known or can be constructed easily ) and the mapping ``\varphi``. Second we
 construct the constraint using the `PeriodicDirichlet` constructor. Here we specify which
@@ -226,7 +226,7 @@ in the ``x``-direction (as seen by the mapping `φ`):
 # Create a constraint handler from the dof handler
 ch = ConstraintHandler(dofhandler)
 
-# Compute the face mapping
+# Compute the facet mapping
 φ(x) = x - Vec{2}((1.0, 0.0))
 face_mapping = collect_periodic_facets(grid, "left", "right", φ)
 
@@ -242,8 +242,8 @@ close!(ch)
 
 !!! note
     `PeriodicDirichlet` constraints are imposed in a strong sense, so note that this
-    requires a periodic mesh such that it is possible to compute the face mapping between
-    faces on the mirror and boundary.
+    requires a periodic mesh such that it is possible to compute the facet mapping between
+    facets on the mirror and boundary.
 
 !!! note "Examples"
     Periodic boundary conditions are used in the following examples [Computational

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -47,10 +47,10 @@ end
 """
     reinit!(cv::CellValues, cell::AbstractCell, x::AbstractVector)
     reinit!(cv::CellValues, x::AbstractVector)
-    reinit!(fv::FacetValues, cell::AbstractCell, x::AbstractVector, face::Int)
-    reinit!(fv::FacetValues, x::AbstractVector, face::Int)
+    reinit!(fv::FacetValues, cell::AbstractCell, x::AbstractVector, facet::Int)
+    reinit!(fv::FacetValues, x::AbstractVector, function_gradient::Int)
 
-Update the `CellValues`/`FacetValues` object for a cell or face with coordinates `x`.
+Update the `CellValues`/`FacetValues` object for a cell or facet with cell coordinates `x`.
 The derivatives of the shape functions, and the new integration weights are computed.
 For interpolations with non-identity mappings, the current `cell` is also required.
 """
@@ -60,7 +60,7 @@ reinit!
     getnquadpoints(fe_v::AbstractValues)
 
 Return the number of quadrature points. For `FacetValues`,
-this is the number for the current face.
+this is the number for the current facet.
 """
 function getnquadpoints end
 
@@ -71,7 +71,7 @@ Return the product between the determinant of the Jacobian and the quadrature
 point weight for the given quadrature point: ``\\det(J(\\mathbf{x})) w_q``.
 
 This value is typically used when one integrates a function on a
-finite element cell or face as
+finite element cell or facet as
 
 ``\\int\\limits_\\Omega f(\\mathbf{x}) d \\Omega \\approx \\sum\\limits_{q = 1}^{n_q} f(\\mathbf{x}_q) \\det(J(\\mathbf{x})) w_q``
 ``\\int\\limits_\\Gamma f(\\mathbf{x}) d \\Gamma \\approx \\sum\\limits_{q = 1}^{n_q} f(\\mathbf{x}_q) \\det(J(\\mathbf{x})) w_q``

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -284,22 +284,22 @@ FaceIterator(args...) = error("FaceIterator is deprecated, use FacetIterator ins
 
 # Leaving flags undocumented as for CellIterator
 """
-    FacetIterator(gridordh::Union{Grid,AbstractDofHandler}, faceset::AbstractVecOrSet{FacetIndex})
+    FacetIterator(gridordh::Union{Grid,AbstractDofHandler}, facetset::AbstractVecOrSet{FacetIndex})
 
-Create a `FacetIterator` to conveniently iterate over the faces in `faceset`. The elements of
+Create a `FacetIterator` to conveniently iterate over the faces in `facestet`. The elements of
 the iterator are [`FacetCache`](@ref)s which are properly `reinit!`ialized. See
 [`FacetCache`](@ref) for more details.
 
 Looping over a `FacetIterator`, i.e.:
 ```julia
-for fc in FacetIterator(grid, faceset)
+for fc in FacetIterator(grid, facetset)
     # ...
 end
 ```
 is thus simply convenience for the following equivalent snippet:
 ```julia
 fc = FacetCache(grid)
-for faceindex in faceset
+for faceindex in facetset
     reinit!(fc, faceindex)
     # ...
 end


### PR DESCRIPTION
Realized that `face` was used instead of `facet` in many places in the docs still. Hopefully this catches most of them. 