### PR TITLE
avoid `Core.Box` in the package

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1189,8 +1189,8 @@ function _add!(
             union!(all_node_idxs, nodes)
             for n in nodes
                 x = get_node_coordinate(grid, n)
-                min_x = Tx(i -> min(min_x[i], x[i]))
-                max_x = Tx(i -> max(max_x[i], x[i]))
+                min_x = Tx(min.(min_x.data, x.data))
+                max_x = Tx(max.(max_x.data, x.data))
             end
         end
         all_node_idxs_v = collect(all_node_idxs)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -376,8 +376,10 @@ function create_discontinuous_vtk_griddata(grid::Grid{dim, C, T}) where {dim, C,
         cell_coords = getcoordinates(cell)
         n = length(cell_coords)
         cellnodes[cellid(cell)] = (1:n) .+ icoord
-        vtk_cellnodes = nodes_to_vtkorder(CT((ntuple(i -> i + icoord, n))))
-        cls[cellid(cell)] = WriteVTK.MeshCell(vtk_celltype, vtk_cellnodes)
+        let icoord = icoord
+            vtk_cellnodes = nodes_to_vtkorder(CT((ntuple(i -> i + icoord, n))))
+            cls[cellid(cell)] = WriteVTK.MeshCell(vtk_celltype, vtk_cellnodes)
+        end
         for (x, node_idx) in zip(cell_coords, getnodes(cell))
             icoord += 1
             coords[:, icoord] = x


### PR DESCRIPTION
Uses https://github.com/JuliaLang/julia/pull/60478 to find `Core.Box` entries in the package and remove them. After this, there are no such closure boxes in the package.
