### PR TITLE
Fix facetskeleton for mixed grids

### DIFF
--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -496,17 +496,26 @@ end
         ]
     )
     # test grids with mixed celltypes of same refdim
-    # (4)---(5)
-    #  |     | \
-    #  |  1  |2 \
-    # (1)---(2)-(3)
+    # (4)---(5)---(7)
+    #  |     | \    \
+    #  |  1  |2 \ 3  \
+    # (1)---(2)-(3)--(6)
     tet_quad_grid = Grid(
-        [Quadrilateral((1, 2, 5, 4)), Triangle((2, 3, 5))],
-        [Node(Float64.((x, y))) for (x, y) in ((0, 0), (1, 0), (2, 0), (0, 1), (1, 1))]
+        [Quadrilateral((1, 2, 5, 4)), Triangle((2, 3, 5)), Quadrilateral((3, 6, 7, 5))],
+        [Node(Float64.((x, y))) for (x, y) in ((0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (3, 0), (2, 1))]
     )
     top = ExclusiveTopology(tet_quad_grid)
     @test getneighborhood(top, tet_quad_grid, FacetIndex(1, 2)) == [EdgeIndex(2, 3)]
     @test Set(getneighborhood(top, tet_quad_grid, FacetIndex(1, 2), true)) == Set([EdgeIndex(1, 2), EdgeIndex(2, 3)])
+
+    # This test relies on the assumption that the facet with the lowest cell is chosen
+    @test Set(facetskeleton(top, tet_quad_grid)) == Set(
+        [
+            (FacetIndex(1, i) for i in 1:4)...,
+            (FacetIndex(2, i) for i in 1:2)...,
+            (FacetIndex(3, i) for i in 1:3)...,
+        ]
+    )
 
     # test grids with mixed refdim
     cells = [


### PR DESCRIPTION
`facetskeleton` currently returns `FacetIndex` which doesn't exist on mixed grids. This PR fixes that, and makes the code for `_create_facet_skeleton` a bit more verbose to make it easier to follow. 

Adds a test which also formalizes the convention that was implemented, that the facet on the cell with the lowest cell index is picked. 