### PR TITLE
Make constraint handling tools available for users

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -978,6 +978,18 @@ function _add!(
 
     dofmap = PeriodicDofPosMapping(interpolation, offset)
 
+
+    # Temporary test code
+    ipg = default_geometric_interpolation(interpolation) # dummy
+    bcvalues = BCValues(interpolation, ipg, FacetIndex, offset)
+    pdl = PeriodicDofLocations(interpolation)
+    function _getdofnr(bv::BCValues, facet_nr, dof_location)
+        reinit!(bv, facet_nr)
+        return get_local_dof(bv, dof_location, 1)
+    end
+    # End: Temporary test code
+
+
     # Dof map for mirror dof (constrained) => image dof (master dof)
     # However, here we only add the first component, as the rest can be calculated when needed
     dof_map = Dict{Int, Int}()
@@ -995,6 +1007,14 @@ function _add!(
 
         for dof_location in get_dof_locations(dofmap, facet_pair)
             local_mdof, local_idof = get_local_dof_pair(dofmap, facet_pair, dof_location)
+
+
+            # Temporary test code
+            mirror_dof_location = get_mirror_dof_location(pdl, facet_pair, dof_location)
+            @assert local_idof == _getdofnr(bcvalues, i[2], dof_location)
+            @assert local_mdof == _getdofnr(bcvalues, m[2], mirror_dof_location)
+            # End: Temporary test code
+
 
             idof = image_dofs[local_idof] + first_component_offset
             mdof = mirror_dofs[local_mdof] + first_component_offset

--- a/src/Dofs/periodicity_utils.jl
+++ b/src/Dofs/periodicity_utils.jl
@@ -1,155 +1,3 @@
-struct PeriodicDofPosMapping
-    local_facet_dofpos::Vector{Int}
-    local_facet_dofpos_offset::Vector{Int}
-    rotated_indices::Matrix{Int}
-    mirrored_indices::Vector{Int}
-end
-
-"""
-    PeriodicDofPosMapping(func_interpolation::Interpolation, field_dof_offset)
-
-This helper struct makes it easy to get the corresponding DoF positions between two facets, which may be
-mirrored and/or rotated relative to eachother. A dof position corresponds to the local (cell) dof value for
-standard interpolations, but for `VectorizedInterpolation`s, it corresponds to the local dof value for the
-first component. The functions `get_dof_locations` and `get_local_dof_pair` can be used to get the mapping between
-the *mirror* and *image* DoF, e.g.
-```
-grid = generate_grid(Triangle, (3, 3))
-ip = Lagrange{RefTriangle, 2}()^2
-dh = close!(add!(DofHandler(grid), :u, ip))
-facet_pair = collect_periodic_facets(grid, "right", "left")[1]
-field_dof_offset = 0 # Consider a single field problem (or first field if multifield)
-dofmap = Ferrite.PeriodicDofPosMapping(ip, field_dof_offset)
-for dof_location in Ferrite.get_dof_locations(dofmap, facet_pair)
-    mdof, idof = Ferrite.get_local_dof_pair(dofmap, facet_pair, dof_location)
-    mirror_dof = celldofs(dh, facet_pair.mirror[1])[mdof]
-    image_dof = celldofs(dh, facet_pair.image[1])[idof]
-    println("DoF ", mirror_dof, " should mirror DoF ", image_dof)
-end
-```
-"""
-function PeriodicDofPosMapping(interpolation, field_dof_offset)
-    local_facet_dofpos, local_facet_dofpos_offset = pu_local_facet_dofpos_for_bc(interpolation, field_dof_offset, FacetIndex)
-    ipf_base = get_base_interpolation(interpolation)
-    mirrored_indices = pu_mirror_local_facetdofs(local_facet_dofpos_offset, ipf_base)
-    rotated_indices = pu_rotate_local_facetdofs(local_facet_dofpos_offset, ipf_base)
-    return PeriodicDofPosMapping(local_facet_dofpos, local_facet_dofpos_offset, rotated_indices, mirrored_indices)
-end
-
-function get_dof_locations(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair)
-    mirror_facetnr = facet_pair.mirror[2]
-    offsets = dofmap.local_facet_dofpos_offset
-    return 1:(offsets[mirror_facetnr + 1] - offsets[mirror_facetnr])
-end
-
-function get_local_dof_pair(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair, dof_location::Int)
-    m = facet_pair.mirror
-    i = facet_pair.image
-
-    md = dofmap.local_facet_dofpos_offset[m[2]] + dof_location - 1
-    id = dofmap.local_facet_dofpos_offset[i[2]] + dof_location - 1
-
-    # Rotate the mirror index
-    rotated_md = dofmap.rotated_indices[md, facet_pair.rotation + 1]
-    # Mirror the mirror index (maybe) :)
-    mirrored_md = facet_pair.mirrored ? dofmap.mirrored_indices[rotated_md] : rotated_md
-    idof = dofmap.local_facet_dofpos[id]
-    mdof = dofmap.local_facet_dofpos[mirrored_md]
-    return mdof => idof
-end
-# Convenience (better to use above version and manually add ` component - 1`)
-function get_local_dof_pair(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair, dof_location::Int, component::Int)
-    mdof, idof = get_local_dof_pair(dofmap, facet_pair, dof_location)
-    Δn = component - 1
-    return (mdof + Δn) => (idof + Δn)
-end
-
-function pu_local_facet_dofpos_for_bc(interpolation, field_dof_offset, ::Type{BI}) where {BI <: BoundaryIndex}
-    ipf_base = get_base_interpolation(interpolation)
-    n_dbc_comp = n_dbc_components(interpolation)
-
-    local_facet_dofpos = Int[]
-    local_facet_dofpos_offset = Int[1]
-    for boundarydofs in dirichlet_boundarydof_indices(BI)(ipf_base)
-        for boundarydof in boundarydofs
-            push!(local_facet_dofpos, 1 + (boundarydof - 1) * n_dbc_comp + field_dof_offset)
-        end
-        push!(local_facet_dofpos_offset, length(local_facet_dofpos) + 1)
-    end
-    return local_facet_dofpos, local_facet_dofpos_offset
-end
-
-function pu_mirror_local_facetdofs(_, ::Lagrange{RefLine})
-    return ones(Int, 1) # Nothing to mirror
-end
-function pu_mirror_local_facetdofs(local_facet_dofpos_offset, ip::Lagrange{<:Union{RefQuadrilateral, RefTriangle}})
-    @assert getorder(ip) ≤ 2
-    # For 2D we always permute since Ferrite defines dofs counter-clockwise
-    ret = collect(1:(local_facet_dofpos_offset[end] - 1))
-    for facetnr in 1:nfacets(ip)
-        # Mirror the vertex order
-        v1_offset = local_facet_dofpos_offset[facetnr]
-        v2_offset = v1_offset + 1
-        ret[v1_offset] = v2_offset
-        ret[v2_offset] = v1_offset
-        # TODO: Higher order has more than one edgedof, and this would require mirroring as well.
-    end
-    return ret
-end
-
-# TODO: Can probably be combined with the method above.
-function pu_mirror_local_facetdofs(local_facet_dofpos_offset, ip::Lagrange{<:Union{RefHexahedron, RefTetrahedron}, order}) where {order}
-    @assert 1 <= order <= 2
-    N = ip isa Lagrange{RefHexahedron} ? 4 : 3
-    ret = collect(1:(local_facet_dofpos_offset[end] - 1))
-
-    # Mirror by changing from counter-clockwise to clockwise
-    for facetnr in 1:nfacets(ip)
-        r = local_facet_dofpos_offset[facetnr]:(local_facet_dofpos_offset[facetnr + 1] - 1)
-        # 1. Rotate the corners
-        vertex_range = r[1:N]
-        vlr = @view ret[vertex_range]
-        reverse!(vlr)
-        circshift!(vlr, 1)
-        # 2. Rotate the edge dofs for quadratic interpolation
-        if order > 1
-            edge_range = r[(N + 1):2N]
-            elr = @view ret[edge_range]
-            reverse!(elr)
-            # circshift!(elr, 1) # !!! Note: no shift here
-        end
-    end
-    return ret
-end
-
-function pu_rotate_local_facetdofs(local_facet_dofpos_offset, ip::Lagrange{<:Union{RefQuadrilateral, RefTriangle}})
-    ret = zeros(Int, local_facet_dofpos_offset[end] - 1, 1)
-    ret .= 1:(local_facet_dofpos_offset[end] - 1)
-    return ret
-end
-
-function pu_rotate_local_facetdofs(local_facet_dofpos_offset, ip::Lagrange{<:Union{RefHexahedron, RefTetrahedron}, order}) where {order}
-    @assert 1 <= order <= 2
-    N = ip isa Lagrange{RefHexahedron} ? 4 : 3
-    ret = zeros(Int, local_facet_dofpos_offset[end] - 1, N)
-    ret[:, :] .= 1:(local_facet_dofpos_offset[end] - 1)
-    for f in 1:(length(local_facet_dofpos_offset) - 1)
-        facet_range = local_facet_dofpos_offset[f]:(local_facet_dofpos_offset[f + 1] - 1)
-        for i in 1:(N - 1)
-            # 1. Rotate the vertex dofs
-            vertex_range = facet_range[1:N]
-            circshift!(@view(ret[vertex_range, i + 1]), @view(ret[vertex_range, i]), -1)
-            # 2. Rotate the edge dofs
-            if order > 1
-                edge_range = facet_range[(N + 1):2N]
-                circshift!(@view(ret[edge_range, i + 1]), @view(ret[edge_range, i]), -1)
-            end
-        end
-    end
-    return ret
-end
-
-
 struct PeriodicDofLocations
     local_facet_dofpos_offset::Vector{Int}
     rotated_indices::Matrix{Int}
@@ -192,6 +40,7 @@ function compute_mirror_indices!(pdl::PeriodicDofLocations, ip::Lagrange{<:Union
     # Mirror by changing from counter-clockwise to clockwise
     for (facetnr, nverts) in pairs(length.(reference_facets(getrefshape(ip))))
         inds = get_mirrored_indices(pdl, facetnr)
+        inds .= 1:length(inds)
         # 1. Rotate the vertices
         vertex_range = 1:nverts
         vlr = @view inds[vertex_range]
@@ -231,21 +80,26 @@ function compute_rotated_indices!(pdl::PeriodicDofLocations, ip::Lagrange{<:Unio
                 view(get_rotation_indices(pdl, facetnr, i), vertex_range),
                 view(get_rotation_indices(pdl, facetnr, i - 1), vertex_range), -1
             )
-            # 2. Rotate the edge dofs
             if order == 2
+                # 2. Rotate the edge dofs
                 circshift!(
                     view(get_rotation_indices(pdl, facetnr, i), edge_range),
                     view(get_rotation_indices(pdl, facetnr, i - 1), edge_range), -1
                 )
+                # 3. No change for face dof for Lagrange{RefHexahedron,2}
+                if ip isa Lagrange{RefHexahedron, 2}
+                    get_rotation_indices(pdl, facetnr, i)[end] = get_rotation_indices(pdl, facetnr, i - 1)[end]
+                end
             end
         end
     end
     return pdl
 end
 
-function get_mirror_dof_location(pdl::PeriodicDofLocations, fp::PeriodicFacetPair, image_dof_location::Integer)
+function get_mirror_dof_location(pdl::PeriodicDofLocations, fp::PeriodicFacetPair, image_dof_location::DofLocation)
+    locnr = image_dof_location.location_nr
     facetnr = fp.mirror[2]
-    rotated_dof_location = get_rotation_indices(pdl, facetnr, fp.rotation)[image_dof_location]
+    rotated_dof_location = get_rotation_indices(pdl, facetnr, fp.rotation)[locnr]
     mirrored_dof_location = fp.mirrored ? get_mirrored_indices(pdl, facetnr)[rotated_dof_location] : rotated_dof_location
-    return mirrored_dof_location
+    return DofLocation(facetnr, mirrored_dof_location)
 end

--- a/src/Dofs/periodicity_utils.jl
+++ b/src/Dofs/periodicity_utils.jl
@@ -1,0 +1,154 @@
+#= Some notes
+In general, a permutation of the dof_location could be nice instead, as this would
+also allow easy mapping of coordinates when combined with the new BCValues.
+=#
+struct PeriodicDofPosMapping
+    local_facet_dofpos::Vector{Int}
+    local_facet_dofpos_offset::Vector{Int}
+    rotated_indices::Matrix{Int}
+    mirrored_indices::Vector{Int}
+end
+
+"""
+    PeriodicDofPosMapping(func_interpolation::Interpolation, field_dof_offset)
+
+This helper struct makes it easy to get the corresponding DoF positions between two facets, which may be
+mirrored and/or rotated relative to eachother. A dof position corresponds to the local (cell) dof value for
+standard interpolations, but for `VectorizedInterpolation`s, it corresponds to the local dof value for the
+first component. The functions `get_dof_locations` and `get_local_dof_pair` can be used to get the mapping between
+the *mirror* and *image* DoF, e.g.
+```
+grid = generate_grid(Triangle, (3, 3))
+ip = Lagrange{RefTriangle, 2}()^2
+dh = close!(add!(DofHandler(grid), :u, ip))
+facet_pair = collect_periodic_facets(grid, "right", "left")[1]
+field_dof_offset = 0 # Consider a single field problem (or first field if multifield)
+dofmap = Ferrite.PeriodicDofPosMapping(ip, field_dof_offset)
+for dof_location in Ferrite.get_dof_locations(dofmap, facet_pair)
+    mdof, idof = Ferrite.get_local_dof_pair(dofmap, facet_pair, dof_location)
+    mirror_dof = celldofs(dh, facet_pair.mirror[1])[mdof]
+    image_dof = celldofs(dh, facet_pair.image[1])[idof]
+    println("DoF ", mirror_dof, " should mirror DoF ", image_dof)
+end
+```
+"""
+function PeriodicDofPosMapping(interpolation, field_dof_offset)
+    local_facet_dofpos, local_facet_dofpos_offset = pu_local_facet_dofpos_for_bc(interpolation, field_dof_offset, FacetIndex)
+    ipf_base = get_base_interpolation(interpolation)
+    mirrored_indices = pu_mirror_local_facetdofs(local_facet_dofpos, local_facet_dofpos_offset, ipf_base)
+    rotated_indices = pu_rotate_local_facetdofs(local_facet_dofpos, local_facet_dofpos_offset, ipf_base)
+    return PeriodicDofPosMapping(local_facet_dofpos, local_facet_dofpos_offset, rotated_indices, mirrored_indices)
+end
+
+function get_dof_locations(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair)
+    mirror_facetnr = facet_pair.mirror[2]
+    offsets = dofmap.local_facet_dofpos_offset
+    return 1:(offsets[mirror_facetnr + 1] - offsets[mirror_facetnr])
+end
+
+function get_local_dof_pair(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair, dof_location::Int)
+    m = facet_pair.mirror
+    i = facet_pair.image
+
+    md = dofmap.local_facet_dofpos_offset[m[2]] + dof_location - 1
+    id = dofmap.local_facet_dofpos_offset[i[2]] + dof_location - 1
+
+    # Rotate the mirror index
+    rotated_md = dofmap.rotated_indices[md, facet_pair.rotation + 1]
+    # Mirror the mirror index (maybe) :)
+    mirrored_md = facet_pair.mirrored ? dofmap.mirrored_indices[rotated_md] : rotated_md
+    idof = dofmap.local_facet_dofpos[id]
+    mdof = dofmap.local_facet_dofpos[mirrored_md]
+    return mdof => idof
+end
+# Convenience (better to use above version and manually add ` component - 1`)
+function get_local_dof_pair(dofmap::PeriodicDofPosMapping, facet_pair::PeriodicFacetPair, dof_location::Int, component::Int)
+    mdof, idof = get_local_dof_pair(dofmap, facet_pair, dof_location)
+    Δn = component - 1
+    return (mdof + Δn) => (idof + Δn)
+end
+
+function pu_local_facet_dofpos_for_bc(interpolation, field_dof_offset, ::Type{BI}) where {BI <: BoundaryIndex}
+    ipf_base = get_base_interpolation(interpolation)
+    n_dbc_comp = n_dbc_components(interpolation)
+
+    local_facet_dofpos = Int[]
+    local_facet_dofpos_offset = Int[1]
+    for boundarydofs in dirichlet_boundarydof_indices(BI)(ipf_base)
+        for boundarydof in boundarydofs
+            push!(local_facet_dofpos, 1 + (boundarydof - 1) * n_dbc_comp + field_dof_offset)
+        end
+        push!(local_facet_dofpos_offset, length(local_facet_dofpos) + 1)
+    end
+    return local_facet_dofpos, local_facet_dofpos_offset
+end
+
+function pu_mirror_local_facetdofs(_, _, ::Lagrange{RefLine})
+    return ones(Int, 1) # Nothing to mirror
+end
+function pu_mirror_local_facetdofs(local_facet_dofpos, local_facet_dofpos_offse, ip::Lagrange{<:Union{RefQuadrilateral, RefTriangle}})
+    @assert getorder(ip) ≤ 2
+    # For 2D we always permute since Ferrite defines dofs counter-clockwise
+    ret = collect(1:length(local_facet_dofpos))
+    for facetnr in 1:nfacets(ip)
+        # Mirror the vertex order
+        v1_offset = local_facet_dofpos_offse[facetnr]
+        v2_offset = v1_offset + 1
+        ret[v1_offset] = v2_offset
+        ret[v2_offset] = v1_offset
+        # TODO: Higher order has more than one edgedof, and this would require mirroring as well.
+    end
+    return ret
+end
+
+# TODO: Can probably be combined with the method above.
+function pu_mirror_local_facetdofs(local_facet_dofpos, local_facet_dofpos_offset, ip::Lagrange{<:Union{RefHexahedron, RefTetrahedron}, order}) where {order}
+    @assert 1 <= order <= 2
+    N = ip isa Lagrange{RefHexahedron} ? 4 : 3
+    ret = collect(1:length(local_facet_dofpos))
+
+    # Mirror by changing from counter-clockwise to clockwise
+    for facetnr in 1:nfacets(ip)
+        r = local_facet_dofpos_offset[facetnr]:(local_facet_dofpos_offset[facetnr + 1] - 1)
+        # 1. Rotate the corners
+        vertex_range = r[1:N]
+        vlr = @view ret[vertex_range]
+        reverse!(vlr)
+        circshift!(vlr, 1)
+        # 2. Rotate the edge dofs for quadratic interpolation
+        if order > 1
+            edge_range = r[(N + 1):2N]
+            elr = @view ret[edge_range]
+            reverse!(elr)
+            # circshift!(elr, 1) # !!! Note: no shift here
+        end
+    end
+    return ret
+end
+
+function pu_rotate_local_facetdofs(local_facet_dofpos, _, ip::Lagrange{<:Union{RefQuadrilateral, RefTriangle}})
+    ret = similar(local_facet_dofpos, length(local_facet_dofpos), 1)
+    ret .= 1:length(local_facet_dofpos)
+    return ret
+end
+
+function pu_rotate_local_facetdofs(local_facet_dofpos, local_facet_dofpos_offset, ip::Lagrange{<:Union{RefHexahedron, RefTetrahedron}, order}) where {order}
+    @assert 1 <= order <= 2
+    N = ip isa Lagrange{RefHexahedron} ? 4 : 3
+    ret = similar(local_facet_dofpos, length(local_facet_dofpos), N)
+    ret[:, :] .= 1:length(local_facet_dofpos)
+    for f in 1:(length(local_facet_dofpos_offset) - 1)
+        facet_range = local_facet_dofpos_offset[f]:(local_facet_dofpos_offset[f + 1] - 1)
+        for i in 1:(N - 1)
+            # 1. Rotate the vertex dofs
+            vertex_range = facet_range[1:N]
+            circshift!(@view(ret[vertex_range, i + 1]), @view(ret[vertex_range, i]), -1)
+            # 2. Rotate the edge dofs
+            if order > 1
+                edge_range = facet_range[(N + 1):2N]
+                circshift!(@view(ret[edge_range, i + 1]), @view(ret[edge_range, i]), -1)
+            end
+        end
+    end
+    return ret
+end

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -195,10 +195,11 @@ function reinit!(bcv::BCValues, current_entity::Int)
 end
 
 function BCValues(
-        ::Type{T}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape},
+        ::Type{T}, func_interpol::Interpolation{refshape}, ipg::Interpolation{refshape},
         boundary_type::Type{<:BoundaryIndex}, field_dof_offset
     ) where {T, dim, refshape <: AbstractRefShape{dim}}
 
+    geom_interpol = get_base_interpolation(ipg)
     dof_coords = reference_coordinates(func_interpol)
     n_geom_basefuncs = getnbasefunctions(geom_interpol)
     n_dbc_comp = n_dbc_components(func_interpol)


### PR DESCRIPTION
Supersedes #1152 

Currently, there is a lot of nice functionality for working with dofs and constraints that are not available for users, without relying in clearly internal functions, such as `_local_facet_dofs_for_bc` (ref. e.g. if one should make a how-to from #1119).

The aim of this PR is to make some of this available to users, in particular, the local dofs belonging to an entity are made available via an updated `BCValues` struct. Secondly, the logic for getting periodic dofs are included in a new `PeriodicDofLocations` struct. 

Finally, the concept of a `DofLocation` is included more formally (we use this already, but this PR adds a separate type of this). For a nodal interpolation a `DofLocation` has an actual coordinate (but abstractly doesn't have to). For vectorized interpolations, we can have multiple dofs associated with a single `DofLocation`. 

With the tools introduced, we have the following possibilities, 
```julia
bcv = BCValues(func_interpolation, geom_interpolation, boundary_type::Type{<:BoundaryIndex}, field_offset)
get_dof_locations(bcv::BCValues, entitynr::Int) # Iterate over the `DofLocation`s for the given entity
x = spatial_coordinate(bcv::BCValues, loc::DofLocation, cell_coords) # No need to update entity index in `bcv` to get global coord of a dof location 
local_dof = get_local_dof(bcv::BCValues, loc, component) # celldofs[local_dof] gives global dof for the local dof at location `loc` at component `component`. 

pdl = PeriodicDofLocations(function_interpolation)
component = 1
for image_dof_location in get_dof_locations(bcv, image_facet)
    # Using fp::PeriodicFacetPair from `collect_periodic_facets`
    mirror_dof_location = get_mirror_dof_location(pdl, fp, image_dof_location)
    local_image_dof = get_local_dof(bcv, image_dof_location, component)
    local_mirror_dof = get_local_dof(bcv, mirror_dof_location, component)
    ...
end
```

Currently, I haven't added exports or much documentation. Would be grateful for some feedback. My goal is allowing users build their own custom constraints more easily. 

Brief summary of the internal changes in the code as a result of this
* Removed the `local_facet_dofs` and `local_facet_dofs_offset` fields from `Dirichlet`. (These were also used for nodal BCs, so same fields are there but renamed to describe what they do)
* The `local_facet_dofs` logic is now only for the first dof, and only when calling `get_local_dof` the vector component for vectorized interpolations are used. 
* For `PeriodicDirichlet`, everything now works by identifying dofs with the first component, all components are only added in the end. We also don't use a separate iterator when the rotation matrix is given, as we use the same strategy there.

I moved the `PeriodicDofLocations` functionality into `periodicity_utils.jl`, this can of course be included in `ConstraintHandler.jl`, however, I believe it would be easier to navigate if we could move all logic related to periodicity into a separate file as it is quite hard to navigate the `ConstraintHandler.jl` file.
