### PR TITLE
replaced all deadlinks with wayback links

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -667,7 +667,7 @@ function reference_coordinates(::Lagrange{RefQuadrilateral, 3})
 end
 
 function reference_shape_value(ip::Lagrange{RefQuadrilateral, 3}, ξ::Vec{2}, i::Int)
-    # See https://defelement.com/elements/examples/quadrilateral-Q-3.html
+    # See https://web.archive.org/web/20220817132305/https://defelement.com/elements/examples/quadrilateral-Q-3.html
     # Transform domain from [-1, 1] × [-1, 1] to [0, 1] × [0, 1]
     ξ_x = (ξ[1] + 1) / 2
     ξ_y = (ξ[2] + 1) / 2
@@ -1070,7 +1070,7 @@ end
 #############################
 # Lagrange RefPrism order 1 #
 #############################
-# Build on https://defelement.com/elements/examples/prism-Lagrange-1.html
+# Build on https://web.archive.org/web/20220817123819/https://defelement.com/elements/examples/prism-Lagrange-1.html
 getnbasefunctions(::Lagrange{RefPrism, 1}) = 6
 
 facedof_indices(::Lagrange{RefPrism, 1}) = ((1, 3, 2), (1, 2, 5, 4), (3, 1, 4, 6), (2, 3, 6, 5), (4, 5, 6))
@@ -1101,7 +1101,7 @@ end
 #############################
 # Lagrange RefPrism order 2 #
 #############################
-# Build on https://defelement.com/elements/examples/prism-Lagrange-2.html .
+# Build on https://web.archive.org/web/20220817125403/https://defelement.com/elements/examples/prism-Lagrange-2.html
 # This is simply the tensor-product of a quadratic triangle with a quadratic line.
 getnbasefunctions(::Lagrange{RefPrism, 2}) = 18
 
@@ -1323,7 +1323,7 @@ end
 #######################################
 # Lagrange-Bubble RefTriangle order 1 #
 #######################################
-# Taken from https://defelement.com/elements/bubble-enriched-lagrange.html
+# Taken from https://web.archive.org/web/20240519081038/https://defelement.com/elements/bubble-enriched-lagrange.html 
 getnbasefunctions(::BubbleEnrichedLagrange{RefTriangle, 1}) = 4
 adjust_dofs_during_distribution(::BubbleEnrichedLagrange{RefTriangle, 1}) = false
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1323,7 +1323,7 @@ end
 #######################################
 # Lagrange-Bubble RefTriangle order 1 #
 #######################################
-# Taken from https://web.archive.org/web/20240519081038/https://defelement.com/elements/bubble-enriched-lagrange.html 
+# Taken from https://web.archive.org/web/20240519081038/https://defelement.com/elements/bubble-enriched-lagrange.html
 getnbasefunctions(::BubbleEnrichedLagrange{RefTriangle, 1}) = 4
 adjust_dofs_during_distribution(::BubbleEnrichedLagrange{RefTriangle, 1}) = false
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1323,7 +1323,7 @@ end
 #######################################
 # Lagrange-Bubble RefTriangle order 1 #
 #######################################
-# Taken from https://web.archive.org/web/20240519081038/https://defelement.com/elements/bubble-enriched-lagrange.html
+# Taken from https://web.archive.org/web/20230328191012/https://defelement.com/elements/examples/triangle-bubble-enriched-vector-Lagrange-1.html
 getnbasefunctions(::BubbleEnrichedLagrange{RefTriangle, 1}) = 4
 adjust_dofs_during_distribution(::BubbleEnrichedLagrange{RefTriangle, 1}) = false
 


### PR DESCRIPTION
This PR address issue https://github.com/Ferrite-FEM/Ferrite.jl/issues/1142

Replaced dead links that provided information about the finite elements with the corresponding wayback links. This is still not ideal since in some cases, the wayback machine did not archive a related URL (e.g., the definition for the basis functions for the 1st order BubbleEnrichedLagrange on a triangular element is not accessible: https://web.archive.org/web/20250000000000*/https://defelement.com/elements/examples/triangle-bubble-enriched-lagrange-1.html). 

~A possible solution that I plan on trying this week is to add to `src/interpolations.jl` permalinks to the files from https://github.com/DefElement/DefElement that provide information on the interpolation definitions but whose HTML pages are not archived by the wayback machine. The DefElement files that provide this interpolation information should be findable in the commit history of https://github.com/DefElement/DefElement. The PR should remain in draft mode until this can be resolved.~