### PR TITLE
Fix errors in incompressible elasticity tutorial

### DIFF
--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -113,13 +113,17 @@ function doassemble(
     return K, f
 end;
 
-function dev_3d(t::SymmetricTensor{2, 2, T}) where {T}
-    return dev(SymmetricTensor{2, 3}((i, j) -> (i ≤ 2 && j ≤ 2) ? t[i, j] : zero(T)))
-end
-
 # The element routine integrates the local stiffness and force vector for all elements.
 # Since the problem results in a symmetric matrix we choose to only assemble the lower part,
 # and then symmetrize it after the loop over the quadrature points.
+
+function dev_3d(t::SymmetricTensor{2, 2, T}) where {T}
+    ## Given 2d and 3d tensors, t2 and t3, where the out-of-plane components for t3 are zero,
+    ## we have t2 ⊡ t2 == t3 ⊡ t3, but dev(t2) ⊡ dev(t2) != dev(t3) ⊡ dev(t3), so we have to
+    ## expand the tensor before calling `dev` to get the correct value in the element routine.
+    return dev(SymmetricTensor{2, 3}((i, j) -> (i ≤ 2 && j ≤ 2) ? t[i, j] : zero(T)))
+end
+
 function assemble_up!(Ke, fe, cell, cellvalues_u, cellvalues_p, facetvalues_u, grid, mp, t)
 
     n_basefuncs_u = getnbasefunctions(cellvalues_u)


### PR DESCRIPTION
Found during FEM Solids that the calculation of \varepsilon^dev : \varepsilon^dev in 2d is wrong (Thanks to Melvin Glans)

Other changes
 * Also, fix #1222]
 * Remove preallocated epsdev (no measurable performance gain to pre-calculate)


Performance PR vs master:
```
# PR
julia> @btime solve(0.5, quadratic_u, linear_p);
  160.054 ms (117281 allocations: 272.45 MiB)

julia> @btime solve(0.5, quadratic_u, linear_p);
  150.825 ms (117281 allocations: 272.45 MiB)

# Master
julia> @btime solve(0.5, quadratic_u, linear_p);
  151.628 ms (117283 allocations: 272.45 MiB)

julia> @btime solve(0.5, quadratic_u, linear_p);
  167.466 ms (117283 allocations: 272.45 MiB)
```