### PR TITLE
Miscellaneous fixes to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ almost instant feedback in the browser.
 
 ## Reporting issues
 
-If you have found a bug or a problem with Ferrite.jl you can open an [issue][new-issue]. Try
+If you have found a bug or a problem with Ferrite you can open an [issue][new-issue]. Try
 to include as much information about the problem as possible and preferably some code that
 can be copy-pasted to reproduce it (see [How to create a Minimal, Reproducible
 Example][so-mre]).

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ welcome. See [CONTRIBUTING](CONTRIBUTING.md) for more details.
 
 ## Questions
 
-If you have questions about Ferrite.jl you're welcome to reach out to us on the [Julia
+If you have questions about Ferrite you're welcome to reach out to us on the [Julia
 Slack][julia-slack] under `#ferrite-fem` or on [Zulip][julia-zulip] under `#Ferrite.jl`.
 Alternatively you can start a [new discussion][gh-discussion] in the discussion forum on the
-repository. Feel free to ask us even if you are not sure the problem is with Ferrite.jl.
+repository. Feel free to ask us even if you are not sure the problem is with Ferrite.
 
 If you encounter what you think is a bug please report it, see
 [CONTRIBUTING.md](CONTRIBUTING.md#reporting-issues) for more information.
@@ -40,7 +40,7 @@ Please keep in mind that we are part of the Julia community and adhere to the
 [Julia Community Standards][standards].
 
 ## Related packages
-The following registered packages are part of the `Ferrite.jl` ecosystem in addition to Ferrite itself:
+The following registered packages are part of the Ferrite ecosystem in addition to Ferrite itself:
 * [Tensors.jl][Tensors]: Used throughout Ferrite for efficient tensor manipulation.
 * [FerriteViz.jl][FerriteViz]: [Makie.jl][Makie]-based visualization of Ferrite data.
 * [FerriteGmsh.jl][FerriteGmsh]: Create, interact with, and import [Gmsh][Gmsh] meshes into Ferrite.

--- a/docs/src/devdocs/index.md
+++ b/docs/src/devdocs/index.md
@@ -1,6 +1,6 @@
 # Developer documentation
 
-Here you can find some documentation of the internals of Ferrite.jl which are useful when
+Here you can find some documentation of the internals of Ferrite which are useful when
 developing the library.
 
 ```@contents

--- a/docs/src/devdocs/performance.md
+++ b/docs/src/devdocs/performance.md
@@ -1,4 +1,4 @@
-# [Performance Analysis](@id devdocs-performance)
+# [Performance analysis](@id devdocs-performance)
 
 In the benchmark folder we provide basic infrastructure to analyze the performance of
 Ferrite to help tracking down performance regression issues. Two basic tools can be

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -97,4 +97,4 @@ Ferrite is still under active development. If you find a bug, or have ideas for
 improvements, you are encouraged to interact with the developers on the [Ferrite GitHub
 repository](https://github.com/Ferrite-FEM/Ferrite.jl). There is also a thorough contributor
 guide which can be found in
-[`CONTRIBUTING.md`](https://github.com/Ferrite-FEM/Ferrite.jl/blob/master/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/Ferrite-FEM/Ferrite.jl/blob/master/CONTRIBUTING.md).

--- a/docs/src/literate-howto/postprocessing.jl
+++ b/docs/src/literate-howto/postprocessing.jl
@@ -93,7 +93,7 @@ VTKGridFile("heat_equation_flux", grid) do vtk
     write_projection(vtk, projector, q_projected, "q")
 end;
 
-# ## Point Evaluation
+# ## Point evaluation
 # ![](heat_square_pointevaluation.png)
 #
 # *Figure 2*: Visualization of the cut line where we want to compute

--- a/docs/src/literate-tutorials/computational_homogenization.jl
+++ b/docs/src/literate-tutorials/computational_homogenization.jl
@@ -179,7 +179,7 @@
 
 # ## Commented program
 #
-# Now we will see how this can be implemented in `Ferrite`. What follows is a program
+# Now we will see how this can be implemented in Ferrite. What follows is a program
 # with comments in between which describe the different steps.
 #md # You can also find the same program without comments at the end of the page,
 #md # see [Plain program](@ref homogenization-plain-program).
@@ -189,8 +189,8 @@ using Test #src
 
 # We first load the mesh file [`periodic-rve.msh`](periodic-rve.msh)
 # ([`periodic-rve-coarse.msh`](periodic-rve-coarse.msh) for a coarser mesh). The mesh is
-# generated with [`gmsh`](https://gmsh.info/), and we read it in as a `Ferrite` grid using
-# the [`FerriteGmsh`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package:
+# generated with [Gmsh](https://gmsh.info/), and we read it in as a Ferrite `Grid` using
+# the [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package:
 
 using FerriteGmsh
 

--- a/docs/src/literate-tutorials/hyperelasticity.jl
+++ b/docs/src/literate-tutorials/hyperelasticity.jl
@@ -51,7 +51,7 @@
 # and print a summary at the end,
 # [ProgressMeter.jl](https://github.com/timholy/ProgressMeter.jl) for showing a simple
 # progress bar, and
-# [IterativeSolvers](https://github.com/JuliaLinearAlgebra/IterativeSolvers.jl) for solving
+# [IterativeSolvers.jl](https://github.com/JuliaLinearAlgebra/IterativeSolvers.jl) for solving
 # the linear system using conjugate gradients.
 
 using Ferrite, Tensors, TimerOutputs, ProgressMeter, IterativeSolvers

--- a/docs/src/literate-tutorials/linear_elasticity.jl
+++ b/docs/src/literate-tutorials/linear_elasticity.jl
@@ -99,7 +99,7 @@
 # First we load Ferrite, and some other packages we need.
 using Ferrite, FerriteGmsh, SparseArrays
 # As in the heat equation tutorial, we will use a unit square - but here we'll load the grid of the Ferrite logo!
-# This is done by downloading [`logo.geo`](logo.geo) and loading it using [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl),
+# This is done by downloading [`logo.geo`](logo.geo) and loading it using [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl),
 using Downloads: download
 logo_mesh = "logo.geo"
 asset_url = "https://raw.githubusercontent.com/Ferrite-FEM/Ferrite.jl/gh-pages/assets/"

--- a/docs/src/literate-tutorials/linear_shell.jl
+++ b/docs/src/literate-tutorials/linear_shell.jl
@@ -4,7 +4,7 @@
 #-
 # ## Introduction
 #
-# In this example we show how shell elements can be analyzed in Ferrite.jl. The shell implemented here comes from the book
+# In this example we show how shell elements can be analyzed with Ferrite. The shell implemented here comes from the book
 # "The finite element method - Linear static and dynamic finite element analysis" by Hughes (1987), and a brief description of it is
 # given at the end of this tutorial.  The first part of the tutorial explains how to set up the problem.
 

--- a/docs/src/literate-tutorials/ns_vs_diffeq.jl
+++ b/docs/src/literate-tutorials/ns_vs_diffeq.jl
@@ -13,7 +13,7 @@
 # In this example we focus on a simple but visually appealing problem from
 # fluid dynamics, namely vortex shedding. This problem is also known as
 # [von-Karman vortex streets](https://en.wikipedia.org/wiki/K%C3%A1rm%C3%A1n_vortex_street). Within this example, we show how to utilize [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl)
-# in tandem with Ferrite.jl to solve this space-time problem. To keep things simple we use a naive approach
+# in tandem with Ferrite to solve this space-time problem. To keep things simple we use a naive approach
 # to discretize the system.
 #
 # ## Remarks on DifferentialEquations.jl
@@ -128,7 +128,7 @@ using OrdinaryDiffEq
 ν = 1.0/1000.0; #dynamic viscosity
 
 # Next a rectangular grid with a cylinder in it has to be generated.
-# We use `Gmsh` for the creation of the mesh and `FerriteGmsh` to translate it to a `Ferrite.Grid`.
+# We use Gmsh.jl for the creation of the mesh and FerriteGmsh.jl to translate it to a `Ferrite.Grid`.
 # Note that the mesh is pretty fine, leading to a high memory consumption when
 # feeding the equation system to direct solvers.
 using FerriteGmsh
@@ -195,7 +195,7 @@ add!(dh, :v, ip_v)
 add!(dh, :p, ip_p)
 close!(dh);
 
-# ### Boundary Conditions
+# ### Boundary conditions
 # As in the DFG benchmark we apply no-slip conditions to the top, bottom and
 # cylinder boundary. The no-slip condition states that the velocity of the
 # fluid on this portion of the boundary is fixed to be zero.

--- a/docs/src/literate-tutorials/porous_media.jl
+++ b/docs/src/literate-tutorials/porous_media.jl
@@ -245,7 +245,7 @@ function doassemble!(assembler, domain::FEDomain, a, a_old, Δt)
 end;
 
 # ### Mesh import
-# In this example, we import the mesh from the Abaqus input file, [`porous_media_0p25.inp`](porous_media_0p25.inp) using `FerriteMeshParser`'s
+# In this example, we import the mesh from the Abaqus input file, [`porous_media_0p25.inp`](porous_media_0p25.inp) using FerriteMeshParser's
 # `get_ferrite_grid` function. We then create one cellset for each phase (solid and porous)
 # for each element type. These 4 sets will later be used in their own `SubDofHandler`
 function get_grid()

--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -19,8 +19,8 @@
 # flow on a quarter circle. In particular it shows how to use periodic boundary conditions,
 # how to solve a problem with multiple unknown fields, and how to enforce a specific mean
 # value of the solution. For the mesh generation we use
-# [`Gmsh.jl`](https://github.com/JuliaFEM/Gmsh.jl) and then use
-# [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) to import the mesh into
+# [Gmsh.jl](https://github.com/JuliaFEM/Gmsh.jl) and then use
+# [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) to import the mesh into
 # Ferrite's format.
 #
 # The strong form of Stokes flow with velocity ``\boldsymbol{u}`` and pressure ``p`` can be

--- a/docs/src/reference/boundary_conditions.md
+++ b/docs/src/reference/boundary_conditions.md
@@ -2,7 +2,7 @@
 DocTestSetup = :(using Ferrite)
 ```
 
-# Boundary Conditions
+# Boundary conditions
 
 ```@index
 Pages = ["boundary_conditions.md"]

--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -22,7 +22,7 @@ PointIterator
 PointLocation
 ```
 
-## VTK Export
+## VTK export
 ```@docs
 VTKGridFile
 write_solution

--- a/docs/src/topics/FEValues.md
+++ b/docs/src/topics/FEValues.md
@@ -1,5 +1,5 @@
 # [FEValues](@id fevalues_topicguide)
-A key type of object in `Ferrite.jl` is the so-called `FEValues`, where the most common ones are `CellValues` and `FacetValues`. These objects are used inside the element routines and are used to query the integration weights, shape function values and gradients, and much more; see [`CellValues`](@ref) and [`FacetValues`](@ref). For these values to be correct, it is necessary to reinitialize these for the current cell by using the [`reinit!`](@ref) function. This function maps the values from the reference cell to the actual cell, a process described in detail below, see [Mapping of finite elements](@ref mapping_theory). After that, we show an implementation of a [`SimpleCellValues`](@ref SimpleCellValues) type to illustrate how `CellValues` work for the most standard case, excluding the generalizations and optimization that complicates the actual code.
+A key type of object in Ferrite is the so-called `FEValues`, where the most common ones are `CellValues` and `FacetValues`. These objects are used inside the element routines and are used to query the integration weights, shape function values and gradients, and much more; see [`CellValues`](@ref) and [`FacetValues`](@ref). For these values to be correct, it is necessary to reinitialize these for the current cell by using the [`reinit!`](@ref) function. This function maps the values from the reference cell to the actual cell, a process described in detail below, see [Mapping of finite elements](@ref mapping_theory). After that, we show an implementation of a [`SimpleCellValues`](@ref SimpleCellValues) type to illustrate how `CellValues` work for the most standard case, excluding the generalizations and optimization that complicates the actual code.
 
 ## [Mapping of finite elements](@id mapping_theory)
 The shape functions and gradients stored in an `FEValues` object, are reinitialized for each cell by calling the `reinit!` function.
@@ -161,7 +161,7 @@ This gives the gradient
 
 ## [Walkthrough: Creating `SimpleCellValues`](@id SimpleCellValues)
 In the following, we walk through how to create a `SimpleCellValues` type which
-works similar to `Ferrite.jl`'s `CellValues`, but is not performance optimized and not as general. The main purpose is to explain how the `CellValues` works for the standard case of `IdentityMapping` described above.
+works similar to Ferrite's `CellValues`, but is not performance optimized and not as general. The main purpose is to explain how the `CellValues` works for the standard case of `IdentityMapping` described above.
 Please note that several internal functions are used, and these may change without a major version increment. Please see the [Developer documentation](@ref) for their documentation.
 
 ```@eval

--- a/docs/src/topics/SimpleCellValues_literate.jl
+++ b/docs/src/topics/SimpleCellValues_literate.jl
@@ -1,4 +1,4 @@
-# We start by including `Ferrite` and `Test` (to check our implementation).
+# We start by including Ferrite and Test (to check our implementation).
 using Ferrite, Test
 
 # Then, we define a simple version of the cell values object, which only supports
@@ -93,7 +93,7 @@ reinit!(simple_cv, x)
 reinit!(cv, x);
 
 # If we now pretend we are inside an element routine and have a vector of element degree of freedom values,
-# `ue`. Then, we can check that our function values and gradients match `Ferrite`'s builtin `CellValues`:
+# `ue`. Then, we can check that our function values and gradients match Ferrite's builtin `CellValues`:
 ue = rand(getnbasefunctions(simple_cv))
 q_point = 2
 @test function_value(cv, q_point, ue) ≈ function_value(simple_cv, q_point, ue)

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -2,18 +2,18 @@
 DocTestSetup = :(using Ferrite)
 ```
 
-# Initial and Boundary Conditions
+# Boundary and initial conditions
 
 Every PDE is accompanied with boundary conditions. There are different types of boundary
 conditions, and they need to be handled in different ways. Below we discuss how to handle
-the most common ones, Dirichlet and Neumann boundary conditions, and how to do it `Ferrite`.
+the most common ones, Dirichlet and Neumann boundary conditions, and how to do it in Ferrite.
 
 While boundary conditions can be applied directly to nodes, vertices, edges, or faces,
 they are most commonly applied to [facets](@ref "Reference shapes"). Each facet is described
 by a [`FacetIndex`](@ref).
 When adding boundary conditions to points instead, vertices are preferred over nodes.
 
-## Dirichlet Boundary Conditions
+## Dirichlet boundary conditions
 
 At a Dirichlet boundary the unknown field is prescribed to a given value. For the discrete
 FE-solution this means that there are some degrees of freedom that are fixed. To handle
@@ -94,7 +94,7 @@ end
     Equation](@ref tutorial-heat-equation).
 
 
-## Neumann Boundary Conditions
+## Neumann boundary conditions
 At the Neumann part of the boundary we know something about the gradient of the solution.
 Two different methods for applying these are described below.
 For complete examples that use Neumann boundary conditions, please see
@@ -207,7 +207,7 @@ general be written as
 where ``\boldsymbol{R}`` is a rotation matrix. If the mapping between mirror and image is
 simply a translation (e.g. sides of a cube) this matrix will be the identity matrix.
 
-In `Ferrite` this type of periodic Dirichlet boundary conditions can be added to the
+In Ferrite this type of periodic Dirichlet boundary conditions can be added to the
 `ConstraintHandler` by constructing an instance of [`PeriodicDirichlet`](@ref). This is
 usually done it two steps. First we compute the mapping between mirror and image facets using
 [`collect_periodic_facets`](@ref). Here we specify the mirror set and image sets (the sets
@@ -300,7 +300,7 @@ pdbc = PeriodicDirichlet(
     )
     ```
 
-## Initial Conditions
+## Initial conditions
 
 When solving time-dependent problems, initial conditions, different from zero, may be required.
 For finite element formulations of ODE-type,

--- a/docs/src/topics/degrees_of_freedom.md
+++ b/docs/src/topics/degrees_of_freedom.md
@@ -42,5 +42,7 @@ close!(dh)
 
 ## Ordering of Dofs
 
-ordered in the same order as we add to dofhandler
-vertices -> edges -> faces -> volumes
+!!! todo
+    Describe dof ordering within elements (vertices -> edges -> faces ->
+    volumes) and `dof_range`.
+    Describe (global) dof renumbering

--- a/docs/src/topics/fe_intro.md
+++ b/docs/src/topics/fe_intro.md
@@ -161,7 +161,7 @@ On an intuitive level, and to explain the notation used in the implementation, w
 ```
 being the chosen approximation when changing from the integral to the finite summation.
 
-For an example of the implementation to solve a heat problem with `Ferrite` check out [this
+For an example of the implementation to solve a heat problem with Ferrite check out [this
 thoroughly commented example](@ref tutorial-heat-equation).
 
 ## More details

--- a/docs/src/topics/grid.md
+++ b/docs/src/topics/grid.md
@@ -4,21 +4,21 @@ DocTestSetup = :(using Ferrite)
 
 # Grid
 
-## Mesh Reading
+## Mesh reading
 
 A Ferrite `Grid` can be generated with the [`generate_grid`](@ref) function.
 More advanced meshes can be imported with the
-[`FerriteMeshParser.jl`](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) (from Abaqus input files),
-or even created and translated with the [`Gmsh.jl`](https://github.com/JuliaFEM/Gmsh.jl) and [`FerriteGmsh.jl`](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package, respectively.
+[FerriteMeshParser.jl](https://github.com/Ferrite-FEM/FerriteMeshParser.jl) (from Abaqus input files),
+or even created and translated with the [`Gmsh.jl`](https://github.com/JuliaFEM/Gmsh.jl) and [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl) package, respectively.
 
-### FerriteGmsh
+### FerriteGmsh.jl
 
-`FerriteGmsh.jl` supports all defined cells with an alias in [`Ferrite.jl`](https://github.com/Ferrite-FEM/Ferrite.jl/blob/master/src/Grid/grid.jl#L39-L54) as well as the 3D Serendipity `Cell{3,20,6}`.
+FerriteGmsh.jl supports all defined cells with an alias in [Ferrite.jl](https://github.com/Ferrite-FEM/Ferrite.jl/blob/master/src/Grid/grid.jl#L39-L54) as well as the 3D Serendipity `Cell{3,20,6}`.
 Either, a mesh is created on the fly with the gmsh API or a mesh in `.msh` or `.geo` format can be read and translated with the `FerriteGmsh.togrid` function.
 ```@docs
 FerriteGmsh.togrid
 ```
-`FerriteGmsh.jl` supports currently the translation of `cellsets` and `facetsets`.
+FerriteGmsh supports currently the translation of `cellsets` and `facetsets`.
 Such sets are defined in Gmsh as `PhysicalGroups` of dimension `dim` and `dim-1`, respectively.
 In case only a part of the mesh is the domain, the domain can be specified by providing the keyword argument `domain` the name of the `PhysicalGroups` in the [`FerriteGmsh.togrid`](@ref) function.
 
@@ -28,14 +28,14 @@ In case only a part of the mesh is the domain, the domain can be specified by pr
     which doesn't harm the FE computation, but maybe distort your sophisticated grid operations (if present).
     For more information, see [this issue](https://github.com/Ferrite-FEM/FerriteGmsh.jl/issues/20).
 
-If you want to read another, not yet supported cell from gmsh, consider to open a PR at `FerriteGmsh` that extends the [`gmshtoferritecell` dict](https://github.com/Ferrite-FEM/FerriteGmsh.jl/blob/c9de4f64b3ad3c73fcb36758855a6e517c6d0d95/src/FerriteGmsh.jl#L6-L15)
+If you want to read another, not yet supported cell from gmsh, consider to open a PR at FerriteGmsh that extends the [`gmshtoferritecell` dict](https://github.com/Ferrite-FEM/FerriteGmsh.jl/blob/c9de4f64b3ad3c73fcb36758855a6e517c6d0d95/src/FerriteGmsh.jl#L6-L15)
 and if needed, reorder the element nodes by dispatching [`FerriteGmsh.translate_elements`](https://github.com/Ferrite-FEM/FerriteGmsh.jl/blob/c9de4f64b3ad3c73fcb36758855a6e517c6d0d95/src/FerriteGmsh.jl#L17-L63).
 The reordering of nodes is necessary if the Gmsh ordering doesn't match the one from Ferrite. Gmsh ordering is documented [here](https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering).
-For an exemplary usage of `Gmsh.jl` and `FerriteGmsh.jl`, consider the [Stokes flow](@ref tutorial-stokes-flow) and [Incompressible Navier-Stokes Equations via DifferentialEquations.jl](@ref tutorial-ins-ordinarydiffeq) example.
+For an exemplary usage of Gmsh.jl and FerriteGmsh.jl, consider the [Stokes flow](@ref tutorial-stokes-flow) and [Incompressible Navier-Stokes Equations via DifferentialEquations.jl](@ref tutorial-ins-ordinarydiffeq) example.
 
-### FerriteMeshParser
+### FerriteMeshParser.jl
 
-`FerriteMeshParser.jl` converts the mesh in an Abaqus input file (`.inp`) to a `Ferrite.Grid` with its function `get_ferrite_grid`.
+FerriteMeshParser.jl converts the mesh in an Abaqus input file (`.inp`) to a `Ferrite.Grid` with its function `get_ferrite_grid`.
 The translations for most of Abaqus' standard 2d and 3d continuum elements to a `Ferrite.AbstractCell` are defined.
 Custom translations can be given as input, which can be used to import other (custom) elements or to override the default translation.
 ```@docs
@@ -45,7 +45,7 @@ FerriteMeshParser.get_ferrite_grid
 If you are missing the translation of an Abaqus element that is equivalent to a `Ferrite.AbstractCell`,
 consider to open an [issue](https://github.com/Ferrite-FEM/FerriteMeshParser.jl/issues/new) or a pull request.
 
-## `Grid` Datastructure
+## `Grid` datastructure
 
 In Ferrite a Grid is a collection of `Node`s and `Cell`s and is parameterized in its physical dimensionality and cell type.
 `Node`s are points in the physical space and can be initialized by a N-Tuple, where N corresponds to the dimensions.
@@ -135,7 +135,7 @@ Ferrite.get_coordinate_type(::SmallGrid{dim}) where dim = Vec{dim,Float64}
 Ferrite.nnodes_per_cell(grid::SmallGrid, i::Int=1) = Ferrite.nnodes(grid.cells_test[i])
 ```
 
-These definitions make many of `Ferrite`s functions work out of the box, e.g. you can now call
+These definitions make many of Ferrite functions work out of the box, e.g. you can now call
 `getcoordinates(grid, cellid)` on the `SmallGrid`.
 
 Now, you would be able to assemble the heat equation example over the new custom `SmallGrid` type.

--- a/src/Quadrature/quadrature.jl
+++ b/src/Quadrature/quadrature.jl
@@ -33,7 +33,7 @@ function values at specific points:
 
 The quadrature rule consists of ``n_q`` points in space ``\\mathbf{x}_q`` with corresponding weights ``w_q``.
 
-In `Ferrite`, the `QuadratureRule` type is mostly used as one of the components to create [`CellValues`](@ref).
+In Ferrite, the `QuadratureRule` type is mostly used as one of the components to create [`CellValues`](@ref).
 
 **Common methods:**
 * [`getpoints`](@ref) : the points of the quadrature rule

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,4 +1,4 @@
-# Some utility functions for testing Ferrite.jl
+# Some utility functions for testing Ferrite
 
 using Ferrite: reference_shape_value
 


### PR DESCRIPTION
 - Don't code-quote package names and drop .jl prefix when unnecessary
 - Use consistent capitalization in headers
 - Use a prettier TODO note in DoF docs