### PR TITLE
Add type assert when testing of dof indices functions

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -574,7 +574,7 @@ end
 getnbasefunctions(::Lagrange{RefLine, 2}) = 3
 
 edgedof_indices(::Lagrange{RefLine, 2}) = ((1, 2, 3),)
-edgedof_interior_indices(::Lagrange{RefLine, 2}) = (3,)
+edgedof_interior_indices(::Lagrange{RefLine, 2}) = ((3,),)
 
 function reference_coordinates(::Lagrange{RefLine, 2})
     return [
@@ -627,7 +627,7 @@ getnbasefunctions(::Lagrange{RefQuadrilateral, 2}) = 9
 edgedof_indices(::Lagrange{RefQuadrilateral, 2}) = ((1, 2, 5), (2, 3, 6), (3, 4, 7), (4, 1, 8))
 edgedof_interior_indices(::Lagrange{RefQuadrilateral, 2}) = ((5,), (6,), (7,), (8,))
 facedof_indices(ip::Lagrange{RefQuadrilateral, 2}) = (ntuple(i -> i, getnbasefunctions(ip)),)
-facedof_interior_indices(::Lagrange{RefQuadrilateral, 2}) = ((9,))
+facedof_interior_indices(::Lagrange{RefQuadrilateral, 2}) = ((9,),)
 
 function reference_coordinates(::Lagrange{RefQuadrilateral, 2})
     return [
@@ -1009,7 +1009,7 @@ edgedof_indices(::Lagrange{RefHexahedron, 2}) = (
     (4, 8, 20),
 )
 edgedof_interior_indices(::Lagrange{RefHexahedron, 2}) = (
-    (9,), (10,), (11,), (12,), (13,), (14,), (15,), (16,), (17), (18,), (19,), (20,),
+    (9,), (10,), (11,), (12,), (13,), (14,), (15,), (16,), (17,), (18,), (19,), (20,),
 )
 
 volumedof_interior_indices(::Lagrange{RefHexahedron, 2}) = (27,)
@@ -1466,7 +1466,7 @@ edgedof_indices(::Serendipity{RefHexahedron, 2}) = (
 )
 
 edgedof_interior_indices(::Serendipity{RefHexahedron, 2}) = (
-    (9,), (10,), (11,), (12,), (13,), (14,), (15,), (16,), (17), (18,), (19,), (20,),
+    (9,), (10,), (11,), (12,), (13,), (14,), (15,), (16,), (17,), (18,), (19,), (20,),
 )
 
 function reference_coordinates(::Serendipity{RefHexahedron, 2})

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -33,13 +33,13 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
         as_vector(t::Tuple) = collect(as_vector.(t))
         as_vector(i::Int) = i
         dof_data = (
-            vert = as_vector(Ferrite.vertexdof_indices(ip)),
-            edge = as_vector(Ferrite.edgedof_indices(ip)),
-            face = as_vector(Ferrite.facedof_indices(ip)),
-            edge_i = as_vector(Ferrite.edgedof_interior_indices(ip)),
-            face_i = as_vector(Ferrite.facedof_interior_indices(ip)),
-            vol_i = as_vector(Ferrite.volumedof_interior_indices(ip)),
-            n = getnbasefunctions(ip),
+            vert = as_vector(Ferrite.vertexdof_indices(ip)::NTuple{<:Any, NTuple{<:Any, Int}}),
+            edge = as_vector(Ferrite.edgedof_indices(ip)::NTuple{<:Any, NTuple{<:Any, Int}}),
+            face = as_vector(Ferrite.facedof_indices(ip)::NTuple{<:Any, NTuple{<:Any, Int}}),
+            edge_i = as_vector(Ferrite.edgedof_interior_indices(ip)::NTuple{<:Any, NTuple{<:Any, Int}}),
+            face_i = as_vector(Ferrite.facedof_interior_indices(ip)::NTuple{<:Any, NTuple{<:Any, Int}}),
+            vol_i = as_vector(Ferrite.volumedof_interior_indices(ip)::NTuple{<:Any, Int}),
+            n = getnbasefunctions(ip)::Int,
         )
 
         refshape_data = (


### PR DESCRIPTION
This ensures that silent implementation inconsistencies don't sneak in, ref https://github.com/Ferrite-FEM/Ferrite.jl/pull/1162#discussion_r2060152846

AFAIU the reason this could go through the regular usage tests is that an implementation working for `Tuple{Int}` should also work for `Int` in many cases, since an `Int` supports both indexing by index 1, `length`, and iteration.

Closes #1187