### PR TITLE
Fix signature of `reference_shape_hessians_gradients_and_values!()`

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -232,7 +232,7 @@ end
 Evaluate all shape function hessians, gradients and values of `ip` at once at the reference point `ξ`
 and store them in `hessians`, `gradients`, and `values`.
 """
-@propagate_inbounds function reference_shape_hessians_gradients_and_values!(hessians::AbstractVector, gradients::AbstractVector, values::AbstractVector, ip::Interpolation, ξ::Vec)
+@propagate_inbounds function reference_shape_hessians_gradients_and_values!(hessians::HAT, gradients::GAT, values::SAT, ip::IP, ξ::Vec) where {IP <: Interpolation, SAT <: AbstractArray, GAT <: AbstractArray, HAT <: AbstractArray}
     @boundscheck checkbounds(hessians, 1:getnbasefunctions(ip))
     @boundscheck checkbounds(gradients, 1:getnbasefunctions(ip))
     @boundscheck checkbounds(values, 1:getnbasefunctions(ip))


### PR DESCRIPTION
This small fix allows us to overload the `reference_shape_hessians_gradients_and_values!()` for custom interpolations. It also harmonizes the signature with `reference_shape_gradients_and_values!()`.