### PR TITLE
consistent doc header formatting

### DIFF
--- a/docs/src/devdocs/dofhandler.md
+++ b/docs/src/devdocs/dofhandler.md
@@ -1,4 +1,4 @@
-# [Dof Handler](@id dofhandler-interpolations)
+# [Dof handler](@id dofhandler-interpolations)
 
 ## Type definitions
 

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -125,7 +125,7 @@
 #
 # More details on DG formulations for elliptic problems can be found in [Cockburn:2002:unifiedanalysis](@cite).
 #-
-# ## Commented Program
+# ## Commented program
 #
 # Now we solve the problem in Ferrite. What follows is a program spliced with comments.
 #md # The full program, without comments, can be found in the next [section](@ref heat_equation-DG-plain-program).

--- a/docs/src/literate-tutorials/heat_equation.jl
+++ b/docs/src/literate-tutorials/heat_equation.jl
@@ -73,7 +73,7 @@ close!(dh);
 # !!! warning "Numbering of degrees of freedom"
 #     A common assumption is that the numbering of degrees of freedom follows the global
 #     numbering of the nodes in the grid. This is *NOT* the case in Ferrite. For more
-#     details, see the [Ferrite numbering rules](@ref "Ordering-of-Dofs").
+#     details, see the [Ferrite numbering rules](@ref "Ordering-of-dofs").
 
 # Now that we have distributed all our dofs we can create our tangent matrix,
 # using `allocate_matrix`. This function returns a sparse matrix

--- a/docs/src/literate-tutorials/heat_equation.jl
+++ b/docs/src/literate-tutorials/heat_equation.jl
@@ -35,7 +35,7 @@
 # where $\delta u$ is a test function, and where $\mathbb{U}$ and $\mathbb{T}$ are suitable
 # trial and test function sets, respectively.
 #-
-# ## Commented Program
+# ## Commented program
 #
 # Now we solve the problem in Ferrite. What follows is a program spliced with comments.
 #md # The full program, without comments, can be found in the next [section](@ref heat_equation-plain-program).

--- a/docs/src/literate-tutorials/linear_elasticity.jl
+++ b/docs/src/literate-tutorials/linear_elasticity.jl
@@ -153,7 +153,7 @@ close!(dh);
 # !!! warning "Numbering of degrees of freedom"
 #     A common assumption is that the numbering of degrees of freedom follows the global
 #     numbering of the nodes in the grid. This is *NOT* the case in Ferrite. For more
-#     details, see the [Ferrite numbering rules](@ref "Ordering-of-Dofs").
+#     details, see the [Ferrite numbering rules](@ref "Ordering-of-dofs").
 
 # ### Boundary conditions
 # We set Dirichlet boundary conditions by fixing the motion normal to the bottom and left

--- a/docs/src/literate-tutorials/ns_vs_diffeq.jl
+++ b/docs/src/literate-tutorials/ns_vs_diffeq.jl
@@ -67,7 +67,7 @@ nothing                    #hide
 # $\nu \partial_{\textrm{n}} v - p n = 0$ to model outflow. With these boundary conditions we can choose the zero solution as a
 # feasible initial condition.
 #
-# ### Derivation of Semi-Discrete Weak Form
+# ### Derivation of semi-discrete weak form
 #
 # By multiplying test functions $\varphi$ and $\psi$ from a suitable test function space on the strong form,
 # followed by integrating over the domain and applying partial integration to the pressure and viscosity terms
@@ -183,7 +183,7 @@ gmsh.model.mesh.generate(dim)
 grid = togrid()
 Gmsh.finalize();
 
-#  ### Function Space
+#  ### Function space
 #  To ensure stability we utilize the Taylor-Hood element pair Q2-Q1.
 #  We have to utilize the same quadrature rule for the pressure as for the velocity, because in the weak form the
 #  linear pressure term is tested against a quadratic function.
@@ -239,7 +239,7 @@ add!(ch, inflow_bc);
 close!(ch)
 update!(ch, 0.0);
 
-# ### Linear System Assembly
+# ### Linear system assembly
 # Next we describe how the block mass matrix and the Stokes matrix are assembled.
 #
 # For the block mass matrix $M$ we remember that only the first equation had a time derivative

--- a/docs/src/literate-tutorials/reactive_surface.jl
+++ b/docs/src/literate-tutorials/reactive_surface.jl
@@ -69,7 +69,7 @@ nothing                    #hide
 #     for the theory behind operator splitting and can only refer to the original papers for each method.
 #
 #-
-# ## Commented Program
+# ## Commented program
 #
 # Now we solve the problem in Ferrite. What follows is a program spliced with comments.
 #md # The full program, without comments, can be found in the next [section](@ref reactive_surface-plain-program).

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -52,7 +52,7 @@
 # to a prescribed dof in the system matrix ($\mathbf{A} = Δt \mathbf{K} + \mathbf{M}$) and setting the value of the right-hand side vector to the value
 # of the Dirichlet condition. Thus, we only need to apply in every time step the Dirichlet condition to the right-hand side of the problem.
 #-
-# ## Commented Program
+# ## Commented program
 #
 # Now we solve the problem in Ferrite. What follows is a program spliced with comments.
 #md # The full program, without comments, can be found in the next [section](@ref heat_equation-plain-program).

--- a/docs/src/reference/dofhandler.md
+++ b/docs/src/reference/dofhandler.md
@@ -2,7 +2,7 @@
 DocTestSetup = :(using Ferrite)
 ```
 
-# Degrees of Freedom
+# Degrees of freedom
 Degrees of freedom (dofs) are distributed by the [`DofHandler`](@ref).
 ```@docs
 DofHandler

--- a/docs/src/topics/degrees_of_freedom.md
+++ b/docs/src/topics/degrees_of_freedom.md
@@ -2,7 +2,7 @@
 using Ferrite
 ```
 
-# Degrees of Freedom
+# Degrees of freedom
 
 The distribution and numbering of degrees of freedom (dofs) are handled by the `DofHandler`.
 The DofHandler will be used to query information about the dofs. For example we can obtain
@@ -40,7 +40,7 @@ dofs for the fields we added.
 close!(dh)
 ```
 
-## Ordering of Dofs
+## Ordering of dofs
 
 !!! todo
     Describe dof ordering within elements (vertices -> edges -> faces ->

--- a/docs/src/topics/fe_intro.md
+++ b/docs/src/topics/fe_intro.md
@@ -63,7 +63,7 @@ where $\mathbb{U}, \mathbb{T}$ are suitable function spaces with sufficiently re
 functions. Under very general assumptions it can be shown that the solution to the weak
 form is identical to the solution to the strong form.
 
-## Finite Element approximation
+## Finite element approximation
 
 
 Using the finite element method to solve partial differential equations is usually

--- a/docs/src/topics/fe_intro.md
+++ b/docs/src/topics/fe_intro.md
@@ -77,7 +77,7 @@ Next, we introduce the finite element approximation $u_\mathrm{h} \approx u$ as 
 Sometimes, the dofs are called *weights* or *nodal values*. In Ferrite, the numbering of the dofs does not correspond
 to the node numbers in the grid. While such numbering is common in basic finite element codes,
 Ferrite supports different approximations of the finite element fields and the geometry, prohibiting
-such basic numbering. For more details, see the [Ferrite numbering rules](@ref "Ordering-of-Dofs").
+such basic numbering. For more details, see the [Ferrite numbering rules](@ref "Ordering-of-dofs").
 
 Note that *shape functions* are sometimes referred to as *basis functions* or *trial functions*,
 and instead of $\phi_i$ they are sometimes denoted $N_i$. In this example we choose to approximate

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -29,7 +29,7 @@ of the other tutorials. The remaining tutorials discuss more advanced topics.
 
 ---
 
-##### [Tutorial 1: Heat equation](heat_equation.md)
+#### [Tutorial 1: Heat equation](heat_equation.md)
 
 This tutorial guides you through the process of solving the linear stationary heat equation
 (i.e. Poisson's equation) on a unit square with homogeneous Dirichlet boundary conditions.
@@ -42,7 +42,7 @@ complex tutorials.*
 
 ---
 
-##### [Tutorial 2: Linear elasticity](linear_elasticity.md)
+#### [Tutorial 2: Linear elasticity](linear_elasticity.md)
 
 TBW.
 
@@ -50,7 +50,7 @@ TBW.
 
 ---
 
-##### [Tutorial 3: Incompressible elasticity](incompressible_elasticity.md)
+#### [Tutorial 3: Incompressible elasticity](incompressible_elasticity.md)
 
 This tutorial focuses on a mixed formulation of linear elasticity, with (vector)
 displacement and (scalar) pressure as the two unknowns, suitable for incompressibility.


### PR DESCRIPTION
Partially address https://github.com/Ferrite-FEM/Ferrite.jl/issues/1156

* Conversion of title case in documentation to sentence case.
* POTENTIAL TODO: Does not modify pre-commit pipeline to enforce this sentence naming convention in future commits. I could extend the PR to include enforcing this formatting, but did not do this in the current PR.