### PR TITLE
Use fill instead of Ferrite.fillzero in assembly explanation

### DIFF
--- a/docs/src/topics/assembly.md
+++ b/docs/src/topics/assembly.md
@@ -273,9 +273,9 @@ nothing                             # hide
 using BenchmarkTools
 
 @btime assemble_v1(assembler, K, dofs, Ke) evals = 10 setup = fill!(K, 0)
-@btime assemble_v2(assembler, K, dofs, Ke) evals = 10 setup = Ferrite.fillzero!(K)
-@btime assemble_v3(assembler, K, dofs, Ke) evals = 10 setup = Ferrite.fillzero!(K)
-@btime assemble_v4(assembler, K, dofs, Ke) evals = 10 setup = Ferrite.fillzero!(K)
+@btime assemble_v2(assembler, K, dofs, Ke) evals = 10 setup = fill!(K, 0)
+@btime assemble_v3(assembler, K, dofs, Ke) evals = 10 setup = fill!(K, 0)
+@btime assemble_v4(assembler, K, dofs, Ke) evals = 10 setup = fill!(K, 0)
 ```
 
 The results below are obtained on an Macbook Pro with an Apple M3 CPU.


### PR DESCRIPTION
Fix remaining from https://github.com/Ferrite-FEM/Ferrite.jl/pull/1063#discussion_r1784328929