### PR TITLE
Allow for views (`AbstractVector`) in `evaluate_at_points!`

### DIFF
--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -203,8 +203,8 @@ function _get_node_cell_map(grid::AbstractGrid)
 end
 
 """
-    evaluate_at_points(ph::PointEvalHandler, dh::AbstractDofHandler, dof_values::Vector{T}, [fieldname::Symbol]) where T
-    evaluate_at_points(ph::PointEvalHandler, proj::L2Projector, dof_values::Vector{T}) where T
+    evaluate_at_points(ph::PointEvalHandler, dh::AbstractDofHandler, dof_values::AbstractVector{T}, [fieldname::Symbol]) where T
+    evaluate_at_points(ph::PointEvalHandler, proj::L2Projector, dof_values::AbstractVector{T}) where T
 
 Return a `Vector{T}` (for a 1-dimensional field) or a `Vector{Vec{fielddim, T}}` (for a
 vector field) with the field values of field `fieldname` in the points of the
@@ -248,10 +248,10 @@ end
 
 # values in dof-order. They must be obtained from the same DofHandler that was used for constructing the PointEvalHandler
 function evaluate_at_points!(
-        out_vals::Vector{T2},
+        out_vals::AbstractVector{T2},
         ph::PointEvalHandler{<:Any, T_ph},
         dh::DofHandler,
-        dof_vals::Vector{T},
+        dof_vals::AbstractVector{T},
         fname::Symbol,
         func_interpolations
     ) where {T2, T_ph, T}
@@ -275,8 +275,8 @@ end
 
 # function barrier with concrete type of PointValues
 function _evaluate_at_points!(
-        out_vals::Vector{T2},
-        dof_vals::Vector{T},
+        out_vals::AbstractVector{T2},
+        dof_vals::AbstractVector{T},
         ph::PointEvalHandler,
         dh::AbstractDofHandler,
         pv::PointValues,

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -190,6 +190,26 @@ function test_pe_dofhandler()
     return
 end
 
+function test_pe_views()
+    mesh = generate_grid(Quadrilateral, (3, 3))
+    perturb_standard_grid!(mesh, 1 / 10)
+    dof_vals = 1.0 * [0, 0, 1, 2, 6, 5, 3, 7, 4, 8, 10, 9, 11, 12, 14, 13, 15, 16, 0, 0]
+    points = [node.x for node in mesh.nodes[[6, 7, 11, 10]]] # same as nodes
+    vals_to = zeros(length(points) + 4)
+
+    dh = DofHandler(mesh)
+    add!(dh, :s, Lagrange{RefQuadrilateral, 1}()) # a scalar field
+    close!(dh)
+
+    ph = PointEvalHandler(mesh, points)
+
+    ip = Ferrite.get_func_interpolations(dh, :s)
+    Ferrite.evaluate_at_points!((@view vals_to[3:(end - 2)]), ph, dh, (@view dof_vals[3:(end - 2)]), :s, ip)
+    @test vals_to ≈ 1.0 * [0, 0, 6, 7, 11, 10, 0, 0]
+
+    return nothing
+end
+
 function _pointeval_dofhandler2_manual_projection(dh, csv, cvv, f_s, f_v)
     M = allocate_matrix(dh)
     f = zeros(ndofs(dh))
@@ -441,6 +461,10 @@ end
         test_pe_dofhandler()
         test_pe_dofhandler2(; three_dimensional = false)
         test_pe_dofhandler2(; three_dimensional = true)
+    end
+
+    @testset "inplace with views" begin
+        test_pe_views()
     end
 
     @testset "superparametric" begin


### PR DESCRIPTION
https://github.com/Ferrite-FEM/Ferrite.jl/blob/87b0888a542aaf9d24f36bb82cc1e9b85949e4dc/src/PointEvalHandler.jl#L225-L228
Accepts views, however,
https://github.com/Ferrite-FEM/Ferrite.jl/blob/87b0888a542aaf9d24f36bb82cc1e9b85949e4dc/src/PointEvalHandler.jl#L250-L257
does not.