### PR TITLE
docs: define scope, features, and non-scope use cases in README (#1250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,26 @@
 [![code style: runic](https://img.shields.io/badge/code_style-%E1%9A%B1%E1%9A%A2%E1%9A%BE%E1%9B%81%E1%9A%B2-black)](https://github.com/fredrikekre/Runic.jl)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13862652.svg)](https://doi.org/10.5281/zenodo.13862652)
 
-A finite element toolbox written in Julia.
+Ferrite.jl is a comprehensive toolbox for finite element analysis (FEA) in Julia. It is designed for researchers and engineers who want full control over their simulation pipelines—from the weak form definition to the assembly and solution strategies. If you want to implement your own finite element solver, perform novel multiphysics simulations, or experiment with new element types, Ferrite provides the high-performance building blocks you need.
+
+## Scope & Core Features
+
+Ferrite provides a general, performant, and mathematically abstract foundation for solving partial differential equations (PDEs). Key features include:
+
+*   **Versatile Grid Management**: Support for 1D, 2D, and 3D grids with mixed element types.
+*   **Flexible Degree of Freedom Handling**: Robust `DofHandler` for scalar and vector fields, supporting mixed interpolations and multiple fields.
+*   **Efficient Assembly**: Optimised routines for iterating over cells and faces, calculating shape functions, gradients, and numerical integration.
+*   **Boundary Conditions**: Easy definition of Dirichlet, Neumann, and Periodic boundary conditions.
+*   **High Performance**: Design that leverages Julia's multiple dispatch and type system for speed comparable to C/C++.
+*   **Visualization**: Native export to VTK (Paraview/VisIt) and integration with [FerriteViz.jl](https://github.com/Ferrite-FEM/FerriteViz.jl) for Makie-based visualization.
+
+## When NOT to use Ferrite
+
+While Ferrite is powerful, it might not be the right tool if:
+
+*   You are looking for a commercial-style "black box" solver with a graphical user interface (GUI) to merely configure and run standard simulations.
+*   You require a library with a vast built-in catalogue of material models or structural components (Ferrite focuses on the *engine*, letting you define the physics).
+*   You need complex built-in mesh generation. (Ferrite handles grid data structures excellently but relies on external tools like [Gmsh](https://gmsh.info/) (via [FerriteGmsh.jl](https://github.com/Ferrite-FEM/FerriteGmsh.jl)) for generating complex geometries).
 
 ## Documentation
 


### PR DESCRIPTION
Hi! This PR addresses issue #1250 by expanding the `README.md` to clearly define Ferrite's scope, core features, and intended use cases. 

Following the maintainer's suggestions, I’ve added sections that clarify Ferrite’s role as a low-level "toolbox" for finite element simulations. This helps distinguish it from high-level "black box" solvers, providing better guidance for new users arriving at the repository.

### What’s changed?

* **Project Scope & Mission**: Added a concise introductory paragraph defining Ferrite as a performant, mathematically abstract foundation for FEA in Julia.
* **Core Features**: Provided a bulleted list of the toolbox's strengths, including versatile grid management, flexible DOF handling, and its high-performance design leveraging Julia's multiple dispatch.
* **"When NOT to use Ferrite"**: Added a boundary-setting section to clarify that Ferrite is an *engine* for building solvers, not a GUI-based application or a library with a pre-built material catalog.

### Verification
- Reviewed the existing documentation and recent FerriteCon materials to ensure technical accuracy regarding features like VTK export and the DofHandler.
- Verified that all external links (FerriteViz.jl, Gmsh) are functional and correctly formatted.
- Ensured the Markdown rendering is clean and consistent with the existing documentation style.

I’m a student contributor and very excited to learn more about the Ferrite ecosystem! I've tried to capture the precise yet flexible nature of the project in these descriptions. I would be extremely grateful for any feedback if the tone or specific "Non-Scope" examples should be adjusted to better fit the project's vision.