### PR TITLE
Fix a typo in Tutorial Computational homogenization

### DIFF
--- a/docs/src/literate-tutorials/computational_homogenization.jl
+++ b/docs/src/literate-tutorials/computational_homogenization.jl
@@ -244,7 +244,7 @@ update!(ch_dirichlet, 0.0)
 # which is very similar to the `Dirichlet` type, but instead of a passing a facetset we pass
 # a vector with "facet pairs", i.e. the mapping between mirror and image parts of the
 # boundary. In this example the `"left"` and `"bottom"` boundaries are mirrors, and the
-# `"right"` and `"top"` boundaries are the mirrors.
+# `"right"` and `"top"` boundaries are the images.
 
 ch_periodic = ConstraintHandler(dh);
 periodic = PeriodicDirichlet(


### PR DESCRIPTION
In the Section Commented program of [Computational homogenization](https://ferrite-fem.github.io/Ferrite.jl/stable/tutorials/computational_homogenization/), there is a typo in the last sentence of this paragraph.

> For periodic boundary conditions we use the [PeriodicDirichlet](https://ferrite-fem.github.io/Ferrite.jl/stable/reference/boundary_conditions/#Ferrite.PeriodicDirichlet) constraint type, which is very similar to the Dirichlet type, but instead of a passing a facetset we pass a vector with "facet pairs", i.e. the mapping between mirror and image parts of the boundary. In this example the "left" and "bottom" boundaries are mirrors, and the "right" and "top" boundaries are the mirrors.

"right" and "top" boundaries should be the images