### PR TITLE
Drop support for Julia 1.9

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -27,6 +27,14 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - name: JET tests
+        shell: julia --color=yes --project=@jet {0}
+        run: |
+          using Pkg
+          Pkg.add("JET")
+          Pkg.develop(path = pwd())
+          include(joinpath(pwd(), "test/jet.jl"))
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.julia-version != 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: 'src,ext'

--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ Reexport = "1"
 StaticArrays = "1"
 Tensors = "1.14"
 WriteVTK = "1.13"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
@@ -48,7 +48,6 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -57,4 +56,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["BlockArrays", "Downloads", "FerriteGmsh", "ForwardDiff", "Gmsh", "IterativeSolvers", "Metis", "Pkg", "NBInclude", "OhMyThreads", "ProgressMeter", "Random", "SHA", "TaskLocalValues", "Test", "TimerOutputs", "Logging"]
+test = ["BlockArrays", "Downloads", "FerriteGmsh", "ForwardDiff", "Gmsh", "IterativeSolvers", "Metis", "NBInclude", "OhMyThreads", "ProgressMeter", "Random", "SHA", "TaskLocalValues", "Test", "TimerOutputs", "Logging"]

--- a/ext/FerriteMetis.jl
+++ b/ext/FerriteMetis.jl
@@ -1,12 +1,9 @@
 module FerriteMetis
 
-# This extension requires modules as type parameters
-# https://github.com/JuliaLang/julia/pull/47749
-if VERSION >= v"1.10.0-DEV.90"
-
 using Ferrite:
     Ferrite, CellIterator, ConstraintHandler, DofHandler, DofOrder, celldofs, ndofs,
-    ndofs_per_cell, spzeros!!
+    ndofs_per_cell
+using SparseArrays: SparseArrays
 using Metis.LibMetis: idx_t
 using Metis: Metis
 
@@ -74,7 +71,7 @@ function Ferrite.compute_renumber_permutation(
     end
     @assert length(I) == length(J) == idx
     N = ndofs(dh)
-    S = spzeros!!(Float32, I, J, N, N)
+    S = SparseArrays.spzeros!(Float32, I, J, N, N)
 
     # Add entries from affine constraints
     if ch !== nothing
@@ -93,7 +90,5 @@ function Ferrite.compute_renumber_permutation(
     perm, iperm = Metis.permutation(G)
     return iperm
 end
-
-end # VERSION check
 
 end # module FerriteMetis

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -767,7 +767,7 @@ function create_constraint_matrix(ch::ConstraintHandler{dh,T}) where {dh,T}
     end
     g[ch.prescribed_dofs] .= ch.inhomogeneities
 
-    C = sparse!!(I, J, V, ndofs(ch.dh), length(ch.free_dofs))
+    C = SparseArrays.sparse!(I, J, V, ndofs(ch.dh), length(ch.free_dofs))
 
     return C, g
 end

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -22,7 +22,7 @@ function create_incidence_matrix(g::AbstractGrid, cellset=1:getncells(g))
         end
     end
 
-    incidence_matrix = spzeros!!(Bool, I, J, getncells(g), getncells(g))
+    incidence_matrix = SparseArrays.spzeros!(Bool, I, J, getncells(g), getncells(g))
     fill!(incidence_matrix.nzval, true)
     return incidence_matrix
 end

--- a/src/PoolAllocator.jl
+++ b/src/PoolAllocator.jl
@@ -3,22 +3,14 @@ module PoolAllocator
 # Checkmate LanguageServer.jl
 const var"@propagate_inbounds" = Base.var"@propagate_inbounds"
 
-@eval macro $(Symbol("const"))(field)
-    if VERSION >= v"1.8.0-DEV.1148"
-        Expr(:const, esc(field))
-    else
-        return esc(field)
-    end
-end
-
 const PAGE_SIZE = 4 * 1024 * 1024 # 4 MiB
 
 # A page corresponds to a memory block of size `PAGE_SIZE` bytes.
 # Allocations of arrays are views into this block.
 mutable struct Page{T}
-    @const buf::Vector{T}      # data buffer (TODO: Memory in recent Julias?)
-    @const blocksize::Int      # blocksize for this page
-    @const freelist::BitVector # block is free/used
+    const buf::Vector{T}      # data buffer (TODO: Memory in recent Julias?)
+    const blocksize::Int      # blocksize for this page
+    const freelist::BitVector # block is free/used
     n_free::Int               # number of free blocks
     function Page{T}(blocksize::Int) where T
         @assert isbitstype(T)

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -85,16 +85,3 @@ function fillzero!(A::Symmetric{T,<:SparseMatrixCSC}) where T
     fillzero!(A.data)
     return A
 end
-
-# Compat and convenience layer around SparseArrays.spzeros! (SparseArrays.jl#284, SparseArrays.jl#315)
-if VERSION >= v"1.10.0"
-    const sparse!! = SparseArrays.sparse!
-    const spzeros!! = SparseArrays.spzeros!
-else
-    function sparse!!(I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Integer, n::Integer)
-        return SparseArrays.sparse(I, J, V, m, n)
-    end
-    function spzeros!!(::Type{T}, I::AbstractVector, J::AbstractVector, m::Integer, n::Integer) where T
-        return sparse!!(I, J, zeros(T, length(I)), m, n)
-    end
-end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -128,7 +128,7 @@ function finish_assemble(a::COOAssembler)
     # Create the matrix
     nrows = a.nrows == -1 ? maximum(a.I) : a.nrows
     ncols = a.ncols == -1 ? maximum(a.J) : a.ncols
-    K = sparse!!(a.I, a.J, a.V, nrows, ncols)
+    K = SparseArrays.sparse!(a.I, a.J, a.V, nrows, ncols)
     # Finalize the vector
     f = a.f
     if !isempty(f)

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,62 @@
+# JET.jl tests that run on CI only for released julia versions
+using Ferrite
+using JET: @test_call
+using Test
+
+include("test_utils.jl")
+
+@testset "CellValues" begin
+    @testset "ip=$scalar_interpol" for (scalar_interpol, quad_rule) in (
+            (Lagrange{RefLine, 1}(), QuadratureRule{RefLine}(2)),
+            (Lagrange{RefLine, 2}(), QuadratureRule{RefLine}(2)),
+            (Lagrange{RefQuadrilateral, 1}(), QuadratureRule{RefQuadrilateral}(2)),
+            (Lagrange{RefQuadrilateral, 2}(), QuadratureRule{RefQuadrilateral}(2)),
+            (Lagrange{RefTriangle, 1}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefTriangle, 2}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefTriangle, 3}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefTriangle, 4}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefTriangle, 5}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefHexahedron, 1}(), QuadratureRule{RefHexahedron}(2)),
+            (Serendipity{RefQuadrilateral, 2}(), QuadratureRule{RefQuadrilateral}(2)),
+            (Lagrange{RefTriangle, 1}(), QuadratureRule{RefTriangle}(2)),
+            (Lagrange{RefTetrahedron, 2}(), QuadratureRule{RefTetrahedron}(2)),
+            (Lagrange{RefPrism, 2}(), QuadratureRule{RefPrism}(2)),
+            (Lagrange{RefPyramid, 2}(), QuadratureRule{RefPyramid}(2)),
+        )
+        for func_interpol in (scalar_interpol, VectorizedInterpolation(scalar_interpol)), DiffOrder in 1:2
+            (DiffOrder == 2 && Ferrite.getorder(func_interpol) == 1) && continue # No need to test linear interpolations again
+            geom_interpol = scalar_interpol # Tests below assume this
+            update_gradients = true
+            update_hessians = (DiffOrder == 2 && Ferrite.getorder(func_interpol) > 1)
+            cv = CellValues(quad_rule, func_interpol, geom_interpol; update_gradients, update_hessians)
+            coords, _ = valid_coordinates_and_normals(func_interpol)
+            @test_call reinit!(cv, coords)
+            # TODO: Also @test_call some methods that use cv?
+        end
+    end
+    @testset "Embedded elements" begin
+        @testset "Scalar/vector on curves (vdim = $vdim)" for vdim in (0, 1, 2, 3)
+            ip_base = Lagrange{RefLine, 1}()
+            ip = vdim > 0 ? ip_base^vdim : ip_base
+            qr = QuadratureRule{RefLine}(1)
+            # Reference values
+            csv1 = CellValues(qr, ip)
+            @test_call reinit!(csv1, [Vec((0.0,)), Vec((1.0,))])
+            ## sdim = 2, Consistency with 1D
+            csv2 = CellValues(qr, ip, ip_base^2)
+            @test_call reinit!(csv2, [Vec((0.0, 0.0)), Vec((1.0, 0.0))])
+            ## sdim = 3, Consistency with 1D
+            csv3 = CellValues(qr, ip, ip_base^3)
+            @test_call reinit!(csv3, [Vec((0.0, 0.0, 0.0)), Vec((1.0, 0.0, 0.0))])
+        end
+        @testset "Scalar/vector on surface (vdim = $vdim)" for vdim in (0, 1, 2, 3)
+            ip_base = Lagrange{RefQuadrilateral, 1}()
+            ip = vdim > 0 ? ip_base^vdim : ip_base
+            qr = QuadratureRule{RefQuadrilateral}(1)
+            csv2 = CellValues(qr, ip)
+            @test_call reinit!(csv2, [Vec((-1.0, -1.0)), Vec((1.0, -1.0)), Vec((1.0, 1.0)), Vec((-1.0, 1.0))])
+            csv3 = CellValues(qr, ip, ip_base^3)
+            @test_call reinit!(csv3, [Vec((-1.0, -1.0, 0.0)), Vec((1.0, -1.0, 0.0)), Vec((1.0, 1.0, 0.0)), Vec((-1.0, 1.0, 0.0))])
+        end
+    end
+end # of testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,28 +10,7 @@ using SparseArrays
 using StaticArrays
 using OrderedCollections
 using WriteVTK
-
-const HAS_EXTENSIONS = isdefined(Base, :get_extension)
-
-# https://github.com/JuliaLang/julia/pull/47749
-const MODULE_CAN_BE_TYPE_PARAMETER = VERSION >= v"1.10.0-DEV.90"
-
-if HAS_EXTENSIONS && MODULE_CAN_BE_TYPE_PARAMETER
-    import Metis
-end
-
-const RUN_JET_TESTS = VERSION >= v"1.9" && isempty(VERSION.prerelease)
-
-if RUN_JET_TESTS
-    using Pkg: Pkg
-    Pkg.add("JET")
-    using JET: @test_call
-else
-    # Just eat the macro on incompatible versions
-    macro test_call(args...)
-        nothing
-    end
-end
+import Metis
 
 include("test_utils.jl")
 
@@ -59,7 +38,7 @@ include("test_apply_rhs.jl")
 include("test_apply_analytical.jl")
 include("PoolAllocator.jl")
 include("test_deprecations.jl")
-HAS_EXTENSIONS && include("blockarrays.jl")
+include("blockarrays.jl")
 include("test_examples.jl")
 
 @test all(x -> isdefined(Ferrite, x), names(Ferrite))  # Test that all exported symbols are defined

--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -35,7 +35,6 @@
 
         coords, n = valid_coordinates_and_normals(func_interpol)
         reinit!(cv, coords)
-        @test_call reinit!(cv, coords)
 
         # We test this by applying a given deformation gradient on all the nodes.
         # Since this is a linear deformation we should get back the exact values
@@ -272,7 +271,6 @@ end
         ## sdim = 2, Consistency with 1D
         csv2 = CellValues(qr, ip, ip_base^2)
         reinit!(csv2, [Vec((0.0, 0.0)), Vec((1.0, 0.0))])
-        @test_call skip=true reinit!(csv2, [Vec((0.0, 0.0)), Vec((1.0, 0.0))]) # External error in pinv
         # Test spatial interpolation
         @test spatial_coordinate(csv2, 1, [Vec((0.0, 0.0)), Vec((1.0, 0.0))]) == Vec{2}((0.5, 0.0))
         # Test volume
@@ -293,7 +291,6 @@ end
         ## sdim = 3, Consistency with 1D
         csv3 = CellValues(qr, ip, ip_base^3)
         reinit!(csv3, [Vec((0.0, 0.0, 0.0)), Vec((1.0, 0.0, 0.0))])
-        @test_call skip=true reinit!(csv3, [Vec((0.0, 0.0, 0.0)), Vec((1.0, 0.0, 0.0))]) # External error in pinv
         # Test spatial interpolation
         @test spatial_coordinate(csv3, 1, [Vec((0.0, 0.0, 0.0)), Vec((1.0, 0.0, 0.0))]) == Vec{3}((0.5, 0.0, 0.0))
         # Test volume
@@ -356,9 +353,7 @@ end
         csv2 = CellValues(qr, ip)
         csv3 = CellValues(qr, ip, ip_base^3)
         reinit!(csv2, [Vec((-1.0,-1.0)), Vec((1.0,-1.0)), Vec((1.0,1.0)), Vec((-1.0,1.0))])
-        @test_call skip=true reinit!(csv2, [Vec((-1.0,-1.0)), Vec((1.0,-1.0)), Vec((1.0,1.0)), Vec((-1.0,1.0))]) # External error in pinv
         reinit!(csv3, [Vec((-1.0,-1.0,0.0)), Vec((1.0,-1.0,0.0)), Vec((1.0,1.0,0.0)), Vec((-1.0,1.0,0.0))])
-        @test_call skip=true reinit!(csv3, [Vec((-1.0,-1.0,0.0)), Vec((1.0,-1.0,0.0)), Vec((1.0,1.0,0.0)), Vec((-1.0,1.0,0.0))]) # External error in pinv
         # Test spatial interpolation
         @test spatial_coordinate(csv2, 1, [Vec((-1.0,-1.0)), Vec((1.0,-1.0)), Vec((1.0,1.0)), Vec((-1.0,1.0))]) == Vec{2}((0.0, 0.0))
         @test spatial_coordinate(csv3, 1, [Vec((-1.0,-1.0,0.0)), Vec((1.0,-1.0,0.0)), Vec((1.0,1.0,0.0)), Vec((-1.0,1.0,0.0))]) == Vec{3}((0.0, 0.0, 0.0))
@@ -417,8 +412,6 @@ end
             @test Ferrite.shape_gradient_type(cv) == grad_type(Float32)
             @test Ferrite.geometric_interpolation(cv) == scalar_ip(geo_ip)
         end
-        x = Ferrite.reference_coordinates(fun_ip)
-        @test_call reinit!(cv, x)
     end
 end
 

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -408,14 +408,12 @@ end
     end
 
     # Metis ordering
-    if HAS_EXTENSIONS && MODULE_CAN_BE_TYPE_PARAMETER
-        # TODO: Should probably test that the new order result in less fill-in
-        dh, ch = testdhch()
-        renumber!(dh, DofOrder.Ext{Metis}())
-        @test_throws ErrorException renumber!(dh, ch, DofOrder.Ext{Metis}())
-        renumber!(dh, DofOrder.Ext{Metis}(coupling=[true true; true false]))
-        @test_throws ErrorException renumber!(dh, ch, DofOrder.Ext{Metis}(coupling=[true true; true false]))
-    end
+    # TODO: Should probably test that the new order result in less fill-in
+    dh, ch = testdhch()
+    renumber!(dh, DofOrder.Ext{Metis}())
+    @test_throws ErrorException renumber!(dh, ch, DofOrder.Ext{Metis}())
+    renumber!(dh, DofOrder.Ext{Metis}(coupling=[true true; true false]))
+    @test_throws ErrorException renumber!(dh, ch, DofOrder.Ext{Metis}(coupling=[true true; true false]))
 end
 
 @testset "dof coupling" begin


### PR DESCRIPTION
Julia 1.10 is the LTS now and dropping support for 1.9 leads to some simplifications of the code:
  - `SparseArrays.(sparse|spzeros)!` can be used directly
  - `const` struct fields without macro hack
  - Extensions are always supported
  - Unconditionally use JET in tests