### PR TITLE
Consistently return the vtk file in export methods

### DIFF
--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -44,9 +44,13 @@ function VTKGridFile(f::Function, args...; kwargs...)
     finally
         close(vtk)
     end
+    return vtk
 end
 
-Base.close(vtk::VTKGridFile) = WriteVTK.vtk_save(vtk.vtk)
+function Base.close(vtk::VTKGridFile)
+    WriteVTK.vtk_save(vtk.vtk)
+    return vtk
+end
 
 function Base.show(io::IO, ::MIME"text/plain", vtk::VTKGridFile)
     open_str = isopen(vtk.vtk) ? "open" : "closed"
@@ -55,10 +59,10 @@ function Base.show(io::IO, ::MIME"text/plain", vtk::VTKGridFile)
 end
 
 function WriteVTK.collection_add_timestep(pvd::WriteVTK.CollectionFile, datfile::VTKGridFile, time::Real)
-    WriteVTK.collection_add_timestep(pvd, datfile.vtk, time)
+    return WriteVTK.collection_add_timestep(pvd, datfile.vtk, time)
 end
 function Base.setindex!(pvd::WriteVTK.CollectionFile, datfile::VTKGridFile, time::Real)
-    WriteVTK.collection_add_timestep(pvd, datfile.vtk, time)
+    return WriteVTK.collection_add_timestep(pvd, datfile, time)
 end
 
 cell_to_vtkcell(::Type{Line}) = VTKCellTypes.VTK_LINE
@@ -206,6 +210,7 @@ Write the `celldata` that is ordered by the cells in the grid to the vtk file.
 """
 function write_cell_data(vtk::VTKGridFile, celldata, name)
     WriteVTK.vtk_cell_data(vtk.vtk, celldata, name)
+    return vtk
 end
 
 """
@@ -222,6 +227,7 @@ When `nodedata` contains second order tensors, the index order,
 """
 function write_node_data(vtk::VTKGridFile, nodedata, name)
     _vtk_write_node_data(vtk.vtk, nodedata, name)
+    return vtk
 end
 
 
@@ -312,4 +318,5 @@ function write_cell_colors(vtk, grid::AbstractGrid, cell_colors::AbstractVector{
         end
     end
     write_cell_data(vtk, color_vector, name)
+    return vtk
 end

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -38,10 +38,10 @@ end
         addnodeset!(grid, "middle-nodes", x -> norm(x) < radius)
 
         gridfilename = "grid-$(repr(celltype))"
-        VTKGridFile(gridfilename, grid) do vtk
-            Ferrite.write_cellset(vtk, grid, "cell-1")
-            Ferrite.write_cellset(vtk, grid, "middle-cells")
-            Ferrite.write_nodeset(vtk, grid, "middle-nodes")
+        VTKGridFile(gridfilename, grid) do vtk::VTKGridFile
+            @test Ferrite.write_cellset(vtk, grid, "cell-1") === vtk
+            @test Ferrite.write_cellset(vtk, grid, "middle-cells") === vtk
+            @test Ferrite.write_nodeset(vtk, grid, "middle-nodes") === vtk
         end
 
         # test the sha of the file
@@ -78,9 +78,9 @@ end
         apply!(u, ch)
 
         dofhandlerfilename = "dofhandler-$(repr(celltype))"
-        VTKGridFile(dofhandlerfilename, grid) do vtk
-            Ferrite.write_constraints(vtk, ch)
-            write_solution(vtk, dofhandler, u)
+        VTKGridFile(dofhandlerfilename, grid) do vtk::VTKGridFile
+            @test Ferrite.write_constraints(vtk, ch) === vtk
+            @test write_solution(vtk, dofhandler, u) === vtk
         end
 
         # test the sha of the file
@@ -124,10 +124,10 @@ close(csio)
     vector_data = [Vec{3}(ntuple(i->i, 3)) for j=1:8]
 
     filename_3d = "test_vtk_3d"
-    VTKGridFile(filename_3d, grid) do vtk
-        write_node_data(vtk, sym_tensor_data, "symmetric tensor")
-        write_node_data(vtk, tensor_data, "tensor")
-        write_node_data(vtk, vector_data, "vector")
+    VTKGridFile(filename_3d, grid) do vtk::VTKGridFile
+        @test write_node_data(vtk, sym_tensor_data, "symmetric tensor") === vtk
+        @test write_node_data(vtk, tensor_data, "tensor") === vtk
+        @test write_node_data(vtk, vector_data, "vector") === vtk
     end
 
     # 2D grid
@@ -139,11 +139,11 @@ close(csio)
     vector_data = [Vec{2}(ntuple(i->i, 2)) for j=1:4]
 
     filename_2d = "test_vtk_2d"
-    VTKGridFile(filename_2d, grid) do vtk
-        write_node_data(vtk, sym_tensor_data, "symmetric tensor")
-        write_node_data(vtk, tensor_data, "tensor")
-        write_node_data(vtk, tensor_data_1D, "tensor_1d")
-        write_node_data(vtk, vector_data, "vector")
+    VTKGridFile(filename_2d, grid) do vtk::VTKGridFile
+        @test write_node_data(vtk, sym_tensor_data, "symmetric tensor") === vtk
+        @test write_node_data(vtk, tensor_data, "tensor") === vtk
+        @test write_node_data(vtk, tensor_data_1D, "tensor_1d") === vtk
+        @test write_node_data(vtk, vector_data, "vector") === vtk
     end
 
     # test the shas of the files
@@ -751,7 +751,7 @@ end
         celldata = rand(getncells(grid))
         pvd = WriteVTK.paraview_collection("collection")
         vtk1 = VTKGridFile("file1", grid)
-        write_cell_data(vtk1, celldata, "celldata")
+        @test write_cell_data(vtk1, celldata, "celldata") === vtk1
         @assert isopen(vtk1.vtk)
         pvd[0.5] = vtk1
         @test !isopen(vtk1.vtk) # Should be closed when adding it

--- a/test/test_vtk_export.jl
+++ b/test/test_vtk_export.jl
@@ -17,9 +17,10 @@
             grid = generate_grid(Quadrilateral, (4, 4))
             colors = create_coloring(grid)
             fname = joinpath(tmp, "colors")
-            VTKGridFile(fname, grid) do vtk
-                Ferrite.write_cell_colors(vtk, grid, colors)
+            v = VTKGridFile(fname, grid) do vtk::VTKGridFile
+                @test Ferrite.write_cell_colors(vtk, grid, colors) === vtk
             end
+            @test v isa VTKGridFile
             @test bytes2hex(open(SHA.sha1, fname*".vtu")) == "b804d0b064121b672d8e35bcff8446eda361cac3"
         end
     end
@@ -35,9 +36,10 @@
             add!(ch, Dirichlet(:u, getnodeset(grid, "nodeset"), x -> 0.0))
             close!(ch)
             fname = joinpath(tmp, "constraints")
-            VTKGridFile(fname, grid) do vtk
-                Ferrite.write_constraints(vtk, ch)
+            v = VTKGridFile(fname, grid) do vtk::VTKGridFile
+                @test Ferrite.write_constraints(vtk, ch) === vtk
             end
+            @test v isa VTKGridFile
             @test bytes2hex(open(SHA.sha1, fname*".vtu")) == "31b506bd9729b11992f8bcb79a2191eb65d223bf"
         end
     end
@@ -50,12 +52,14 @@
             addcellset!(grid, "set2", 1:4)
             manual = joinpath(tmp, "manual")
             auto = joinpath(tmp, "auto")
-            VTKGridFile(manual, grid) do vtk
-                Ferrite.write_cellset(vtk, grid, keys(Ferrite.getcellsets(grid)))
+            v = VTKGridFile(manual, grid) do vtk::VTKGridFile
+                @test Ferrite.write_cellset(vtk, grid, keys(Ferrite.getcellsets(grid))) === vtk
             end
-            VTKGridFile(auto, grid) do vtk
-                Ferrite.write_cellset(vtk, grid)
+            @test v isa VTKGridFile
+            v = VTKGridFile(auto, grid) do vtk::VTKGridFile
+                @test Ferrite.write_cellset(vtk, grid) === vtk
             end
+            @test v isa VTKGridFile
             @test bytes2hex(open(SHA.sha1, manual*".vtu")) == bytes2hex(open(SHA.sha1, auto*".vtu"))
         end
     end


### PR DESCRIPTION
This patch make sure that the vtk file is always returned in export related methods. In particular, this make sure that return values of WriteVTK functions don't leak out to Ferrite users. For example, `write_cell_data` returned an `LightXML.XMLElement`.