### PR TITLE
Simplify evaluate_at_grid_nodes

### DIFF
--- a/docs/src/devdocs/FEValues.md
+++ b/docs/src/devdocs/FEValues.md
@@ -22,8 +22,8 @@ Ferrite.BCValues
 ## Internal utilities
 ```@docs
 Ferrite.embedding_det
-Ferrite.shape_value_type(::AbstractValues)
-Ferrite.shape_value_type(::FunctionValues)
+Ferrite.shape_value_type(::Ferrite.AbstractValues)
+Ferrite.shape_value_type(::Ferrite.FunctionValues)
 Ferrite.shape_gradient_type
 Ferrite.ValuesUpdateFlags
 ```

--- a/docs/src/devdocs/FEValues.md
+++ b/docs/src/devdocs/FEValues.md
@@ -22,7 +22,8 @@ Ferrite.BCValues
 ## Internal utilities
 ```@docs
 Ferrite.embedding_det
-Ferrite.shape_value_type
+Ferrite.shape_value_type(::AbstractValues)
+Ferrite.shape_value_type(::FunctionValues)
 Ferrite.shape_gradient_type
 Ferrite.ValuesUpdateFlags
 ```

--- a/docs/src/devdocs/FEValues.md
+++ b/docs/src/devdocs/FEValues.md
@@ -23,7 +23,6 @@ Ferrite.BCValues
 ```@docs
 Ferrite.embedding_det
 Ferrite.shape_value_type(::Ferrite.AbstractValues)
-Ferrite.shape_value_type(::Ferrite.FunctionValues)
 Ferrite.shape_gradient_type
 Ferrite.ValuesUpdateFlags
 ```

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -19,7 +19,7 @@ Ferrite.reference_shape_values!
 Ferrite.reference_shape_gradients!
 Ferrite.reference_shape_gradients_and_values!
 Ferrite.reference_shape_hessians_gradients_and_values!
-Ferrite.shape_value_type(::Ferrite.Interpolation)
+Ferrite.shape_value_type(ip::Interpolation, ::Type{T}) where T<:Number
 ```
 
 ### Required methods to implement for all subtypes of `Interpolation` to define a new finite element

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -19,7 +19,7 @@ Ferrite.reference_shape_values!
 Ferrite.reference_shape_gradients!
 Ferrite.reference_shape_gradients_and_values!
 Ferrite.reference_shape_hessians_gradients_and_values!
-Ferrite.shape_value_type
+Ferrite.shape_value_type(::Ferrite.Interpolation)
 ```
 
 ### Required methods to implement for all subtypes of `Interpolation` to define a new finite element

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -19,6 +19,7 @@ Ferrite.reference_shape_values!
 Ferrite.reference_shape_gradients!
 Ferrite.reference_shape_gradients_and_values!
 Ferrite.reference_shape_hessians_gradients_and_values!
+Ferrite.shape_value_type
 ```
 
 ### Required methods to implement for all subtypes of `Interpolation` to define a new finite element

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -930,7 +930,7 @@ function evaluate_at_grid_nodes(dh::DofHandler, u::AbstractVector, fieldname::Sy
 end
 
 # Internal method that have the vtk option to allocate the output differently
-function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fieldname::Symbol, ::Val{vtk}=Val(false)) where {T, vtk, sdim}
+function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fieldname::Symbol, ::Val{vtk} = Val(false)) where {T, vtk, sdim}
     # Make sure the field exists
     fieldname ∈ getfieldnames(dh) || error("Field $fieldname not found.")
     # Figure out the return type (scalar or vector)
@@ -966,8 +966,10 @@ function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fie
 end
 
 # Loop over the cells and use shape functions to compute the value
-function _evaluate_at_grid_nodes!(data::Union{Vector,Matrix}, sdh::SubDofHandler,
-        u::AbstractVector{T}, cv::CellValues, drange::UnitRange) where {T}
+function _evaluate_at_grid_nodes!(
+        data::Union{Vector, Matrix}, sdh::SubDofHandler,
+        u::AbstractVector{T}, cv::CellValues, drange::UnitRange
+    ) where {T}
     ue = zeros(T, length(drange))
     for cell in CellIterator(sdh)
         # Note: We are only using the shape functions: no reinit!(cv, cell) necessary

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -957,7 +957,7 @@ function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fie
         ip_geo = geometric_interpolation(CT)
         local_node_coords = reference_coordinates(ip_geo)
         qr = QuadratureRule{getrefshape(ip)}(zeros(length(local_node_coords)), local_node_coords)
-        cv = CellValues(qr, ip, ip_geo^sdim; update_gradients = Val(false), update_hessians = Val(false), update_detJdV = Val(false))
+        cv = CellValues(qr, ip, ip_geo^sdim; update_gradients = false, update_hessians = false, update_detJdV = false)
         drange = dof_range(sdh, field_idx)
         # Function barrier
         _evaluate_at_grid_nodes!(data, sdh, u, cv, drange)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -57,6 +57,11 @@ n_components(::VectorInterpolation{vdim}) where {vdim} = vdim
 # Number of components that are allowed to prescribe in e.g. Dirichlet BC
 n_dbc_components(ip::Interpolation) = n_components(ip)
 
+"""
+    shape_value_type(ip::Iterpolation, ::Type{T}) where T<:Number
+
+Return the type of `shape_value(ip::Interpolation, ξ::Vec, ib::Int)`
+"""
 shape_value_type(::ScalarInterpolation, ::Type{T}) where {T <: Number} = T
 shape_value_type(::VectorInterpolation{vdim}, ::Type{T}) where {vdim, T <: Number} = Vec{vdim, T}
 #shape_value_type(::MatrixInterpolation, T::Type) = Tensor  #958

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -58,10 +58,12 @@ n_components(::VectorInterpolation{vdim}) where {vdim} = vdim
 n_dbc_components(ip::Interpolation) = n_components(ip)
 
 """
-    shape_value_type(ip::Iterpolation, ::Type{T}) where T<:Number
+    shape_value_type(ip::Interpolation, ::Type{T}) where T<:Number
 
-Return the type of `shape_value(ip::Interpolation, ξ::Vec, ib::Int)`
+Return the type of `shape_value(ip::Interpolation, ξ::Vec, ib::Int)`.
 """
+shape_value_type(::Interpolation, ::Type{T}) where {T <: Number} 
+
 shape_value_type(::ScalarInterpolation, ::Type{T}) where {T <: Number} = T
 shape_value_type(::VectorInterpolation{vdim}, ::Type{T}) where {vdim, T <: Number} = Vec{vdim, T}
 #shape_value_type(::MatrixInterpolation, T::Type) = Tensor  #958

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -57,8 +57,8 @@ n_components(::VectorInterpolation{vdim}) where {vdim} = vdim
 # Number of components that are allowed to prescribe in e.g. Dirichlet BC
 n_dbc_components(ip::Interpolation) = n_components(ip)
 
-shape_value_type(::ScalarInterpolation, T::Type) = T
-shape_value_type(::VectorInterpolation{vdim}, T::Type) where {vdim} = Vec{vdim,T}
+shape_value_type(::ScalarInterpolation, ::Type{T}) where {T <: Number} = T
+shape_value_type(::VectorInterpolation{vdim}, ::Type{T}) where {vdim, T <: Number} = Vec{vdim, T}
 #shape_value_type(::MatrixInterpolation, T::Type) = Tensor  #958
 
 # TODO: Add a fallback that errors if there are multiple dofs per edge/face instead to force

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -57,6 +57,10 @@ n_components(::VectorInterpolation{vdim}) where {vdim} = vdim
 # Number of components that are allowed to prescribe in e.g. Dirichlet BC
 n_dbc_components(ip::Interpolation) = n_components(ip)
 
+shape_value_type(::ScalarInterpolation, T::Type) = T
+shape_value_type(::VectorInterpolation{vdim}, T::Type) where {vdim} = Vec{vdim,T}
+#shape_value_type(::MatrixInterpolation, T::Type) = Tensor  #958
+
 # TODO: Add a fallback that errors if there are multiple dofs per edge/face instead to force
 #       interpolations to opt-out instead of silently do nothing.
 """

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -62,7 +62,7 @@ n_dbc_components(ip::Interpolation) = n_components(ip)
 
 Return the type of `shape_value(ip::Interpolation, ξ::Vec, ib::Int)`.
 """
-shape_value_type(::Interpolation, ::Type{T}) where {T <: Number} 
+shape_value_type(::Interpolation, ::Type{T}) where {T <: Number}
 
 shape_value_type(::ScalarInterpolation, ::Type{T}) where {T <: Number} = T
 shape_value_type(::VectorInterpolation{vdim}, ::Type{T}) where {vdim, T <: Number} = Vec{vdim, T}


### PR DESCRIPTION
There were some hacks in `evaluate_at_grid_nodes` for embedded element which I don't think is needed anymore.
Also added `shape_value_type(::Interpolation, T)` which I think will be required for #958  also. 