### PR TITLE
continue-on-error for prerelease test

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
-    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    continue-on-error: ${{ matrix.julia-version == 'pre' }}
     strategy:
       matrix:
         julia-version: ['lts', '1', 'pre']


### PR DESCRIPTION
While it should not be ignored, it is good to at least make all other CI runs finish if it fails due to unrelated changes. 