### PR TITLE
Use the same function and definition for face orientations

### DIFF
--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -777,3 +777,21 @@ function OrientationInfo(surface::NTuple{N, Int}) where {N}
     end
     return OrientationInfo(flipped, shift_index)
 end
+
+function get_edge_direction(edgenodes::NTuple{2, Int})
+    positive = edgenodes[2] > edgenodes[1]
+    return ifelse(positive, 1, -1)
+end
+
+function get_face_direction(facenodes::NTuple{N, Int}) where {N}
+    N > 2 || throw(ArgumentError("A face must have at least 3 nodes"))
+    min_idx = argmin(facenodes)
+    if min_idx == 1
+        positive = facenodes[2] < facenodes[end]
+    elseif min_idx == length(facenodes)
+        positive = facenodes[1] < facenodes[end - 1]
+    else
+        positive = facenodes[min_idx + 1] < facenodes[min_idx - 1]
+    end
+    return ifelse(positive, 1, -1)
+end

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -760,21 +760,14 @@ struct OrientationInfo
     shift_index::Int
 end
 
-function OrientationInfo(path::NTuple{2, Int})
-    flipped = first(path) < last(path)
-    return OrientationInfo(flipped, 0)
+function OrientationInfo(edgenodes::NTuple{2, Int})
+    return OrientationInfo(get_edge_direction(edgenodes) < 0, 0)
 end
 
-function OrientationInfo(surface::NTuple{N, Int}) where {N}
-    min_idx = argmin(surface)
+function OrientationInfo(facenodes::NTuple{N, Int}) where {N}
+    min_idx = argmin(facenodes)
     shift_index = min_idx - 1
-    if min_idx == 1
-        flipped = surface[2] < surface[end]
-    elseif min_idx == length(surface)
-        flipped = surface[1] < surface[end - 1]
-    else
-        flipped = surface[min_idx + 1] < surface[min_idx - 1]
-    end
+    flipped = get_face_direction(facenodes) < 0
     return OrientationInfo(flipped, shift_index)
 end
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -461,25 +461,6 @@ dirichlet_boundarydof_indices(::Type{FacetIndex}) = dirichlet_facetdof_indices
 get_edge_direction(cell, edgenr) = get_edge_direction(edges(cell)[edgenr])
 get_face_direction(cell, facenr) = get_face_direction(faces(cell)[facenr])
 
-function get_edge_direction(edgenodes::NTuple{2, Int})
-    positive = edgenodes[2] > edgenodes[1]
-    return ifelse(positive, 1, -1)
-end
-
-function get_face_direction(facenodes::NTuple{N, Int}) where {N}
-    N > 2 || throw(ArgumentError("A face must have at least 3 nodes"))
-    min_idx = argmin(facenodes)
-    if min_idx == 1
-        positive = facenodes[2] < facenodes[end]
-    elseif min_idx == length(facenodes)
-        positive = facenodes[1] < facenodes[end - 1]
-    else
-        positive = facenodes[min_idx + 1] < facenodes[min_idx - 1]
-    end
-    return ifelse(positive, 1, -1)
-end
-
-
 #########################
 # DiscontinuousLagrange #
 #########################


### PR DESCRIPTION
In #1162, the functions `get_edge_direction` and `get_face_direction` were introduced. This PR use those functions (moved to `grid.jl`) to get the directions used in `OrientationInfo`, which is later used by the `InterfaceOrientationInfo` struct.