### PR TITLE
Use OrientationInfo instead of {Path,Surface}OrientationInfo everywhere

### DIFF
--- a/docs/src/devdocs/dofhandler.md
+++ b/docs/src/devdocs/dofhandler.md
@@ -9,8 +9,7 @@ during dof distribution, because the interpolations are not available as concret
 
 ```@docs
 Ferrite.InterpolationInfo
-Ferrite.PathOrientationInfo
-Ferrite.SurfaceOrientationInfo
+Ferrite.OrientationInfo
 ```
 
 

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -639,12 +639,12 @@ described therein.
 # References
  - [Scroggs2022](@cite) Scroggs et al. ACM Trans. Math. Softw. 48 (2022).
 """
-@inline function permute_and_push!(cell_dofs::Vector{Int}, dofs::StepRange{Int, Int}, orientation::PathOrientationInfo, adjust_during_distribution::Bool)
+@inline function permute_and_push!(cell_dofs::Vector{Int}, dofs::StepRange{Int, Int}, orientation::OrientationInfo, adjust_during_distribution::Bool)
     # TODO Investigate if we can somehow pass the interpolation into this function in a
     # typestable way.
     n_copies = step(dofs)
     @assert n_copies > 0
-    if adjust_during_distribution && !orientation.regular
+    if adjust_during_distribution && orientation.flipped
         # Reverse the dofs for the path
         dofs = reverse(dofs)
     end
@@ -666,7 +666,7 @@ if the edge is flipped.
 """
 function sortedge(edge::Tuple{Int, Int})
     a, b = edge
-    return a < b ? (edge, PathOrientationInfo(true)) : ((b, a), PathOrientationInfo(false))
+    return a < b ? (edge, OrientationInfo(false, 0)) : ((b, a), OrientationInfo(true, 0))
 end
 
 """
@@ -720,7 +720,7 @@ For more details we refer to [1] as we follow the methodology described therein.
 
     !!!TODO Investigate if we can somehow pass the interpolation into this function in a typestable way.
 """
-@inline function permute_and_push!(cell_dofs::Vector{Int}, dofs::StepRange{Int, Int}, ::SurfaceOrientationInfo, adjust_during_distribution::Bool, rdim::Int)
+@inline function permute_and_push!(cell_dofs::Vector{Int}, dofs::StepRange{Int, Int}, ::OrientationInfo, adjust_during_distribution::Bool, rdim::Int)
     if rdim == 3 && adjust_during_distribution && length(dofs) > 1
         error("Dof distribution for interpolations with multiple dofs per face not implemented yet.")
     end
@@ -739,7 +739,7 @@ function sortface(face::Tuple{Int, Int, Int})
     b, c = minmax(b, c)
     a, c = minmax(a, c)
     a, b = minmax(a, b)
-    return (a, b, c), SurfaceOrientationInfo() # TODO fill struct
+    return (a, b, c), OrientationInfo(false, 0)
 end
 
 
@@ -760,7 +760,7 @@ function sortface(face::Tuple{Int, Int, Int, Int})
     b, c = minmax(b, c)
     a, c = minmax(a, c)
     a, b = minmax(a, b)
-    return (a, b, c), SurfaceOrientationInfo() # TODO fill struct
+    return (a, b, c), OrientationInfo(false, 0)
 end
 
 

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -664,58 +664,8 @@ end
 #################################
 # @TODO merge this code with into the logic in `ConstraintHandler`.
 
-"""
-    PathOrientationInfo
-
-Orientation information for 1D entities.
-
-The orientation for 1D entities is defined by the indices of the grid nodes
-associated to the vertices. To give an example, the oriented path
-```
-1 ---> 2
-```
-is called *regular*, indicated by `regular=true`, while the oriented path
-```
-2 ---> 1
-```
-is called *inverted*, indicated by `regular=false`.
-"""
-struct PathOrientationInfo
-    regular::Bool # Indicator whether the orientation is regular or inverted.
-end
-
-"""
-    SurfaceOrientationInfo
-
-Orientation information for 2D entities. Such an entity can be
-possibly flipped (i.e. the defining vertex order is reverse to the
-spanning vertex order) and the vertices can be rotated against each other.
-Take for example the faces
-```
-1---2 2---3
-| A | | B |
-4---3 1---4
-```
-which are rotated against each other by 90° (shift index is 1) or the faces
-```
-1---2 2---1
-| A | | B |
-4---3 3---4
-```
-which are flipped against each other. Any combination of these can happen.
-The combination to map this local face to the defining face is encoded with
-this data structure via ``rotate \\circ flip`` where the rotation is indiced by
-the shift index.
-    !!!NOTE TODO implement me.
-"""
-struct SurfaceOrientationInfo
-    #flipped::Bool
-    #shift_index::Int
-end
-
-
 @doc raw"""
-    InterfaceOrientationInfo
+    OrientationInfo
 
 Orientation information for 1D and 2D entities.
 The orientation is defined by the indices of the grid nodes


### PR DESCRIPTION
As far as I can see, `OrientationInfo` has the same functionality as `PathOrientationInfo` and `SurfaceOrientationInfo`, so it makes more sense to use only the former. This is preparation work for https://github.com/Ferrite-FEM/Ferrite.jl/issues/1195.