### PR TITLE
`addboundary*set()` errors for mixed grids

### DIFF
--- a/src/Grid/utils.jl
+++ b/src/Grid/utils.jl
@@ -165,6 +165,7 @@ function _create_boundaryset(f::Function, grid::AbstractGrid, top::ExclusiveTopo
             cell_idx = ff_nh_idx[1]
             facet_nr = ff_nh_idx[2]
             cell = getcells(grid, cell_idx)
+            facet_nr > length(facets(cell)) && continue
             facet_nodes = facets(cell)[facet_nr]
             for (subentity_idx, subentity_nodes) in pairs(boundaryfunction(BI)(cell))
                 if Base.all(n -> n in facet_nodes, subentity_nodes)

--- a/src/Grid/utils.jl
+++ b/src/Grid/utils.jl
@@ -165,6 +165,8 @@ function _create_boundaryset(f::Function, grid::AbstractGrid, top::ExclusiveTopo
             cell_idx = ff_nh_idx[1]
             facet_nr = ff_nh_idx[2]
             cell = getcells(grid, cell_idx)
+            # `ff_nh::AbstractMatrix`, indexed by (cell_idx, facet_nr). For mixed grids,
+            # `facet_nr` can then become too large and should be skipped as the facet doesn't exist.
             facet_nr > length(facets(cell)) && continue
             facet_nodes = facets(cell)[facet_nr]
             for (subentity_idx, subentity_nodes) in pairs(boundaryfunction(BI)(cell))

--- a/test/test_grid_addboundaryset.jl
+++ b/test/test_grid_addboundaryset.jl
@@ -236,7 +236,7 @@
         @test getfacetset(grid, "test_boundary_facetset") == Ferrite.create_boundaryfacetset(grid, topology, filter_function)
     end
 
-    @testset "mixed grid" begin
+    @testset "mixed grid 3D" begin
         nodes = reshape([Node(Vec(x, y, z)) for x in -1:1, y in -1:1, z in 0:1], :)
         for (shape1, shape2) in ((Hexahedron, Wedge), (Wedge, Hexahedron))
             grid = Grid([generate_cell1(shape1), generate_cell2(shape2)], nodes)
@@ -244,5 +244,16 @@
             addboundaryfacetset!(grid, topology, "boundary", _ -> true)
             @test getfacetset(grid, "boundary") == boundary_facets(shape1, shape2)
         end
+    end
+    @testset "mixed grid 2D" begin
+        nodes = [Node((-1.0, 0.0)), Node((0.0, 0.0)), Node((1.0, 0.0)), Node((-1.0, 1.0)), Node((0.0, 1.0))]
+        cells = [
+            Quadrilateral((1, 2, 5, 4)),
+            Triangle((3, 5, 2)),
+        ]
+        grid = Grid(cells, nodes)
+        topology = ExclusiveTopology(grid)
+        addboundaryfacetset!(grid, topology, "boundary", _ -> true)
+        @test getfacetset(grid, "boundary") == Set([FacetIndex(1, 1), FacetIndex(1, 3), FacetIndex(1, 4), FacetIndex(2, 1), FacetIndex(2, 3)])
     end
 end

--- a/test/test_grid_addboundaryset.jl
+++ b/test/test_grid_addboundaryset.jl
@@ -62,40 +62,6 @@
         return union(facets, edges, vertices)
     end
 
-    function generate_cell1(::Type{Hexahedron})
-        return Hexahedron((1, 2, 5, 4, 7, 8, 11, 10))
-    end
-
-    function generate_cell1(::Type{Wedge})
-        return Wedge((2, 1, 5, 8, 7, 11))
-    end
-
-    function generate_cell2(::Type{Hexahedron})
-        return Hexahedron((2, 3, 6, 5, 8, 9, 12, 11))
-    end
-
-    function generate_cell2(::Type{Wedge})
-        return Wedge((2, 3, 5, 8, 9, 11))
-    end
-
-    function boundary_facets(::Type{Hexahedron}, ::Type{Wedge})
-        return Set(
-            [
-                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5), FacetIndex(1, 6),
-                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 4), FacetIndex(2, 5),
-            ]
-        )
-    end
-
-    function boundary_facets(::Type{Wedge}, ::Type{Hexahedron})
-        return Set(
-            [
-                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5),
-                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 3), FacetIndex(2, 4), FacetIndex(2, 6),
-            ]
-        )
-    end
-
     #=
     @testset "getentities" begin
     #                            (8)
@@ -238,12 +204,10 @@
 
     @testset "mixed grid 3D" begin
         nodes = reshape([Node(Vec(x, y, z)) for x in -1:1, y in -1:1, z in 0:1], :)
-        for (shape1, shape2) in ((Hexahedron, Wedge), (Wedge, Hexahedron))
-            grid = Grid([generate_cell1(shape1), generate_cell2(shape2)], nodes)
-            topology = ExclusiveTopology(grid)
-            addboundaryfacetset!(grid, topology, "boundary", _ -> true)
-            @test getfacetset(grid, "boundary") == boundary_facets(shape1, shape2)
-        end
+        grid = Grid([Hexahedron((1, 2, 5, 4, 7, 8, 11, 10)), Wedge((2, 3, 5, 8, 9, 11))], nodes)
+        topology = ExclusiveTopology(grid)
+        addboundaryfacetset!(grid, topology, "boundary", _ -> true)
+        @test getfacetset(grid, "boundary") == Set([FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5), FacetIndex(1, 6), FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 4), FacetIndex(2, 5)])
     end
     @testset "mixed grid 2D" begin
         nodes = [Node((-1.0, 0.0)), Node((0.0, 0.0)), Node((1.0, 0.0)), Node((-1.0, 1.0)), Node((0.0, 1.0))]

--- a/test/test_grid_addboundaryset.jl
+++ b/test/test_grid_addboundaryset.jl
@@ -196,6 +196,7 @@
         @test extractboundary(grid, topology) == extractboundarycheck(grid)
 
         filter_function(x) = x[1] > 0
+        # Test that the sets are actually addeed to the grid's dict
         addboundaryvertexset!(grid, topology, "test_boundary_vertexset", filter_function)
         @test getvertexset(grid, "test_boundary_vertexset") == Ferrite.create_boundaryvertexset(grid, topology, filter_function)
         addboundaryfacetset!(grid, topology, "test_boundary_facetset", filter_function)

--- a/test/test_grid_addboundaryset.jl
+++ b/test/test_grid_addboundaryset.jl
@@ -61,7 +61,6 @@
         vertices = _extractboundarycheck(grid, Ferrite.create_vertexset)
         return union(facets, edges, vertices)
     end
-
     #=
     @testset "getentities" begin
     #                            (8)

--- a/test/test_grid_addboundaryset.jl
+++ b/test/test_grid_addboundaryset.jl
@@ -61,6 +61,41 @@
         vertices = _extractboundarycheck(grid, Ferrite.create_vertexset)
         return union(facets, edges, vertices)
     end
+
+    function generate_cell1(::Type{Hexahedron})
+        return Hexahedron((1, 2, 5, 4, 7, 8, 11, 10))
+    end
+
+    function generate_cell1(::Type{Wedge})
+        return Wedge((2, 1, 5, 8, 7, 11))
+    end
+
+    function generate_cell2(::Type{Hexahedron})
+        return Hexahedron((2, 3, 6, 5, 8, 9, 12, 11))
+    end
+
+    function generate_cell2(::Type{Wedge})
+        return Wedge((2, 3, 5, 8, 9, 11))
+    end
+
+    function boundary_facets(::Type{Hexahedron}, ::Type{Wedge})
+        return Set(
+            [
+                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5), FacetIndex(1, 6),
+                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 4), FacetIndex(2, 5),
+            ]
+        )
+    end
+
+    function boundary_facets(::Type{Wedge}, ::Type{Hexahedron})
+        return Set(
+            [
+                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5),
+                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 3), FacetIndex(2, 4), FacetIndex(2, 6),
+            ]
+        )
+    end
+
     #=
     @testset "getentities" begin
     #                            (8)
@@ -199,44 +234,6 @@
         @test getvertexset(grid, "test_boundary_vertexset") == Ferrite.create_boundaryvertexset(grid, topology, filter_function)
         addboundaryfacetset!(grid, topology, "test_boundary_facetset", filter_function)
         @test getfacetset(grid, "test_boundary_facetset") == Ferrite.create_boundaryfacetset(grid, topology, filter_function)
-    end
-    ref_shapes = [
-        Hexahedron,
-        Wedge,
-    ]
-
-    function generate_cell1(::Type{Hexahedron})
-        return Hexahedron((1, 2, 5, 4, 7, 8, 11, 10))
-    end
-
-    function generate_cell1(::Type{Wedge})
-        return Wedge((2, 1, 5, 8, 7, 11))
-    end
-
-    function generate_cell2(::Type{Hexahedron})
-        return Hexahedron((2, 3, 6, 5, 8, 9, 12, 11))
-    end
-
-    function generate_cell2(::Type{Wedge})
-        return Wedge((2, 3, 5, 8, 9, 11))
-    end
-
-    function boundary_facets(::Type{Hexahedron}, ::Type{Wedge})
-        return Set(
-            [
-                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5), FacetIndex(1, 6),
-                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 4), FacetIndex(2, 5),
-            ]
-        )
-    end
-
-    function boundary_facets(::Type{Wedge}, ::Type{Hexahedron})
-        return Set(
-            [
-                FacetIndex(1, 1), FacetIndex(1, 2), FacetIndex(1, 4), FacetIndex(1, 5),
-                FacetIndex(2, 1), FacetIndex(2, 2), FacetIndex(2, 3), FacetIndex(2, 4), FacetIndex(2, 6),
-            ]
-        )
     end
 
     @testset "mixed grid" begin


### PR DESCRIPTION
It seems like it's iterating over neighborhoods of non-existing facets. Checking against `length(facets(cell))` should solve the issue.