### PR TITLE
Deprecate assemble! with local vector before local matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -462,6 +462,9 @@ more discussion).
 - `start_assemble(f, K)` have been deprecated in favor of the "canonical" `start_assemble(K,
   f)`. ([#707][github-707])
 
+- `assemble!(assembler, dofs, fe, Ke)` have been deprecated in favor of the "canonical"
+  `assemble!(assembler, dofs, Ke, fe)`. ([#1059][github-1059])
+
 - `end_assemble` have been deprecated in favor of `finish_assemble`. ([#754][github-754])
 
 - `get_point_values` have been deprecated in favor of `evaluate_at_points`.
@@ -1032,3 +1035,4 @@ poking into Ferrite internals:
 [github-949]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/949
 [github-953]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/953
 [github-974]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/974
+[github-1059]: https://github.com/Ferrite-FEM/Ferrite.jl/pull/1059

--- a/docs/src/literate-gallery/helmholtz.jl
+++ b/docs/src/literate-gallery/helmholtz.jl
@@ -152,7 +152,7 @@ function doassemble(cellvalues::CellValues, facetvalues::FacetValues,
         end
 
         celldofs!(global_dofs, cell)
-        assemble!(assembler, global_dofs, fe, Ke)
+        assemble!(assembler, global_dofs, Ke, fe)
     end
     return K, f
 end;

--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -265,7 +265,7 @@ function assemble_global!(K::SparseMatrixCSC, f, cellvalues_u::CellValues,
         ue = w[global_dofsu] # displacement dofs for the current cell
         pe = w[global_dofsp] # pressure dofs for the current cell
         assemble_element!(ke, fe, cell, cellvalues_u, cellvalues_p, mp, ue, pe)
-        assemble!(assembler, global_dofs, fe, ke)
+        assemble!(assembler, global_dofs, ke, fe)
     end
 end;
 

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -328,7 +328,7 @@ function doassemble!(cellvalues::CellValues, facetvalues::FacetValues, K::Sparse
         ue = u[eldofs]
 
         elmt!(Ke, re, element, cellvalues, facetvalues, grid, mp, ue, state)
-        assemble!(assembler, celldofs(element), re, Ke)
+        assemble!(assembler, celldofs(element), Ke, re)
     end
 
     return K, r

--- a/docs/src/literate-howto/threaded_assembly.jl
+++ b/docs/src/literate-howto/threaded_assembly.jl
@@ -173,7 +173,7 @@ function assemble_cell!(scratch::ScratchValues, cell::Int, K::SparseMatrixCSC,
     end
 
     celldofs!(global_dofs, dh, cell)
-    assemble!(assembler, global_dofs, fe, Ke)
+    assemble!(assembler, global_dofs, Ke, fe)
 end;
 
 function run_assemble()

--- a/docs/src/literate-tutorials/hyperelasticity.jl
+++ b/docs/src/literate-tutorials/hyperelasticity.jl
@@ -301,7 +301,7 @@ function assemble_global!(K, g, dh, cv, fv, mp, u, ΓN)
         global_dofs = celldofs(cell)
         ue = u[global_dofs] # element dofs
         @timeit "element assemble" assemble_element!(ke, ge, cell, cv, fv, mp, ue, ΓN)
-        assemble!(assembler, global_dofs, ge, ke)
+        assemble!(assembler, global_dofs, ke, ge)
     end
 end;
 

--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -107,7 +107,7 @@ function doassemble(
         fill!(ke, 0)
         fill!(fe, 0)
         assemble_up!(ke, fe, cell, cellvalues_u, cellvalues_p, facetvalues_u, grid, mp, ɛdev, t)
-        assemble!(assembler, celldofs(cell), fe, ke)
+        assemble!(assembler, celldofs(cell), ke, fe)
     end
 
     return K, f

--- a/docs/src/literate-tutorials/linear_shell.jl
+++ b/docs/src/literate-tutorials/linear_shell.jl
@@ -103,7 +103,7 @@ for cell in CellIterator(grid)
     #Call the element routine
     integrate_shell!(ke, cv, qr_ooplane, cellcoords, data)
 
-    assemble!(assembler, celldofs, fe, ke)
+    assemble!(assembler, celldofs, ke, fe)
 end
 
 # Apply BC and solve.

--- a/docs/src/literate-tutorials/plasticity.jl
+++ b/docs/src/literate-tutorials/plasticity.jl
@@ -187,7 +187,7 @@ function doassemble!(K::SparseMatrixCSC, r::Vector, cellvalues::CellValues, dh::
         state = @view states[:, i]
         state_old = @view states_old[:, i]
         assemble_cell!(ke, re, cell, cellvalues, material, ue, state, state_old)
-        assemble!(assembler, eldofs, re, ke)
+        assemble!(assembler, eldofs, ke, re)
     end
     return K, r
 end

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -137,7 +137,7 @@ function doassemble_K!(K::SparseMatrixCSC, f::Vector, cellvalues::CellValues, dh
             end
         end
 
-        assemble!(assembler, celldofs(cell), fe, Ke)
+        assemble!(assembler, celldofs(cell), Ke, fe)
     end
     return K, f
 end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -188,16 +188,10 @@ stiffness matrix and `f` the global force/residual vector, but more efficient.
 """
 assemble!(::AbstractAssembler, ::AbstractVector{<:Integer}, ::AbstractMatrix, ::AbstractVector)
 
-@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix)
-    assemble!(A, dofs, Ke, eltype(Ke)[])
-end
-@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, fe::AbstractVector, Ke::AbstractMatrix)
-    assemble!(A, dofs, Ke, fe)
-end
-@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector)
+@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
     _assemble!(A, dofs, Ke, fe, false)
 end
-@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector)
+@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
     _assemble!(A, dofs, Ke, fe, true)
 end
 
@@ -215,10 +209,10 @@ Sorts the dofs into a separate buffer and returns it together with a permutation
     return sorteddofs, permutation
 end
 
-@propagate_inbounds function _assemble!(A::AbstractCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector, sym::Bool)
+@propagate_inbounds function _assemble!(A::AbstractCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing}, sym::Bool)
     ld = length(dofs)
     @boundscheck checkbounds(Ke, keys(dofs), keys(dofs))
-    if length(fe) != 0
+    if fe !== nothing
         @boundscheck checkbounds(fe, keys(dofs))
         @boundscheck checkbounds(A.f, dofs)
         @inbounds assemble!(A.f, dofs, fe)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -438,3 +438,8 @@ export VTKFile
 function VTKFile(args...)
     throw(DeprecationError("VTKFile(args...)" => "VTKGridFile(args...)"))
 end
+
+# assemble with vector first
+function assemble!(::AbstractAssembler, ::AbstractVector{<:Integer}, ::AbstractVector, ::AbstractMatrix)
+    throw(DeprecationError("assemble!(assembler, dofs, fe, Ke)" => "assemble!(assembler, dofs, Ke, fe)"))
+end

--- a/test/test_abstractgrid.jl
+++ b/test/test_abstractgrid.jl
@@ -57,7 +57,7 @@
                     end
                 end
             end
-            assemble!(assembler, celldofs(dh,cellid), fe, Ke)
+            assemble!(assembler, celldofs(dh,cellid), Ke, fe)
         end
         return K, f
     end

--- a/test/test_apply_rhs.jl
+++ b/test/test_apply_rhs.jl
@@ -56,7 +56,7 @@ function test_apply_rhs()
                 end
             end
 
-            assemble!(assembler, celldofs(cell), fe, Ke)
+            assemble!(assembler, celldofs(cell), Ke, fe)
         end
         return K, f
     end

--- a/test/test_mixeddofhandler.jl
+++ b/test/test_mixeddofhandler.jl
@@ -331,7 +331,7 @@ function test_2_element_heat_eq()
                     end
                 end
             end
-            assemble!(assembler, eldofs, fe, Ke)
+            assemble!(assembler, eldofs, Ke, fe)
         end
     end
 


### PR DESCRIPTION
This patch deprecates the signature
`assemble!(assembler, dofs, local_vector, local_matrix)` in favor of `assemble!(assembler, dofs, local_matrix, local_vector)`. The former signature was not used in many places, not supported by e.g. the block matrix assembler, and it is confusing that there are two options. See also #707 for a similar change to `start_assemble`.

In addition, if the assembler is used just for matrix assembly, this patch removes an unnecessary allocation of an empty vector for every call to `assemble!`.