### PR TITLE
simplify state signature and inline in InterfaceIterator

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -370,13 +370,14 @@ end
         facet_a = skeleton[i]; i += 1
         neighbors = neighborhood[facet_a[1], facet_a[2]]
         isempty(neighbors) && continue
-        length(neighbors) > 1 && error("multiple neighboring faces not supported yet")
-        reinit!( ii.cache, facet_a, neighbors[1])
-        return  ii.cache, i
+        length(neighbors) > 1 && error("multiple neighboring facets not supported yet")
+        facet_b = neighbors[1]
+        reinit!(ii.cache, facet_a, facet_b)
+        return ii.cache, i
     end
     return nothing
 end
-@inline Base.iterate(ii::InterfaceIterator) = Base.iterate(ii, 1)
+@inline Base.iterate(ii::InterfaceIterator) = iterate(ii, 1)
 
 # Iterator interface for CellIterator/FacetIterator
 const GridIterators{C} = Union{CellIterator{C}, FacetIterator{C}, InterfaceIterator{C}}


### PR DESCRIPTION
Attempt at solving https://github.com/Ferrite-FEM/Ferrite.jl/issues/1280, 
mwe : 
```julia
using Ferrite
function loop_bad(dh, topo)
    s = 0
    for ic in InterfaceIterator(dh, topo)  # allocs here ( iterate on flamegraph)
        s += length(interfacedofs(ic))  
    end
    return s
end
function loop_cached(skel, neigh, icache)
    s = 0
    for facet in skel # no allocs
        nbhs = @inbounds neigh[facet[1], facet[2]]
        isempty(nbhs) && continue
        Ferrite.reinit!(icache, facet, nbhs[1])
        s += length(icache.dofs)         
    end
    return s
end
function main(; nx=50, ny=50, order=1)
    grid = generate_grid(Quadrilateral, (nx,ny), Vec{2}((0.0,0.0)), Vec{2}((1.0,1.0)))
    topo = ExclusiveTopology(grid)
    ip = DiscontinuousLagrange{RefQuadrilateral,order}()
    dh = DofHandler(grid); add!(dh, :u, ip); close!(dh)
    skel   = collect(facetskeleton(topo, grid))               
    neigh  = Ferrite.get_facet_facet_neighborhood(topo, grid)     
    icache = InterfaceCache(dh)
    loop_bad(dh, topo)
    loop_cached(skel, neigh, icache)
    bad    = @allocated loop_bad(dh, topo)
    cached = @allocated loop_cached(skel, neigh, icache)
    println((bad=bad, cached=cached))
end
main()
```
before : `(bad = 719888, cached = 0)` getting worse with nx , ny and order
after : `(bad = 960, cached = 0)` only getting bigger with order 