### PR TITLE
Test continuity for Nedelec on mixed grid

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1942,3 +1942,25 @@ function get_direction(::Nedelec{RefTriangle, 2}, j, cell)
     edge = edges(cell)[(j + 1) ÷ 2]
     return ifelse(edge[2] > edge[1], 1, -1)
 end
+
+# RefQuadrilateral, 1st order Lagrange
+# https://defelement.org/elements/examples/quadrilateral-nedelec1-lagrange-1.html
+# Scaled by 1/2 as the reference edge length in Ferrite is length 2, but 1 in DefElement.
+function reference_shape_value(ip::Nedelec{RefQuadrilateral, 1}, ξ::Vec{2, T}, i::Int) where {T}
+    x, y = ξ
+    nil = zero(T)
+
+    i == 1 && return Vec((1 - y) / 4, nil)
+    i == 2 && return Vec(nil, (1 + x) / 4)
+    i == 3 && return Vec(-(1 + y) / 4, nil) # Changed sign, follow Ferrite's sign convention
+    i == 4 && return Vec(nil, -(1 - x) / 4) # Changed sign, follow Ferrite's sign convention
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+getnbasefunctions(::Nedelec{RefQuadrilateral, 1}) = 4
+edgedof_interior_indices(::Nedelec{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
+adjust_dofs_during_distribution(::Nedelec{RefQuadrilateral, 1}) = false
+function get_direction(::Nedelec{RefQuadrilateral, 1}, j, cell)
+    edge = edges(cell)[j]
+    return ifelse(edge[2] > edge[1], 1, -1)
+end

--- a/test/test_continuity.jl
+++ b/test/test_continuity.jl
@@ -178,7 +178,7 @@
     ip1 = Nedelec{RefTriangle, 1}(); set1 = setdiff(1:getncells(mixgrid), cellnr)
     ip2 = Nedelec{RefQuadrilateral, 1}(); set2 = Set(cellnr)
     @testset "Quad in Tri-grid, 1st order Nedelec" begin
-        for testcell in (basecell,) #cell_permutations(basecell)
+        for testcell in cell_permutations(basecell)
             mixgrid.cells[cellnr] = testcell
             dh = DofHandler(mixgrid)
             sdh1 = SubDofHandler(dh, set1)
@@ -187,7 +187,7 @@
             add!(sdh2, :u, ip2)
             close!(dh)
             cnt = 0
-            for facetnr in 1:1 #:nfacets(testcell)
+            for facetnr in 1:nfacets(testcell)
                 fi = FacetIndex(cellnr, facetnr)
                 # Check continuity of function value according to continuity_function
                 found_matching = test_continuity(dh, fi; transformation_function = continuity_function(ip1))

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -354,9 +354,9 @@ end
 
     @testset "H(curl) and H(div)" begin
         Hcurl_interpolations = [Nedelec{RefTriangle, 1}(), Nedelec{RefTriangle, 2}()] # Nedelec{3, RefTetrahedron, 1}(), Nedelec{3, RefHexahedron, 1}()]
-        Hdiv_interpolations = [RaviartThomas{RefTriangle, 1}(), RaviartThomas{RefTriangle, 2}(), BrezziDouglasMarini{RefTriangle, 1}()]
-        test_interpolation_properties.(Hcurl_interpolations)  # Requires PR1136
-        test_interpolation_properties.(Hdiv_interpolations)   # Requires PR1136
+        Hdiv_interpolations = [RaviartThomas{RefTriangle, 1}(), RaviartThomas{RefTriangle, 2}(), Nedelec{RefQuadrilateral, 1}(), BrezziDouglasMarini{RefTriangle, 1}()]
+        test_interpolation_properties.(Hcurl_interpolations)
+        test_interpolation_properties.(Hdiv_interpolations)
 
         # These reference moments define the functionals that an interpolation should fulfill
         reference_moment(::RaviartThomas{RefTriangle, 1}, s, facet_shape_nr) = 1
@@ -364,6 +364,8 @@ end
         reference_moment(::BrezziDouglasMarini{RefTriangle, 1}, s, facet_shape_nr) = facet_shape_nr == 1 ? (1 - s) : s
         reference_moment(::Nedelec{RefTriangle, 1}, s, edge_shape_nr) = 1
         reference_moment(::Nedelec{RefTriangle, 2}, s, edge_shape_nr) = edge_shape_nr == 1 ? (1 - s) : s
+        reference_moment(::Nedelec{RefQuadrilateral, 1}, s, edge_shape_nr) = 1
+
 
         function_space(::RaviartThomas) = Val(:Hdiv)
         function_space(::BrezziDouglasMarini) = Val(:Hdiv)

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -366,7 +366,6 @@ end
         reference_moment(::Nedelec{RefTriangle, 2}, s, edge_shape_nr) = edge_shape_nr == 1 ? (1 - s) : s
         reference_moment(::Nedelec{RefQuadrilateral, 1}, s, edge_shape_nr) = 1
 
-
         function_space(::RaviartThomas) = Val(:Hdiv)
         function_space(::BrezziDouglasMarini) = Val(:Hdiv)
         function_space(::Nedelec) = Val(:Hcurl)

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -353,8 +353,8 @@ end
     end
 
     @testset "H(curl) and H(div)" begin
-        Hcurl_interpolations = [Nedelec{RefTriangle, 1}(), Nedelec{RefTriangle, 2}()] # Nedelec{3, RefTetrahedron, 1}(), Nedelec{3, RefHexahedron, 1}()]
-        Hdiv_interpolations = [RaviartThomas{RefTriangle, 1}(), RaviartThomas{RefTriangle, 2}(), Nedelec{RefQuadrilateral, 1}(), BrezziDouglasMarini{RefTriangle, 1}()]
+        Hcurl_interpolations = [Nedelec{RefTriangle, 1}(), Nedelec{RefTriangle, 2}(), Nedelec{RefQuadrilateral, 1}()] # Nedelec{3, RefTetrahedron, 1}(), Nedelec{3, RefHexahedron, 1}()]
+        Hdiv_interpolations = [RaviartThomas{RefTriangle, 1}(), RaviartThomas{RefTriangle, 2}(), BrezziDouglasMarini{RefTriangle, 1}()]
         test_interpolation_properties.(Hcurl_interpolations)
         test_interpolation_properties.(Hdiv_interpolations)
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -345,3 +345,41 @@ function function_value_from_physical_coord(interpolation::Interpolation, cell_c
     end
     return u
 end
+
+# Insert different cell(s) into a grid with a single cell type.
+# This is useful for testing properties on mixed grids.
+
+"""
+grid_with_inserted_quad(
+    grid::Grid{2, <:Union{Triangle, QuadraticTriangle}}, nrs::NTuple{2, Int};
+    update_sets = true)
+
+Replace the two triangles with cell `nrs` by a single Quadrilateral cell, and return
+the new grid along with the cell number of the inserted cell.
+If `updated_sets = true`, the sets should be updated and included in the new grid,
+otherwise there are no sets.
+"""
+function grid_with_inserted_quad(grid::Grid{2, Triangle}, nrs::NTuple{2, Int}; update_sets = true)
+    nrs = nrs[2] > nrs[1] ? nrs : (nrs[2], nrs[1]) # Sort.
+    t1, t2 = getcells.((grid,), nrs)
+    # Find the node numbers of for the new quadrilateral
+    t1v, t2v = Ferrite.vertices.((t1, t2))
+    @assert length(intersect(t1v, t2v)) == 2 # Exactly two overlapping vertices.
+    i1 = findfirst(v -> v ∉ t2v, t1v)
+    v1 = t1v[i1]
+    v2 = t1v[mod1(i1 + 1, 3)]
+    v3 = t2v[findfirst(v -> v ∉ t1v, t2v)]
+    v4 = t1v[mod1(i1 + 2, 3)]
+    quadcell = Quadrilateral((v1, v2, v3, v4))
+    cells = Union{Triangle, Quadrilateral}[]
+    append!(cells, grid.cells[1:(nrs[1] - 1)])
+    push!(cells, quadcell)
+    append!(cells, grid.cells[(nrs[1] + 1):(nrs[2] - 1)])
+    append!(cells, grid.cells[(nrs[2] + 1):end])
+    if !update_sets
+        return Grid(cells, grid.nodes), nrs[1]
+    else
+        throw(ArgumentError("Updating and including sets is not implemented"))
+    end
+    # TODO: Update sets (not needed for current usage)
+end


### PR DESCRIPTION
Adding testing of mixed grid Nedelec continuity needed to validate #1162, should be merged before that. 

Note: Implementation of `Nedelec{RefQuadrilateral, 1}` based on the work from @gijswl in #1162. 

Also adds a test utility function `grid_with_inserted_quad` to allow easier creation of a mixed grid, could be useful for other parts of the testing too. 