### PR TITLE
Modularize interpolation testing

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -488,8 +488,8 @@ function reference_coordinates(ip::DiscontinuousLagrange{RefTetrahedron, 0})
 end
 
 function reference_shape_value(ip::DiscontinuousLagrange{shape, 0}, ::Vec{dim, T}, i::Int) where {dim, shape <: AbstractRefShape{dim}, T}
-    i > 1 && throw(ArgumentError("no shape function $i for interpolation $ip"))
-    return one(T)
+    i == 1 && return one(T)
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
 end
 
 is_discontinuous(::Type{<:DiscontinuousLagrange}) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("test_utils.jl")
 
 # Unit tests
 include("test_collectionsofviews.jl")
+include("test_refshapes.jl")
 include("test_interpolations.jl")
 include("test_cellvalues.jl")
 include("test_facevalues.jl")

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -1,89 +1,184 @@
 using Ferrite: reference_shape_value, reference_shape_gradient
 
-@testset "interpolations" begin
+"""
+    test_interpolation_properties(ip::Interpolation)
 
-    @testset "Value Type $value_type" for value_type in (Float32, Float64)
-        @testset "Correctness of $interpolation" for interpolation in (
-                Lagrange{RefLine, 1}(),
-                Lagrange{RefLine, 2}(),
-                Lagrange{RefQuadrilateral, 1}(),
-                Lagrange{RefQuadrilateral, 2}(),
-                Lagrange{RefQuadrilateral, 3}(),
-                Lagrange{RefTriangle, 1}(),
-                Lagrange{RefTriangle, 2}(),
-                Lagrange{RefTriangle, 3}(),
-                Lagrange{RefTriangle, 4}(),
-                Lagrange{RefTriangle, 5}(),
-                Lagrange{RefHexahedron, 1}(),
-                Lagrange{RefHexahedron, 2}(),
-                Serendipity{RefQuadrilateral, 2}(),
-                Serendipity{RefHexahedron, 2}(),
-                Lagrange{RefTetrahedron, 1}(),
-                Lagrange{RefTetrahedron, 2}(),
-                Lagrange{RefPrism, 1}(),
-                Lagrange{RefPrism, 2}(),
-                Lagrange{RefPyramid, 1}(),
-                Lagrange{RefPyramid, 2}(),
-                #
-                DiscontinuousLagrange{RefLine, 0}(),
-                DiscontinuousLagrange{RefQuadrilateral, 0}(),
-                DiscontinuousLagrange{RefHexahedron, 0}(),
-                DiscontinuousLagrange{RefTriangle, 0}(),
-                DiscontinuousLagrange{RefTetrahedron, 0}(),
-                DiscontinuousLagrange{RefLine, 1}(),
-                DiscontinuousLagrange{RefQuadrilateral, 1}(),
-                DiscontinuousLagrange{RefHexahedron, 1}(),
-                DiscontinuousLagrange{RefTriangle, 1}(),
-                DiscontinuousLagrange{RefTetrahedron, 1}(),
-                DiscontinuousLagrange{RefPrism, 1}(),
-                DiscontinuousLagrange{RefPyramid, 1}(),
-                #
-                BubbleEnrichedLagrange{RefTriangle, 1}(),
-                #
-                CrouzeixRaviart{RefTriangle, 1}(),
-                CrouzeixRaviart{RefTetrahedron, 1}(),
-                RannacherTurek{RefQuadrilateral, 1}(),
-                RannacherTurek{RefHexahedron, 1}(),
-            )
-            # Test of utility functions
-            ref_dim = Ferrite.getrefdim(interpolation)
-            ref_shape = Ferrite.getrefshape(interpolation)
-            func_order = Ferrite.getorder(interpolation)
-            @test typeof(interpolation) <: Interpolation{ref_shape, func_order}
+This function tests the following implementation details for an
+interpolation. All base interpolations should pass this test, but
+`VectorizedInterpolation`s do not which is ok as these are
+special-cased in the code base.
 
-            # Note that not every element formulation exists for every order and dimension.
-            applicable(Ferrite.getlowerorder, interpolation) && @test typeof(Ferrite.getlowerorder(interpolation)) <: Interpolation{ref_shape, func_order - 1}
-            @testset "transform face points" begin
-                # Test both center point and random points on the face
-                ref_coord = Ferrite.reference_coordinates(Lagrange{ref_shape, 1}())
-                for face in 1:nfacets(interpolation)
-                    face_nodes = Ferrite.reference_facets(ref_shape)[face]
-                    center_coord = [0.0 for _ in 1:ref_dim]
-                    rand_coord = [0.0 for _ in 1:ref_dim]
-                    rand_weights = rand(length(face_nodes))
-                    rand_weights /= sum(rand_weights)
-                    for (i, node) in pairs(face_nodes)
-                        center_coord += ref_coord[node] / length(face_nodes)
-                        rand_coord += rand_weights[i] .* ref_coord[node]
-                    end
-                    for point in (center_coord, rand_coord)
-                        vec_point = Vec{ref_dim}(point)
-                        cell_to_face = Ferrite.element_to_facet_transformation(vec_point, ref_shape, face)
-                        face_to_cell = Ferrite.facet_to_element_transformation(cell_to_face, ref_shape, face)
-                        @test vec_point ≈ face_to_cell
-                    end
+A) Length of `<entity>dof_indices` and `<entity>dof_interior_indices`
+   matches number of reference shape entities (e.g. `edge`)
+B) Numbering convention
+   - vertices -> edges -> faces -> volume
+   - Numbered in entity order (e.g. edge 1 has lower indices than edge 2)
+   - Continuous and increasing numbering within entity (e.g. `edgedof_interior_indices(ip)[edgenr]`)
+     can be `(4, 5)`, but not `(4, 6)` or `(5, 4)`.
+C) Lower-dimensional entities' dof indices + current interior dof indices
+   matches current dof indices (e.g. vertexdof + edge_interior => edgedofs) for each entity.
+D) The dof indices values matches `1:N` without duplication (follows from B, but also checked separately)
+E) All `N` base functions are implemented + `ArgumentError` if `i=0` or `i=N+1`
+F) Interpolation accessor functions versus type parameters (e.g. same refshape)
+
+"""
+function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) where {RefShape, FunOrder}
+    return @testset "Interpolation properties: $ip" begin
+        # test accessor functions and type parameters
+        @test RefShape == getrefshape(ip)
+        @test Ferrite.getrefdim(RefShape) == Ferrite.getrefdim(ip)
+        @test Ferrite.getorder(ip) == FunOrder
+
+        rdim = Ferrite.getrefdim(ip)
+        collect_all_dofs(t::Tuple) = vcat(Int[], collect.(t)...)
+        vdofs = Ferrite.vertexdof_indices(ip)
+        edofs = Ferrite.edgedof_indices(ip)
+        fdofs = Ferrite.facedof_indices(ip)
+        edofs_i = Ferrite.edgedof_interior_indices(ip)
+        fdofs_i = Ferrite.facedof_interior_indices(ip)
+        voldofs_i = Ferrite.volumedof_interior_indices(ip)
+
+        # Check match to reference shape (A)
+        @test length(vdofs) == Ferrite.nvertices(RefShape)
+        @test length(edofs) == Ferrite.nedges(RefShape)
+        @test length(edofs_i) == Ferrite.nedges(RefShape)
+        @test length(fdofs) == Ferrite.nfaces(RefShape)
+        @test length(fdofs_i) == Ferrite.nfaces(RefShape)
+
+        # Check numbering convention (B) and entity matching
+        all_dofs = Int[]
+        # Vertices numbered first
+        append!(all_dofs, collect_all_dofs(vdofs))
+        @test all(all_dofs .== 1:length(all_dofs))
+        if rdim ≥ 1 # Test edges
+            # Edges numbered next, no gaps or missing numbers. Sorted by edge number.
+            all_edofs_i = collect_all_dofs(edofs_i)
+            @test all(all_edofs_i .== length(all_dofs) .+ (1:length(all_edofs_i)))
+            # - all edge dofs include both vertexdofs and interior edegdofs, and nothing more.
+            append!(all_dofs, all_edofs_i)
+            @test all(all_dofs .== 1:length(all_dofs))
+            @test length(all_dofs) == length(collect_all_dofs(vdofs)) + length(all_edofs_i)
+            # Coarse check for C
+            @test Set(collect_all_dofs(edofs)) == Set(1:length(all_dofs))
+            # - test each edge individually (Detailed check for C)
+            for i in 1:Ferrite.nedges(RefShape)
+                vdofs_e = Int[] # vdofs for vertices belonging to the current edge
+                for j in Ferrite.reference_edges(RefShape)[i] # vertices in edge i
+                    isempty(vdofs[j]) || append!(vdofs_e, collect(vdofs[j]))
                 end
+                @test Set(edofs[i]) == Set(vcat(vdofs_e, collect(edofs_i[i])))
             end
-            n_basefuncs = getnbasefunctions(interpolation)
-            coords = Ferrite.reference_coordinates(interpolation)
-            @test length(coords) == n_basefuncs
-            f(x) = [reference_shape_value(interpolation, Tensor{1, ref_dim}(x), i) for i in 1:n_basefuncs]
+        end
+        if rdim ≥ 2 # Test faces
+            # Face numbered next, no gaps or missing numbers. Sorted by face number.
+            all_fdofs_i = collect_all_dofs(fdofs_i)
+            @test all(all_fdofs_i .== length(all_dofs) .+ (1:length(all_fdofs_i)))
+            # - all dofs now include vertex dofs, edge dofs and face dofs, but not volume dofs.
+            append!(all_dofs, all_fdofs_i)
+            @test all(all_dofs .== 1:length(all_dofs))
+            # Coarse check for C
+            @test Set(collect_all_dofs(fdofs)) == Set(1:length(all_dofs))
+            # - test each face individually (Detailed check for C)
+            for i in 1:Ferrite.nfaces(RefShape)
+                face_verts = Ferrite.reference_faces(RefShape)[i]
+                vdofs_f = Int[]
+                for j in face_verts # vertices in face i
+                    vdof_indices = Ferrite.vertexdof_indices(ip)[j]
+                    isempty(vdof_indices) || append!(vdofs_f, collect(vdof_indices))
+                end
+                edofs_f = Int[] # Interior edgedofs for edges belong to current face
+                for (edgenr, edge) in enumerate(Ferrite.reference_edges(RefShape)) # All edges
+                    # Both edge vertices belong to face => edge belongs to face
+                    (edge[1] ∈ face_verts && edge[2] ∈ face_verts) || continue
+                    append!(edofs_f, collect(edofs_i[edgenr]))
+                end
+                @test Set(fdofs[i]) == Set(vcat(vdofs_f, edofs_f, collect(fdofs_i[i])))
+            end
+        end
+        # Test volume
+        # We always test this, since volumedofs are also used by lower-dimensional
+        # discontinuous inteprolations to make them internal to the cell, e.g. DiscontinuousLagrange
+        # Volumedofs numbered last
+        append!(all_dofs, collect(voldofs_i))
+        @test all(all_dofs .== 1:length(all_dofs))        # Numbering convention
 
-            #TODO prefer this test style after 1.6 is removed from CI
-            # @testset let x = sample_random_point(ref_shape) # not compatible with Julia 1.6
-            x = Vec{ref_dim, value_type}(sample_random_point(ref_shape))
-            random_point_testset = @testset "Random point test" begin
+        # Test D: getnbasefunctions matching number of dof indices
+        @test length(all_dofs) == getnbasefunctions(ip)
+
+        # Test E: All base functions implemented.
+        # Argument errors for 0th and n+1 indices.
+        ξ = zero(Vec{Ferrite.getrefdim(ip)})
+        @test_throws ArgumentError Ferrite.reference_shape_value(ip, ξ, 0)
+        for i in 1:getnbasefunctions(ip)
+            @test Ferrite.reference_shape_value(ip, ξ, i) isa Ferrite.shape_value_type(ip, Float64)
+        end
+        @test_throws ArgumentError Ferrite.reference_shape_value(ip, ξ, getnbasefunctions(ip) + 1)
+    end
+end
+
+@testset "interpolations" begin
+    @testset "Correctness of $interpolation" for interpolation in (
+            Lagrange{RefLine, 1}(),
+            Lagrange{RefLine, 2}(),
+            Lagrange{RefQuadrilateral, 1}(),
+            Lagrange{RefQuadrilateral, 2}(),
+            Lagrange{RefQuadrilateral, 3}(),
+            Lagrange{RefTriangle, 1}(),
+            Lagrange{RefTriangle, 2}(),
+            Lagrange{RefTriangle, 3}(),
+            Lagrange{RefTriangle, 4}(),
+            Lagrange{RefTriangle, 5}(),
+            Lagrange{RefHexahedron, 1}(),
+            Lagrange{RefHexahedron, 2}(),
+            Serendipity{RefQuadrilateral, 2}(),
+            Serendipity{RefHexahedron, 2}(),
+            Lagrange{RefTetrahedron, 1}(),
+            Lagrange{RefTetrahedron, 2}(),
+            Lagrange{RefPrism, 1}(),
+            Lagrange{RefPrism, 2}(),
+            Lagrange{RefPyramid, 1}(),
+            Lagrange{RefPyramid, 2}(),
+            #
+            DiscontinuousLagrange{RefLine, 0}(),
+            DiscontinuousLagrange{RefQuadrilateral, 0}(),
+            DiscontinuousLagrange{RefHexahedron, 0}(),
+            DiscontinuousLagrange{RefTriangle, 0}(),
+            DiscontinuousLagrange{RefTetrahedron, 0}(),
+            DiscontinuousLagrange{RefLine, 1}(),
+            DiscontinuousLagrange{RefQuadrilateral, 1}(),
+            DiscontinuousLagrange{RefHexahedron, 1}(),
+            DiscontinuousLagrange{RefTriangle, 1}(),
+            DiscontinuousLagrange{RefTetrahedron, 1}(),
+            DiscontinuousLagrange{RefPrism, 1}(),
+            DiscontinuousLagrange{RefPyramid, 1}(),
+            #
+            BubbleEnrichedLagrange{RefTriangle, 1}(),
+            #
+            CrouzeixRaviart{RefTriangle, 1}(),
+            CrouzeixRaviart{RefTetrahedron, 1}(),
+            RannacherTurek{RefQuadrilateral, 1}(),
+            RannacherTurek{RefHexahedron, 1}(),
+        )
+        # Standard test all base interpolations must fullfill
+        test_interpolation_properties(interpolation)
+
+        ref_dim = Ferrite.getrefdim(interpolation)
+        ref_shape = Ferrite.getrefshape(interpolation)
+        func_order = Ferrite.getorder(interpolation)
+
+        # Note that not every element formulation exists for every order and dimension.
+        if applicable(Ferrite.getlowerorder, interpolation)
+            @test isa(Ferrite.getlowerorder(interpolation), Interpolation{ref_shape, func_order - 1})
+        end
+
+        n_basefuncs = getnbasefunctions(interpolation)
+        coords = Ferrite.reference_coordinates(interpolation)
+        @test length(coords) == n_basefuncs
+
+        @testset "Value Type $value_type" for value_type in (Float32, Float64)
+            @testset let x = Vec{ref_dim, value_type}(sample_random_point(ref_shape))
                 # Check gradient evaluation
+                f(ξ) = [reference_shape_value(interpolation, Vec{ref_dim}(ξ), i) for i in 1:n_basefuncs]
                 @test vec(ForwardDiff.jacobian(f, Array(x))') ≈
                     reinterpret(value_type, [reference_shape_gradient(interpolation, x, i) for i in 1:n_basefuncs])
                 # Check partition of unity at random point.
@@ -92,104 +187,72 @@ using Ferrite: reference_shape_value, reference_shape_gradient
                 @test_throws ArgumentError reference_shape_value(interpolation, x, n_basefuncs + 1)
                 # Idempotency test
                 @test reference_shape_value(interpolation, x, n_basefuncs) == reference_shape_value(interpolation, x, n_basefuncs)
-            end
-            # Remove after 1.6 is removed from CI (see above)
-            # Show coordinate in case failure (see issue #811)
-            !isempty(random_point_testset.results) && println("^^^^^Random point test failed at $x for $interpolation !^^^^^")
 
-            # Test whether we have for each entity corresponding dof indices (possibly empty)
-            @test length(Ferrite.vertexdof_indices(interpolation)) == Ferrite.nvertices(interpolation)
-            @test length(Ferrite.facedof_indices(interpolation)) == Ferrite.nfaces(interpolation)
-            @test length(Ferrite.facedof_interior_indices(interpolation)) == Ferrite.nfaces(interpolation)
-            @test length(Ferrite.edgedof_indices(interpolation)) == Ferrite.nedges(interpolation)
-            @test length(Ferrite.edgedof_interior_indices(interpolation)) == Ferrite.nedges(interpolation)
-            # We have at least as many edge/face dofs as we have edge/face interior dofs
-            @test all(length.(Ferrite.facedof_interior_indices(interpolation)) .<= length.(Ferrite.facedof_indices(interpolation)))
-            @test all(length.(Ferrite.edgedof_interior_indices(interpolation)) .<= length.(Ferrite.edgedof_indices(interpolation)))
-            # The total number of dofs must match the number of base functions
-            totaldofs = sum(length.(Ferrite.vertexdof_indices(interpolation)); init = 0)
-            totaldofs += sum(length.(Ferrite.facedof_interior_indices(interpolation)); init = 0)
-            totaldofs += sum(length.(Ferrite.edgedof_interior_indices(interpolation)); init = 0)
-            totaldofs += length(Ferrite.volumedof_interior_indices(interpolation))
-            @test totaldofs == n_basefuncs
-
-            # The dof indices are valid.
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.vertexdof_indices(interpolation)])
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.facedof_indices(interpolation)])
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.facedof_interior_indices(interpolation)])
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.edgedof_indices(interpolation)])
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.edgedof_interior_indices(interpolation)])
-            @test all([all(0 .< i .<= n_basefuncs) for i in Ferrite.volumedof_interior_indices(interpolation)])
-
-            # Check for evaluation type correctness of interpolation
-            @testset "return type correctness dof $dof" for dof in 1:n_basefuncs
-                @test (@inferred reference_shape_value(interpolation, x, dof)) isa value_type
-                @test (@inferred reference_shape_gradient(interpolation, x, dof)) isa Vec{ref_dim, value_type}
-            end
-
-            # Check for dirac delta property of interpolation
-            @testset "dirac delta property of dof $dof" for dof in 1:n_basefuncs
-                for k in 1:n_basefuncs
-                    N_dof = reference_shape_value(interpolation, coords[dof], k)
-                    if k == dof
-                        @test N_dof ≈ 1.0
-                    else
-                        factor = interpolation isa Lagrange{RefQuadrilateral, 3} ? 200 : 4
-                        @test N_dof ≈ 0.0 atol = factor * eps(value_type)
-                    end
+                # Check for evaluation type correctness of interpolation
+                for dof in 1:n_basefuncs
+                    @test (@inferred reference_shape_value(interpolation, x, dof)) isa value_type
+                    @test (@inferred reference_shape_gradient(interpolation, x, dof)) isa Vec{ref_dim, value_type}
                 end
-            end
-
-            # Test that facedof_indices(...) return in counter clockwise order (viewing from the outside)
-            if interpolation isa Lagrange
-                function __outward_normal(coords::Vector{<:Vec{1}}, nodes)
-                    n = coords[nodes[1]]
-                    return n / norm(n)
-                end
-                function __outward_normal(coords::Vector{<:Vec{2}}, nodes)
-                    p1 = coords[nodes[1]]
-                    p2 = coords[nodes[2]]
-                    n = Vec{2}((p2[2] - p1[2], - p2[1] + p1[1]))
-                    return n / norm(n)
-                end
-                function __outward_normal(coords::Vector{<:Vec{3}}, nodes)
-                    p1 = coords[nodes[1]]
-                    p2 = coords[nodes[2]]
-                    p3 = coords[nodes[3]]
-                    n = (p3 - p2) × (p1 - p2)
-                    return n / norm(n)
-                end
-                _bfunc = if ref_dim == 3
-                    Ferrite.facedof_indices(interpolation)
-                elseif ref_dim == 2
-                    Ferrite.edgedof_indices(interpolation)
-                elseif ref_dim == 1
-                    Ferrite.vertexdof_indices(interpolation)
-                end
-                for (facenodes, normal) in zip(_bfunc, reference_normals(interpolation))
-                    @test __outward_normal(coords, facenodes) ≈ normal
-                end
-            end
-
-            # regression for https://github.com/Ferrite-FEM/Ferrite.jl/issues/520
-            #=interpolation_type = typeof(interpolation).name.wrapper
-    if func_order > 1 && interpolation_type != Ferrite.Serendipity
-        first_order = interpolation_type{ref_shape,1}()
-        for (highorderface, firstorderface) in zip(Ferrite.facedof_indices(interpolation), Ferrite.facedof_indices(first_order))
-            for (h_node, f_node) in zip(highorderface, firstorderface)
-                @test h_node == f_node
             end
         end
-        if ref_dim > 2
-            for (highorderedge, firstorderedge) in zip(Ferrite.edgedof_indices(interpolation), Ferrite.edgedof_indices(first_order))
-                for (h_node, f_node) in zip(highorderedge, firstorderedge)
+
+        # Check for dirac delta property of interpolation
+        @testset "dirac delta property of dof $dof" for dof in 1:n_basefuncs
+            for k in 1:n_basefuncs
+                N_dof = reference_shape_value(interpolation, coords[dof], k)
+                if k == dof
+                    @test N_dof ≈ 1.0
+                else
+                    factor = interpolation isa Lagrange{RefQuadrilateral, 3} ? 200 : 4
+                    @test N_dof ≈ 0.0 atol = factor * eps(typeof(N_dof))
+                end
+            end
+        end
+
+        # Test that facedof_indices(...) return in counter clockwise order (viewing from the outside)
+        if interpolation isa Lagrange
+            function __outward_normal(coords::Vector{<:Vec{1}}, nodes)
+                n = coords[nodes[1]]
+                return n / norm(n)
+            end
+            function __outward_normal(coords::Vector{<:Vec{2}}, nodes)
+                p1 = coords[nodes[1]]
+                p2 = coords[nodes[2]]
+                n = Vec{2}((p2[2] - p1[2], - p2[1] + p1[1]))
+                return n / norm(n)
+            end
+            function __outward_normal(coords::Vector{<:Vec{3}}, nodes)
+                p1 = coords[nodes[1]]
+                p2 = coords[nodes[2]]
+                p3 = coords[nodes[3]]
+                n = (p3 - p2) × (p1 - p2)
+                return n / norm(n)
+            end
+            normals = reference_normals(getrefshape(interpolation))
+            for (facetnodes, normal) in zip(Ferrite.facetdof_indices(interpolation), normals)
+                @test __outward_normal(coords, facetnodes) ≈ normal
+            end
+        end
+
+        # regression for https://github.com/Ferrite-FEM/Ferrite.jl/issues/520
+        interpolation_type = typeof(interpolation).name.wrapper
+        if func_order > 1 && interpolation_type != Ferrite.Serendipity
+            first_order = interpolation_type{ref_shape, 1}()
+            for (highorderface, firstorderface) in zip(Ferrite.facedof_indices(interpolation), Ferrite.facedof_indices(first_order))
+                for (h_node, f_node) in zip(highorderface, firstorderface)
                     @test h_node == f_node
                 end
             end
+            if ref_dim > 2
+                for (highorderedge, firstorderedge) in zip(Ferrite.edgedof_indices(interpolation), Ferrite.edgedof_indices(first_order))
+                    for (h_node, f_node) in zip(highorderedge, firstorderedge)
+                        @test h_node == f_node
+                    end
+                end
+            end
         end
-    end=#
 
-            # VectorizedInterpolation
+        @testset "VectorizedInterpolation" begin
             v_interpolation_1 = interpolation^2
             v_interpolation_2 = (d = 2; interpolation^d)
             @test getnbasefunctions(v_interpolation_1) ==
@@ -200,12 +263,18 @@ using Ferrite: reference_shape_value, reference_shape_gradient
 
             # Check for evaluation type correctness of vectorized interpolation
             v_interpolation_3 = interpolation^ref_dim
-            @testset "vectorized case of return type correctness of dof $dof" for dof in 1:n_basefuncs
-                @test @inferred(reference_shape_value(v_interpolation_1, x, dof)) isa Vec{2, value_type}
-                @test @inferred(reference_shape_gradient(v_interpolation_3, x, dof)) isa Tensor{2, ref_dim, value_type}
-            end
-        end # correctness testset
 
+            @testset "Value Type $value_type" for value_type in (Float32, Float64)
+                x = Vec{ref_dim, value_type}(sample_random_point(getrefshape(v_interpolation_1)))
+                @testset "vectorized case of return type correctness of dof $dof" for dof in 1:n_basefuncs
+                    @test @inferred(reference_shape_value(v_interpolation_1, x, dof)) isa Vec{2, value_type}
+                    @test @inferred(reference_shape_gradient(v_interpolation_3, x, dof)) isa Tensor{2, ref_dim, value_type}
+                end
+            end
+        end
+    end
+
+    @testset "Discontinuous interpolations" begin
         @test Ferrite.reference_coordinates(DiscontinuousLagrange{RefTriangle, 0}()) ≈ [Vec{2, Float64}((1 / 3, 1 / 3))]
         @test Ferrite.reference_coordinates(DiscontinuousLagrange{RefQuadrilateral, 0}()) ≈ [Vec{2, Float64}((0, 0))]
         @test Ferrite.reference_coordinates(DiscontinuousLagrange{RefTetrahedron, 0}()) ≈ [Vec{3, Float64}((1 / 4, 1 / 4, 1 / 4))]
@@ -264,6 +333,5 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         @test_throws ArgumentError Ferrite.volumedof_interior_indices(ip)
         @test_throws ArgumentError Ferrite.facetdof_interior_indices(ip)
     end
-
 
 end # testset

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -3,8 +3,8 @@ using Ferrite: reference_shape_value, reference_shape_gradient
 """
     test_interpolation_properties(ip::Interpolation)
 
-This function tests the following implementation details for an
-interpolation. All base interpolations should pass this test, but
+This function tests the following
+interpolation properties. All base interpolations should pass this test, but
 `VectorizedInterpolation`s do not which is ok as these are
 special-cased in the code base.
 

--- a/test/test_refshapes.jl
+++ b/test/test_refshapes.jl
@@ -1,0 +1,20 @@
+@testset "ReferenceShape" begin
+    for RefShape in (RefLine, RefTriangle, RefQuadrilateral, RefTetrahedron, RefHexahedron, RefPyramid, RefPrism)
+        @testset "transform facet points" begin
+            # Test both center point and random points on the facet
+            ref_coords = Ferrite.reference_coordinates(Lagrange{RefShape, 1}())
+            for facet in 1:nfacets(RefShape)
+                facet_nodes = collect(Ferrite.reference_facets(RefShape)[facet])
+                facet_coords = ref_coords[facet_nodes]
+                center_coord = sum(facet_coords) / length(facet_nodes)
+                rand_weights = rand(length(facet_nodes))
+                rand_coord = sum(rand_weights .* facet_coords) / sum(rand_weights)
+                for point in (center_coord, rand_coord)
+                    cell_to_facet = Ferrite.element_to_facet_transformation(point, RefShape, facet)
+                    facet_to_cell = Ferrite.facet_to_element_transformation(cell_to_facet, RefShape, facet)
+                    @test point ≈ facet_to_cell
+                end
+            end
+        end
+    end
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -28,21 +28,21 @@ function reference_face_area(fs::Interpolation{RefPyramid}, face::Int)
 end
 
 ######################################################
-# Coordinates and normals for the reference elements #
+# Coordinates and normals for the reference shapes #
 ######################################################
 
-reference_normals(ip::VectorizedInterpolation) = reference_normals(ip.ip)
+function reference_normals(::Interpolation{RefShape}) where {RefShape}
+    @warn "Using reference normals of Interpolation, use of RefShape directly instead"
+    return reference_normals(RefShape)
+end
 
-# Lagrange{1, RefLine}
-function reference_normals(::Lagrange{RefLine})
+function reference_normals(::Type{RefLine})
     return [
         Vec{1, Float64}((-1.0,)),
         Vec{1, Float64}((1.0,)),
     ]
 end
-
-# Lagrange{2, RefQuadrilateral}
-function reference_normals(::Lagrange{RefQuadrilateral})
+function reference_normals(::Type{RefQuadrilateral})
     return [
         Vec{2, Float64}((0.0, -1.0)),
         Vec{2, Float64}((1.0, 0.0)),
@@ -51,8 +51,7 @@ function reference_normals(::Lagrange{RefQuadrilateral})
     ]
 end
 
-# Lagrange{2, RefTriangle}
-function reference_normals(::Lagrange{RefTriangle})
+function reference_normals(::Type{RefTriangle})
     return [
         Vec{2, Float64}((1 / √2, 1 / √2)),
         Vec{2, Float64}((-1.0, 0.0)),
@@ -60,8 +59,7 @@ function reference_normals(::Lagrange{RefTriangle})
     ]
 end
 
-# Lagrange{3, RefTetrahedron}
-function reference_normals(::Lagrange{RefTetrahedron})
+function reference_normals(::Type{RefTetrahedron})
     return [
         Vec{3, Float64}((0.0, 0.0, -1.0)),
         Vec{3, Float64}((0.0, -1.0, 0.0)),
@@ -70,8 +68,7 @@ function reference_normals(::Lagrange{RefTetrahedron})
     ]
 end
 
-# Lagrange{3, Cube}
-function reference_normals(::Lagrange{RefHexahedron})
+function reference_normals(::Type{RefHexahedron})
     return [
         Vec{3, Float64}((0.0, 0.0, -1.0)),
         Vec{3, Float64}((0.0, -1.0, 0.0)),
@@ -82,8 +79,7 @@ function reference_normals(::Lagrange{RefHexahedron})
     ]
 end
 
-# Lagrange{3, Wedge}
-function reference_normals(::Lagrange{RefPrism})
+function reference_normals(::Type{RefPrism})
     return [
         Vec{3, Float64}((0.0, 0.0, -1.0)),
         Vec{3, Float64}((0.0, -1.0, 0.0)),
@@ -93,8 +89,7 @@ function reference_normals(::Lagrange{RefPrism})
     ]
 end
 
-# Lagrange{3, RefPyramid}
-function reference_normals(::Lagrange{RefPyramid})
+function reference_normals(::Type{RefPyramid})
     return [
         Vec{3, Float64}((0.0, 0.0, -1.0)),
         Vec{3, Float64}((0.0, -1.0, 0.0)),
@@ -103,9 +98,6 @@ function reference_normals(::Lagrange{RefPyramid})
         Vec{3, Float64}((0.0, 1 / √2, 1 / √2)),
     ]
 end
-
-# Serendipity{2, RefQuadrilateral}
-reference_normals(::Serendipity{RefQuadrilateral, 2}) = reference_normals(Lagrange{RefQuadrilateral, 1}())
 
 ##################################
 # Valid coordinates by expanding #
@@ -128,7 +120,7 @@ end
 
 function valid_coordinates_and_normals(fs::Interpolation{shape, order}) where {dim, shape <: Ferrite.AbstractRefShape{dim}, order}
     x = Ferrite.reference_coordinates(fs)
-    n = reference_normals(fs)
+    n = reference_normals(shape)
     R = rotmat(dim)
     return [2.0 * (R ⋅ x[i]) for i in 1:length(x)], [(R ⋅ n[i]) / norm((R ⋅ n[i])) for i in 1:length(n)]
 end


### PR DESCRIPTION
This PR includes some modularization of the testing of interpolations started in #798, and is the first breakout from that PR. 

Specifically all tests that every base interpolations should pass should be put into `test_interpolation_properties(ip::Interpolation)`. Having such a function was very valuable when developing the interpolations in #798, and it also makes it easier to include it in testing of such exotic interpolations when all assumptions currently tested for scalar and nodal interpolations don't hold. 

It also separates testing of the reference shapes from the testing of the interpolations, and fixes one discovered issue with the thrown error from `reference_shape_value(ip::DiscontinuousLagrange{shape, 0}, ...` (it silently accepted `i > n_basefunctions`)