### PR TITLE
Make dispatch for reinit without cell more generic

### DIFF
--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -101,7 +101,7 @@ getnquadpoints(cv::CellValues) = getnquadpoints(cv.qr)
 end
 @inline _update_detJdV!(::Nothing, q_point, w, mapping) = nothing
 
-@inline function reinit!(cv::CellValues, x::AbstractVector)
+@inline function reinit!(cv::AbstractCellValues, x::AbstractVector)
     return reinit!(cv, nothing, x)
 end
 

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -120,7 +120,7 @@ function set_current_facet!(fv::FacetValues, facet_nr::Int)
     return
 end
 
-@inline function reinit!(fv::FacetValues, x::AbstractVector, facet_nr::Int)
+@inline function reinit!(fv::AbstractFacetValues, x::AbstractVector, facet_nr::Int)
     return reinit!(fv, nothing, x, facet_nr)
 end
 


### PR DESCRIPTION
Hit this issue when trying to use `IGA.jl` with `FerriteAssembly.jl` after changing `FerriteAssembly.jl` to pass the cell as well. 

After doing it I realized that this PR won't solve that, since `IGA.BezierCoords` isn't a subtype of `AbstractVector`, but nevertheless this makes it easier to support the new interface for other packages. 

I guess allowing `x::Any` in combination with `::AbstractCellValues` could lead to ambiguities, that's why I didn't add that...