### PR TITLE
Base test_utils more on reference shape than interpolations

### DIFF
--- a/test/test_cellvalues.jl
+++ b/test/test_cellvalues.jl
@@ -29,6 +29,7 @@
                 @inferred CellValues(quad_rule, func_interpol, geom_interpol; update_gradients = Val(false), update_detJdV = Val(false))
             end
             rdim = Ferrite.getrefdim(func_interpol)
+            RefShape = Ferrite.getrefshape(func_interpol)
             n_basefuncs = getnbasefunctions(func_interpol)
 
             @test getnbasefunctions(cv) == n_basefuncs
@@ -132,7 +133,7 @@
             for i in 1:getnquadpoints(cv)
                 vol += getdetJdV(cv, i)
             end
-            @test vol ≈ reference_volume(func_interpol)
+            @test vol ≈ reference_volume(RefShape)
 
             # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
             for (i, qp_x) in pairs(Ferrite.getpoints(quad_rule))

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -27,14 +27,15 @@
             end
 
             rdim = Ferrite.getrefdim(func_interpol)
+            RefShape = Ferrite.getrefshape(func_interpol)
             n_basefuncs = getnbasefunctions(func_interpol)
 
             @test getnbasefunctions(fv) == n_basefuncs
 
             coords, n = valid_coordinates_and_normals(func_interpol)
-            for face in 1:Ferrite.nfacets(func_interpol)
-                reinit!(fv, coords, face)
-                @test Ferrite.getcurrentfacet(fv) == face
+            for facet in 1:Ferrite.nfacets(func_interpol)
+                reinit!(fv, coords, facet)
+                @test Ferrite.getcurrentfacet(fv) == facet
 
                 # We test this by applying a given deformation gradient on all the nodes.
                 # Since this is a linear deformation we should get back the exact values
@@ -101,7 +102,7 @@
                 # Only do this for one interpolation becuase it relise on AD on "iterative function"
                 if scalar_interpol === Lagrange{RefQuadrilateral, 2}()
                     coords_nl = [x + rand(x) * 0.01 for x in coords] # add some displacement to nodes
-                    reinit!(fv, coords_nl, face)
+                    reinit!(fv, coords_nl, facet)
 
                     _ue_nl = [u_funk(coords_nl[i], V, G, H) for i in 1:n_basefunc_base]
                     ue_nl = reinterpret(Float64, _ue_nl)
@@ -115,7 +116,7 @@
                             @test Ferrite.function_hessian(fv, i, ue_nl) ≈ Hqp
                         end
                     end
-                    reinit!(fv, coords, face) # reinit back to old coords
+                    reinit!(fv, coords, facet) # reinit back to old coords
                 end
 
 
@@ -125,18 +126,18 @@
                     vol += getdetJdV(fv, i)
                 end
                 let ip_base = func_interpol isa VectorizedInterpolation ? func_interpol.ip : func_interpol
-                    x_face = coords[[Ferrite.facetdof_indices(ip_base)[face]...]]
-                    @test vol ≈ calculate_facet_area(ip_base, x_face, face)
+                    x_face = coords[[Ferrite.facetdof_indices(ip_base)[facet]...]]
+                    @test vol ≈ calculate_facet_area(ip_base, x_face, facet)
                 end
 
                 # Test quadrature rule after reinit! with ref. coords
                 x = Ferrite.reference_coordinates(func_interpol)
-                reinit!(fv, x, face)
+                reinit!(fv, x, facet)
                 vol = 0.0
                 for i in 1:getnquadpoints(fv)
                     vol += getdetJdV(fv, i)
                 end
-                @test vol ≈ reference_face_area(func_interpol, face)
+                @test vol ≈ reference_facet_area(RefShape, facet)
 
                 # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
                 # # TODO: Renable somehow after quad rule is no longer stored in FacetValues

--- a/test/test_quadrules.jl
+++ b/test/test_quadrules.jl
@@ -109,7 +109,7 @@ using Ferrite: reference_shape_value
                         fcoords[i] = x
                     end
                     ipcell = Lagrange{refshape, 1}()
-                    ipface = Lagrange{getfacerefshape(cell, lfaceid), 1}()
+                    ipface = Lagrange{getfacetrefshape(refshape, lfaceid), 1}()
 
                     ξface = rand(Vec_face_t) / 4
                     ξcell = Ferrite.facet_to_element_transformation(ξface, refshape, lfaceid)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -5,26 +5,33 @@ using Ferrite: reference_shape_value
 #####################################
 # Volume for the reference elements #
 #####################################
-reference_volume(::Interpolation{Ferrite.RefHypercube{dim}}) where {dim} = 2^dim
-reference_volume(::Interpolation{Ferrite.RefSimplex{dim}}) where {dim} = 1 / factorial(dim)
-reference_volume(::Interpolation{RefPrism}) = 1 / 2
-reference_volume(::Interpolation{RefPyramid}) = 1 / 3
-# For faces
-reference_face_area(fs::VectorizedInterpolation, f::Int) = reference_face_area(fs.ip, f)
-reference_face_area(fs::Interpolation{Ferrite.RefHypercube{dim}}, face::Int) where {dim} = 2^(dim - 1)
-reference_face_area(fs::Interpolation{RefTriangle}, face::Int) = face == 1 ? sqrt(2) : 1.0
-reference_face_area(fs::Interpolation{RefTetrahedron}, face::Int) = face == 3 ? sqrt(2 * 1.5) / 2.0 : 0.5
-function reference_face_area(fs::Interpolation{RefPrism}, face::Int)
-    face == 4 && return √2
-    face ∈ [1, 5] && return 0.5
-    face ∈ [2, 3] && return 1.0
-    error("Invalid face index")
+function reference_volume(::Interpolation{RefShape}) where {RefShape}
+    @warn "Using reference_volume of Interpolation, use RefShape directly instead"
+    return reference_volume(RefShape)
 end
-function reference_face_area(fs::Interpolation{RefPyramid}, face::Int)
-    face == 1 && return 1.0
-    face ∈ [2, 3] && return 0.5
-    face ∈ [4, 5] && return sqrt(2) / 2
-    error("Invalid face index")
+reference_volume(::Type{Ferrite.RefHypercube{dim}}) where {dim} = 2^dim
+reference_volume(::Type{Ferrite.RefSimplex{dim}}) where {dim} = 1 / factorial(dim)
+reference_volume(::Type{RefPrism}) = 1 / 2
+reference_volume(::Type{RefPyramid}) = 1 / 3
+# For facets
+function reference_facet_area(::Interpolation{RefShape}, facetnr::Int) where {RefShape}
+    @warn "Using reference_facet_area of Interpolation, use RefShape directly instead"
+    return reference_facet_area(RefShape, facetnr)
+end
+reference_facet_area(::Type{Ferrite.RefHypercube{dim}}, ::Int) where {dim} = 2^(dim - 1)
+reference_facet_area(::Type{RefTriangle}, facet::Int) = facet == 1 ? sqrt(2) : 1.0
+reference_facet_area(::Type{RefTetrahedron}, facet::Int) = facet == 3 ? sqrt(2 * 1.5) / 2.0 : 0.5
+function reference_facet_area(::Type{RefPrism}, facet::Int)
+    facet == 4 && return √2
+    facet ∈ [1, 5] && return 0.5
+    facet ∈ [2, 3] && return 1.0
+    error("Invalid facet index")
+end
+function reference_facet_area(::Type{RefPyramid}, facet::Int)
+    facet == 1 && return 1.0
+    facet ∈ [2, 3] && return 0.5
+    facet ∈ [4, 5] && return sqrt(2) / 2
+    error("Invalid facet index")
 end
 
 ######################################################
@@ -32,7 +39,7 @@ end
 ######################################################
 
 function reference_normals(::Interpolation{RefShape}) where {RefShape}
-    @warn "Using reference normals of Interpolation, use of RefShape directly instead"
+    @warn "Using reference normals of Interpolation, use RefShape directly instead"
     return reference_normals(RefShape)
 end
 
@@ -261,14 +268,14 @@ coords_on_faces(x, ::Serendipity{RefHexahedron, 2}) =
 check_equal_or_nan(a::Any, b::Any) = a == b || (isnan(a) && isnan(b))
 check_equal_or_nan(a::Union{Tensor, Array}, b::Union{Tensor, Array}) = all(check_equal_or_nan.(a, b))
 
-######################################################
+#######################################################
 # Helpers for testing facet_to_element_transformation #
-######################################################
-getfacerefshape(::Union{Quadrilateral, Triangle}, ::Int) = RefLine
-getfacerefshape(::Hexahedron, ::Int) = RefQuadrilateral
-getfacerefshape(::Tetrahedron, ::Int) = RefTriangle
-getfacerefshape(::Pyramid, face::Int) = face == 1 ? RefQuadrilateral : RefTriangle
-getfacerefshape(::Wedge, face::Int) = face ∈ (1, 5) ? RefTriangle : RefQuadrilateral
+#######################################################
+getfacetrefshape(::Type{<:Ferrite.AbstractRefShape{2}}, ::Int) = RefLine
+getfacetrefshape(::Type{<:RefHexahedron}, ::Int) = RefQuadrilateral
+getfacetrefshape(::Type{RefTetrahedron}, ::Int) = RefTriangle
+getfacetrefshape(::Type{RefPyramid}, facet::Int) = facet == 1 ? RefQuadrilateral : RefTriangle
+getfacetrefshape(::Type{RefPrism}, facet::Int) = facet ∈ (1, 5) ? RefTriangle : RefQuadrilateral
 
 function perturb_standard_grid!(grid::Ferrite.AbstractGrid{dim}, strength) where {dim}
     function perturb(x::Vec{dim}) where {dim}

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -5,19 +5,11 @@ using Ferrite: reference_shape_value
 #####################################
 # Volume for the reference elements #
 #####################################
-function reference_volume(::Interpolation{RefShape}) where {RefShape}
-    @warn "Using reference_volume of Interpolation, use RefShape directly instead"
-    return reference_volume(RefShape)
-end
 reference_volume(::Type{Ferrite.RefHypercube{dim}}) where {dim} = 2^dim
 reference_volume(::Type{Ferrite.RefSimplex{dim}}) where {dim} = 1 / factorial(dim)
 reference_volume(::Type{RefPrism}) = 1 / 2
 reference_volume(::Type{RefPyramid}) = 1 / 3
 # For facets
-function reference_facet_area(::Interpolation{RefShape}, facetnr::Int) where {RefShape}
-    @warn "Using reference_facet_area of Interpolation, use RefShape directly instead"
-    return reference_facet_area(RefShape, facetnr)
-end
 reference_facet_area(::Type{Ferrite.RefHypercube{dim}}, ::Int) where {dim} = 2^(dim - 1)
 reference_facet_area(::Type{RefTriangle}, facet::Int) = facet == 1 ? sqrt(2) : 1.0
 reference_facet_area(::Type{RefTetrahedron}, facet::Int) = facet == 3 ? sqrt(2 * 1.5) / 2.0 : 0.5
@@ -37,11 +29,6 @@ end
 ######################################################
 # Coordinates and normals for the reference shapes #
 ######################################################
-
-function reference_normals(::Interpolation{RefShape}) where {RefShape}
-    @warn "Using reference normals of Interpolation, use RefShape directly instead"
-    return reference_normals(RefShape)
-end
 
 function reference_normals(::Type{RefLine})
     return [


### PR DESCRIPTION
This updates `test_utils.jl` such that instead of relying on `::Interpolation{RefShape}` dispatches, we reduce it down to only the reference shape. Similar for `AbstracCell`, we use the corresponding reference shape when that is the required information. 

Also corrects some `face` -> `facet`. 