### PR TITLE
Remove explicit documention of fields in CellCache

### DIFF
--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -214,7 +214,7 @@ function compute_stresses(cellvalues_u::CellValues, cellvalues_p::CellValues,
         reinit!(cellvalues_u, cc)
         reinit!(cellvalues_p, cc)
         ## Extract the cell local part of the solution
-        for (i, I) in pairs(cc.dofs)
+        for (i, I) in pairs(celldofs(cc))
             ae[i] = a[I]
         end
         ## Loop over the quadrature points

--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -447,8 +447,8 @@ function check_mean_constraint(dh, fvp, u)                                  #src
     ∫pdΓ, Γ= 0.0, 0.0                                                       #src
     for (ci, fi) in set                                                     #src
         reinit!(cc, ci)                                                     #src
-        reinit!(fvp, cc.coords, fi)                                         #src
-        ue = u[cc.dofs]                                                     #src
+        reinit!(fvp, cc, fi)                                                #src
+        ue = u[celldofs(cc)]                                                #src
         for qp in 1:getnquadpoints(fvp)                                     #src
             dΓ = getdetJdV(fvp, qp)                                         #src
             ∫pdΓ += function_value(fvp, qp, ue, range_p) * dΓ               #src
@@ -466,7 +466,7 @@ function check_L2(dh, cvu, cvp, u)                                          #src
     for cell in CellIterator(dh)                                            #src
         reinit!(cvu, cell)                                                  #src
         reinit!(cvp, cell)                                                  #src
-        ue = u[cell.dofs]                                                   #src
+        ue = u[celldofs(cell)]                                              #src
         for qp in 1:getnquadpoints(cvu)                                     #src
             dΩ = getdetJdV(cvu, qp)                                         #src
             uh = function_value(cvu, qp, ue, range_u)                       #src

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -22,11 +22,6 @@ Create a cache object with pre-allocated memory for the nodes, coordinates, and 
 cell. The cache is updated for a new cell by calling `reinit!(cache, cellid)` where
 `cellid::Int` is the cell id.
 
-**Struct fields of `CellCache`**
- - `cc.nodes :: Vector{Int}`: global node ids
- - `cc.coords :: Vector{<:Vec}`: node coordinates
- - `cc.dofs :: Vector{Int}`: global dof ids (empty when constructing the cache from a grid)
-
 **Methods with `CellCache`**
  - `reinit!(cc, i)`: reinitialize the cache for cell `i`
  - `cellid(cc)`: get the cell id of the currently cached cell
@@ -105,10 +100,6 @@ celldofs!(v::Vector, cc::CellCache) = copyto!(v, cc.dofs) # celldofs!(v, cc.dh, 
 nfacets(cc::CellCache) = nfacets(getcells(cc.grid, cc.cellid))
 
 
-# TODO: Currently excluded from the docstring below. Should they be public?
-# - `Ferrite.faceindex(fc)`: get the `FaceIndex` of the currently cached face
-# - `Ferrite.faceid(fc)`: get the current faceid (`faceindex(fc)[2]`)
-
 """
     FacetCache(grid::Grid)
     FacetCache(dh::AbstractDofHandler)
@@ -119,7 +110,7 @@ calling `reinit!(cache, fi::FacetIndex)`.
 
 **Methods with `fc::FacetCache`**
  - `reinit!(fc, fi)`: reinitialize the cache for face `fi::FacetIndex`
- - `cellid(fc)`: get the current cellid (`faceindex(fc)[1]`)
+ - `cellid(fc)`: get the current cellid
  - `getnodes(fc)`: get the global node ids of the *cell*
  - `getcoordinates(fc)`: get the coordinates of the *cell*
  - `celldofs(fc)`: get the global dof ids of the *cell*
@@ -152,9 +143,8 @@ for op = (:getnodes, :getcoordinates, :cellid, :celldofs)
         end
     end
 end
-# @inline faceid(fc::FacetCache) = fc.current_faceid[]
+
 @inline celldofs!(v::Vector, fc::FacetCache) = celldofs!(v, fc.cc)
-# @inline faceindex(fc::FacetCache) = FaceIndex(cellid(fc), faceid(fc))
 @inline function reinit!(fv::FacetValues, fc::FacetCache)
     reinit!(fv, fc.cc, fc.current_facet_id)
 end


### PR DESCRIPTION
* Better to use the functions, e.g. `getnodes`, as these also work with `FacetCache`.
* In PRs such as #1060, not documented increases flexibility of changing representation (when cell is stored, no need to store the nodes)
