### PR TITLE
FastSparsityPattern

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"

--- a/benchmark/benchmark-sparsitypattern.jl
+++ b/benchmark/benchmark-sparsitypattern.jl
@@ -2,6 +2,7 @@ using Ferrite
 using SparseMatricesCSR: SparseMatrixCSR
 using SparseArrays: SparseMatrixCSC
 using DataFrames
+using Ferrite: FastSparsityPattern
 
 function dh_scalar(grid)
     CT = getcelltype(grid)

--- a/benchmark/benchmark-sparsitypattern.jl
+++ b/benchmark/benchmark-sparsitypattern.jl
@@ -1,0 +1,81 @@
+using Ferrite
+using SparseMatricesCSR: SparseMatrixCSR
+using SparseArrays: SparseMatrixCSC
+using DataFrames
+
+function dh_scalar(grid)
+    CT = getcelltype(grid)
+    RS = getrefshape(CT)
+    return close!(add!(DofHandler(grid), :u, Lagrange{RS, 1}()))
+end
+
+function dh_complex(grid::Grid{sdim}) where {sdim}
+    CT = getcelltype(grid)
+    RS = getrefshape(CT)
+    dh = DofHandler(grid)
+    add!(dh, :u, Lagrange{RS, 2}())
+    add!(dh, :v, Lagrange{RS, 1}()^sdim)
+    return close!(dh)
+end
+
+create_sp(dh) = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
+create_fsp(dh) = FastSparsityPattern(dh)
+
+grid_2d = generate_grid(Triangle, 1000 .* (1, 1))
+grid_3d = generate_grid(Hexahedron, 80 .* (1, 1, 1))
+
+dofhandlers = [
+    "dh_2d_scalar" => dh_scalar(grid_2d),
+    "dh_3d_scalar" => dh_scalar(grid_3d),
+    "dh_2d_complex" => dh_complex(grid_2d),
+    "dh_3d_complex" => dh_complex(grid_3d),
+]
+
+function timef(f::F, ::Type{MatrixType}, args...; kwargs...) where {F, MatrixType}
+    sp0 = f(args...; kwargs...)       # Compile
+    allocate_matrix(MatrixType, sp0)  # Compile
+    GC.gc()
+    sp_allocs = @allocations (sp_runtime = @elapsed (sp = f(args...; kwargs...)))
+    m_allocs = @allocations (m_runtime = @elapsed allocate_matrix(MatrixType, sp))
+    return (; sp_t = sp_runtime, sp_a = sp_allocs, m_t = m_runtime, m_a = m_allocs)
+end
+
+function fmt_time(t::Number; digits = 2)
+    units = ["ns", "μs", "ms", "s", "min", "h"]
+    values = [1.0e-9, 1.0e-6, 1.0e-3, 1.0, 60.0, 3600]
+    idx = findfirst(v -> v > t, values)
+    i = max(idx === nothing ? length(values) : idx - 1, 1)
+    return string(round(t / values[i]; digits)) * " " * units[i]
+end
+
+function fmt_count(n::Integer; digits = 2)
+    units = ["k", "M", "G"]
+    values = [1.0e3, 1.0e6, 1.0e9]
+    n < 1000 && return string(n)
+    i = findlast(v -> v ≤ n, values)
+    return string(round(n / values[i]; digits)) * units[i]
+end
+
+function make_timings(MatrixType)
+    return map([create_sp, create_fsp]) do f
+        [key => timef(f, MatrixType, dh) for (key, dh) in dofhandlers]
+    end
+end
+
+function make_df(timings)
+    _getdata(v, k) = getindex.(last.(v), k)
+    return DataFrame(
+        "case" => first.(dofhandlers),
+        "t (sp) [s]" => fmt_time.(_getdata(timings[1], :sp_t)),
+        "t (fsp) [s]" => fmt_time.(_getdata(timings[2], :sp_t)),
+        "allocs (sp)" => fmt_count.(_getdata(timings[1], :sp_a)),
+        "allocs (fsp)" => fmt_count.(_getdata(timings[2], :sp_a)),
+        "t (K,sp) [s]" => fmt_time.(_getdata(timings[1], :m_t)),
+        "t (K,fsp) [s]" => fmt_time.(_getdata(timings[2], :m_t)),
+        "allocs (K,sp)" => fmt_count.(_getdata(timings[1], :m_a)),
+        "allocs (K,fsp)" => fmt_count.(_getdata(timings[2], :m_a))
+    )
+end
+
+display(make_df(make_timings(SparseMatrixCSC{Float64, Int})))
+display(make_df(make_timings(SparseMatrixCSR)))

--- a/benchmark/benchmark-sparsitypattern.jl
+++ b/benchmark/benchmark-sparsitypattern.jl
@@ -79,4 +79,4 @@ function make_df(timings)
 end
 
 display(make_df(make_timings(SparseMatrixCSC{Float64, Int})))
-display(make_df(make_timings(SparseMatrixCSR)))
+# display(make_df(make_timings(SparseMatrixCSR)))

--- a/docs/src/devdocs/special_datastructures.md
+++ b/docs/src/devdocs/special_datastructures.md
@@ -14,3 +14,8 @@ Ferrite.ArrayOfVectorViews
 Ferrite.ConstructionBuffer
 Ferrite.push_at_index!
 ```
+
+## `FastSparsityPattern`
+```@docs
+Ferrite.FastSparsityPattern
+```

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -134,7 +134,7 @@ function sort_rows!(sp::FastSparsityPattern, rowrange::UnitRange)
         i1 = sp.rowptr[row]
         i2 = sp.rowptr[row + 1] - 1
         if i1 < i2
-            sort!(view(sp.colidx, i1:i2))
+            sort!(view(sp.colidx, i1:i2); alg = QuickSort)
         end
     end
     return sp
@@ -145,15 +145,11 @@ function sort_rows_threaded!(
         ntasks = max(min(Threads.nthreads() * 100, getnrows(sp) ÷ 1000), 1)
     )               # Otherwise, 100 per thread for load balancing
     nrows = getnrows(sp)
-    ΔN = nrows ÷ ntasks
-    Base.Experimental.@sync begin
-        for taskid in 1:ntasks
-            Threads.@spawn begin
-                first_idx = 1 + ΔN * (taskid - 1)
-                last_idx = min(first_idx + ΔN - 1, nrows)
-                sort_rows!(sp, first_idx:last_idx)
-            end
-        end
+    ΔN = (nrows + 1) ÷ ntasks
+    Threads.@threads for taskid in 1:ntasks
+        first_idx = 1 + ΔN * (taskid - 1)
+        last_idx = min(first_idx + ΔN - 1, nrows)
+        sort_rows!(sp, first_idx:last_idx)
     end
     sp.is_colidx_sorted = true
     return sp

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -123,12 +123,6 @@ function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::FastSparsityPa
     return SparseMatrixCSR{1}(getnrows(sp), getncols(sp), sp.rowptr, sp.colidx, nzval)
 end
 
-function sort_rows!(sp)
-    sort_rows!(sp, 1:getnrows(sp))
-    sp.is_colidx_sorted = true
-    return sp
-end
-
 function sort_rows!(sp::FastSparsityPattern, rowrange::UnitRange)
     @inbounds for row in rowrange
         i1 = sp.rowptr[row]

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -145,7 +145,7 @@ function sort_rows_threaded!(
         ntasks = max(min(Threads.nthreads() * 100, getnrows(sp) ÷ 1000), 1)
     )               # Otherwise, 100 per thread for load balancing
     nrows = getnrows(sp)
-    ΔN = (nrows + 1) ÷ ntasks
+    ΔN = cld(nrows, ntasks)
     Threads.@threads for taskid in 1:ntasks
         first_idx = 1 + ΔN * (taskid - 1)
         last_idx = min(first_idx + ΔN - 1, nrows)

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -1,7 +1,7 @@
 module FerriteSparseMatrixCSR
 
 using Ferrite, SparseArrays, SparseMatricesCSR
-import Ferrite: AbstractSparsityPattern, CSRAssembler
+import Ferrite: AbstractSparsityPattern, CSRAssembler, FastSparsityPattern, getnrows, getncols
 import Base: @propagate_inbounds
 
 # Could be generalized if https://github.com/JuliaSparse/SparseArrays.jl/pull/546 is merged
@@ -110,6 +110,53 @@ function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::AbstractSparsi
     end
     S = SparseMatrixCSR{1}(Ferrite.getnrows(sp), Ferrite.getncols(sp), rowptr, colval, nzval)
     return S
+end
+
+## ================= ##
+# FastSparsityPattern #
+## ================= ##
+
+function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::FastSparsityPattern{Ti}, sym::Bool) where {Tv, Ti}
+    sym && throw(ArgumentError("FastSparsityPattern does not support symmetric matrices yet"))
+    sp.is_colidx_sorted || sort_rows_threaded!(sp) # Require sorted rows
+    nzval = zeros(Tv, length(sp.colidx))
+    return SparseMatrixCSR{1}(getnrows(sp), getncols(sp), sp.rowptr, sp.colidx, nzval)
+end
+
+function sort_rows!(sp)
+    sort_rows!(sp, 1:getnrows(sp))
+    sp.is_colidx_sorted = true
+    return sp
+end
+
+function sort_rows!(sp::FastSparsityPattern, rowrange::UnitRange)
+    @inbounds for row in rowrange
+        i1 = sp.rowptr[row]
+        i2 = sp.rowptr[row + 1] - 1
+        if i1 < i2
+            sort!(view(sp.colidx, i1:i2))
+        end
+    end
+    return sp
+end
+
+function sort_rows_threaded!(
+        sp::FastSparsityPattern, # Default ΔN ≥ 1000 and `n_tasks ≥ 1`
+        ntasks = max(min(Threads.nthreads() * 100, getnrows(sp) ÷ 1000), 1)
+    )               # Otherwise, 100 per thread for load balancing
+    nrows = getnrows(sp)
+    ΔN = nrows ÷ ntasks
+    Base.Experimental.@sync begin
+        for taskid in 1:ntasks
+            Threads.@spawn begin
+                first_idx = 1 + ΔN * (taskid - 1)
+                last_idx = min(first_idx + ΔN - 1, nrows)
+                sort_rows!(sp, first_idx:last_idx)
+            end
+        end
+    end
+    sp.is_colidx_sorted = true
+    return sp
 end
 
 end

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -681,3 +681,195 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::AbstractSparsityP
     S = SparseMatrixCSC(getnrows(sp), getncols(sp), colptr, rowval, nzval)
     return S
 end
+
+## ================== ##
+# FastSparsityPattern #
+## ================== ##
+
+# Full `AbstractSparsityPattern` interface not supported
+mutable struct FastSparsityPattern{Ti} <: AbstractSparsityPattern
+    const rowlen::Vector{Ti} # Number of stored entries in each row
+    const marker::Vector{Ti} # Marker if column has been "visited" by certain row
+    const rowptr::Vector{Ti} # Index of stored entries at the start of each row
+    const colidx::Vector{Ti} # colidx[i] gives the column number of the ith stored entry
+    is_colidx_sorted::Bool   # Is colidx sorted for each row
+end
+function FastSparsityPattern(::Type{Ti}, ncols, nrows) where {Ti <: Integer}
+    rowlen = zeros(Ti, nrows)
+    marker = zeros(Ti, ncols)
+    rowptr = Vector{Ti}(undef, nrows + 1)
+    colidx = Vector{Ti}(undef, 0) # To be resized later
+    return FastSparsityPattern(rowlen, marker, rowptr, colidx, false)
+end
+
+FastSparsityPattern(dh::DofHandler) = FastSparsityPattern(Int, dh)
+function FastSparsityPattern(::Type{Ti}, dh::DofHandler) where {Ti}
+    sp = FastSparsityPattern(Ti, ndofs(dh), ndofs(dh))
+    # Step 1: Create cell_dof_views::ArrayOfVectorViews (would be nice in `DofHandler` directly)
+    ncells = getncells(dh.grid)
+    indices = copy(dh.cell_dofs_offset)
+    push!(indices, length(dh.cell_dofs) + 1)
+    cell_dofs_views = ArrayOfVectorViews(indices, dh.cell_dofs, LinearIndices((ncells,)))
+    # Step 2: Define mapping rownr to cells
+    row_to_cells = create_row_to_cells(cell_dofs_views, sp)
+    # Step 3: Count how many cols stored for each row
+    count_row_sizes!(sp, row_to_cells, cell_dofs_views)
+    # Step 4: Build the rowptr (indices for s)
+    build_rowptr!(sp)
+    fill_colidx!(sp, row_to_cells, cell_dofs_views)
+    return sp
+end
+
+getncols(sp::FastSparsityPattern) = length(sp.marker)
+getnrows(sp::FastSparsityPattern) = length(sp.rowlen)
+
+function create_row_to_cells(cell_dofs::ArrayOfVectorViews, sp)
+    nrows = getnrows(sp)
+    num_cells = zeros(Int, nrows)
+    # 1: Figure out how many cells are connected to each dof
+    n_connected = 0
+    @inbounds for rows in cell_dofs # dof = row
+        for row in rows
+            num_cells[row] += 1
+            n_connected += 1
+        end
+    end
+    # n_connected = sum(num_cells) better?
+
+    # 2: Create the correct datastructure
+    data = Vector{Int}(undef, n_connected)
+    indices = Vector{Int}(undef, nrows + 1)
+    indices[1] = 1
+    @inbounds for row in 1:nrows
+        indices[row + 1] = indices[row] + num_cells[row]
+    end
+    fill!(num_cells, 0) # Now we use this to count how many have been added
+    @inbounds for (cellnr, rows) in enumerate(cell_dofs)
+        for row in rows
+            data[indices[row] + num_cells[row]] = cellnr
+            num_cells[row] += 1
+        end
+    end
+    return ArrayOfVectorViews(indices, data, LinearIndices((nrows,)))
+end
+
+function count_row_sizes!(sp::FastSparsityPattern, row_to_cells::AbstractVector, cell_dofs::ArrayOfVectorViews)
+    @inbounds for row in 1:getnrows(sp)
+        for cnr in row_to_cells[row]
+            for col in cell_dofs[cnr]
+                if sp.marker[col] != row
+                    sp.marker[col] = row
+                    sp.rowlen[row] += 1
+                end
+            end
+        end
+    end
+    return sp
+end
+
+function build_rowptr!(sp)
+    sp.rowptr[1] = 1
+    @inbounds for row in 1:getnrows(sp)
+        sp.rowptr[row + 1] = sp.rowptr[row] + sp.rowlen[row]
+    end
+    return sp
+end
+
+function fill_colidx!(sp::FastSparsityPattern, row_to_cells::AbstractVector, cell_dofs::ArrayOfVectorViews)
+    resize!(sp.colidx, sp.rowptr[end] - 1) # nnz
+    fill!(sp.marker, 0)
+    @inbounds for row in 1:getnrows(sp)
+        pos = sp.rowptr[row]
+        for cnr in row_to_cells[row]
+            for col in cell_dofs[cnr]
+                if sp.marker[col] != row
+                    sp.marker[col] = row
+                    sp.colidx[pos] = col
+                    pos += 1
+                end
+            end
+        end
+    end
+    return sp
+end
+
+allocate_matrix(sp::FastSparsityPattern) = allocate_matrix(SparseMatrixCSC, sp)
+allocate_matrix(::Type{SparseMatrixCSC}, sp::FastSparsityPattern{Int}) = allocate_matrix(SparseMatrixCSC{Float64, Int}, sp)
+function allocate_matrix(::Type{<:SparseMatrixCSC{Tv, Ti}}, sp::FastSparsityPattern{Ti}) where {Ti, Tv}
+    nnz = length(sp.colidx)
+    ncols = getncols(sp)
+    nrows = getnrows(sp)
+
+    # Number of stored entries per column
+    collen = zeros(Ti, ncols)
+    @inbounds for col in sp.colidx
+        collen[col] += 1
+    end
+
+    # Index of stored entries at the start of each column
+    colptr = Vector{Ti}(undef, ncols + 1)
+    colptr[1] = 1
+    @inbounds for col in 1:ncols
+        colptr[col + 1] = colptr[col] + collen[col]
+    end
+
+    # Build rowidx[i] giving the row number of the ith stored entry
+    rowidx = Vector{Ti}(undef, nnz)
+    next = copy(colptr)
+    @inbounds for row in 1:nrows
+        for p in sp.rowptr[row]:(sp.rowptr[row + 1] - 1)
+            col = sp.colidx[p]
+            q = next[col]
+            rowidx[q] = row
+            next[col] = q + 1
+            # For a given col, next[col] is increasing, and row is
+            # increasing in the outer loop -> rowidx sorted for each col
+        end
+    end
+    nzval = zeros(Tv, nnz)
+    return SparseMatrixCSC(nrows, ncols, colptr, rowidx, nzval)
+end
+
+#= # TODO: Move to extension
+function sort_rows!(sp)
+    sort_rows!(sp, 1:getnrows(sp))
+    sp.is_sorted = true
+    return sp
+end
+
+function sort_rows!(sp::FastSparsityPattern, rowrange::UnitRange)
+    @inbounds for row in rowrange
+        i1 = sp.rowptr[row]
+        i2 = sp.rowptr[row + 1] - 1
+        if i1 < i2
+            sort!(view(sp.colidx, i1:i2))
+        end
+    end
+    return sp
+end
+
+function sort_rows_threaded!(
+        sp::FastSparsityPattern, # Default ΔN ≥ 1000 and `n_tasks ≥ 1`
+        ntasks = max(min(Threads.nthreads() * 100, getnrows(sp) ÷ 1000), 1)
+        )               # Otherwise, 100 per thread for load balancing
+    nrows = getnrows(sp)
+    ΔN = nrows ÷ ntasks
+    Base.Experimental.@sync begin
+        for taskid in 1:ntasks
+            Threads.@spawn begin
+                first_idx = 1 + ΔN * (taskid - 1)
+                last_idx = min(first_idx + ΔN - 1, nrows)
+                sort_rows!(sp, first_idx:last_idx)
+            end
+        end
+    end
+    sp.is_sorted = true
+    return sp
+end
+
+function allocate_matrix(::Type{<:SparseMatrixCSR}, sp::FastSparsityPattern{Ti}) where {Ti}
+    sp.is_sorted || sort_rows_threaded!(sp) # Require sorted rows
+    nzval = zeros(Float64, length(sp.colidx))
+    return SparseMatrixCSR{1}(ndofs(sp), ndofs(sp), sp.rowptr, sp.colidx, nzval)
+end
+=#

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -413,7 +413,12 @@ arguments `args` and keyword arguments `kwargs`.
     copy(K)`) instead.
 """
 function allocate_matrix(::Type{MatrixType}, dh::DofHandler, args...; kwargs...) where {MatrixType}
-    _can_use_fastsp(MatrixType, args...; kwargs...) && return allocate_matrix(MatrixType, FastSparsityPattern(dh, args...; kwargs...))
+    _get_Ti(::Type{<:AbstractMatrix}) = Int
+    _get_Ti(::Type{<:AbstractSparseMatrix{<:Any, Ti}}) where {Ti} = Ti
+    if _can_use_fastsp(MatrixType, args...; kwargs...)
+        fsp = FastSparsityPattern(_get_Ti(MatrixType), dh, args...; kwargs...)
+        return allocate_matrix(MatrixType, fsp)
+    end
     sp = init_sparsity_pattern(dh)
     add_sparsity_entries!(sp, dh, args...; kwargs...)
     return allocate_matrix(MatrixType, sp)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -739,17 +739,23 @@ end
 getncols(sp::FastSparsityPattern) = length(sp.marker)
 getnrows(sp::FastSparsityPattern) = length(sp.rowlen)
 
-function create_celldofs(dh)
+function create_celldofs(dh::DofHandler)
+    isclosed(dh) || throw(ArgumentError("DofHandler must be closed"))
     ncells = getncells(dh.grid)
     indices = similar(dh.cell_dofs_offset, ncells + 1)
     cell_dofs = similar(dh.cell_dofs)
     n = 1
-    for cell_idx in 1:getncells(dh.grid)
+    for cell_idx in 1:ncells
         indices[cell_idx] = n
-        r = n:(n + ndofs_per_cell(dh, cell_idx) - 1)
-        celldofs!(view(cell_dofs, r), dh, cell_idx)
+        num = ndofs_per_cell(dh, cell_idx)
+        num == 0 && continue
+        r = n:(n + num - 1)
+        #celldofs!(view(cell_dofs, r), dh, cell_idx), but faster without view:
+        soffs = dh.cell_dofs_offset[cell_idx]
+        copyto!(cell_dofs, n, dh.cell_dofs, soffs, num)
         n = last(r) + 1
     end
+    indices[end] = n
     return ArrayOfVectorViews(indices, cell_dofs, LinearIndices((ncells,)))
 end
 
@@ -764,7 +770,6 @@ function create_row_to_cells(cell_dofs::ArrayOfVectorViews, sp)
             n_connected += 1
         end
     end
-    # n_connected = sum(num_cells) better?
 
     # 2: Create the correct datastructure
     data = Vector{Int}(undef, n_connected)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -698,7 +698,8 @@ end
 This sparsity does not currently support the full `AbstractSparsityPattern` interface,
 but is used as an internal fast-path for `allocate_matrix(MatrixType, dh)` for some
 supported `MatrixType`s. It can be extended in the future or potentially be merged
-with `SparsityPattern`. See #1302 for details.
+with `SparsityPattern`.
+See [#1302](https://github.com/Ferrite-FEM/Ferrite.jl/pull/1302) for details.
 
 !!! warning "Internal"
     `FastSparsityPattern` is strictly internal and its interface and implementation

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -682,9 +682,9 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::AbstractSparsityP
     return S
 end
 
-## ================== ##
+## ================= ##
 # FastSparsityPattern #
-## ================== ##
+## ================= ##
 
 # Full `AbstractSparsityPattern` interface not supported
 mutable struct FastSparsityPattern{Ti} <: AbstractSparsityPattern
@@ -829,47 +829,3 @@ function allocate_matrix(::Type{<:SparseMatrixCSC{Tv, Ti}}, sp::FastSparsityPatt
     nzval = zeros(Tv, nnz)
     return SparseMatrixCSC(nrows, ncols, colptr, rowidx, nzval)
 end
-
-#= # TODO: Move to extension
-function sort_rows!(sp)
-    sort_rows!(sp, 1:getnrows(sp))
-    sp.is_sorted = true
-    return sp
-end
-
-function sort_rows!(sp::FastSparsityPattern, rowrange::UnitRange)
-    @inbounds for row in rowrange
-        i1 = sp.rowptr[row]
-        i2 = sp.rowptr[row + 1] - 1
-        if i1 < i2
-            sort!(view(sp.colidx, i1:i2))
-        end
-    end
-    return sp
-end
-
-function sort_rows_threaded!(
-        sp::FastSparsityPattern, # Default ΔN ≥ 1000 and `n_tasks ≥ 1`
-        ntasks = max(min(Threads.nthreads() * 100, getnrows(sp) ÷ 1000), 1)
-        )               # Otherwise, 100 per thread for load balancing
-    nrows = getnrows(sp)
-    ΔN = nrows ÷ ntasks
-    Base.Experimental.@sync begin
-        for taskid in 1:ntasks
-            Threads.@spawn begin
-                first_idx = 1 + ΔN * (taskid - 1)
-                last_idx = min(first_idx + ΔN - 1, nrows)
-                sort_rows!(sp, first_idx:last_idx)
-            end
-        end
-    end
-    sp.is_sorted = true
-    return sp
-end
-
-function allocate_matrix(::Type{<:SparseMatrixCSR}, sp::FastSparsityPattern{Ti}) where {Ti}
-    sp.is_sorted || sort_rows_threaded!(sp) # Require sorted rows
-    nzval = zeros(Float64, length(sp.colidx))
-    return SparseMatrixCSR{1}(ndofs(sp), ndofs(sp), sp.rowptr, sp.colidx, nzval)
-end
-=#

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -725,10 +725,7 @@ FastSparsityPattern(dh::DofHandler) = FastSparsityPattern(Int, dh)
 function FastSparsityPattern(::Type{Ti}, dh::DofHandler) where {Ti}
     sp = FastSparsityPattern(Ti, ndofs(dh), ndofs(dh))
     # Step 1: Create cell_dof_views::ArrayOfVectorViews (would be nice in `DofHandler` directly)
-    ncells = getncells(dh.grid)
-    indices = copy(dh.cell_dofs_offset)
-    push!(indices, length(dh.cell_dofs) + 1)
-    cell_dofs_views = ArrayOfVectorViews(indices, dh.cell_dofs, LinearIndices((ncells,)))
+    cell_dofs_views = create_celldofs(dh)
     # Step 2: Define mapping rownr to cells
     row_to_cells = create_row_to_cells(cell_dofs_views, sp)
     # Step 3: Count how many cols stored for each row
@@ -741,6 +738,20 @@ end
 
 getncols(sp::FastSparsityPattern) = length(sp.marker)
 getnrows(sp::FastSparsityPattern) = length(sp.rowlen)
+
+function create_celldofs(dh)
+    ncells = getncells(dh.grid)
+    indices = similar(dh.cell_dofs_offset, ncells + 1)
+    cell_dofs = similar(dh.cell_dofs)
+    n = 1
+    for cell_idx in 1:getncells(dh.grid)
+        indices[cell_idx] = n
+        r = n:(n + ndofs_per_cell(dh, cell_idx) - 1)
+        celldofs!(view(cell_dofs, r), dh, cell_idx)
+        n = last(r) + 1
+    end
+    return ArrayOfVectorViews(indices, cell_dofs, LinearIndices((ncells,)))
+end
 
 function create_row_to_cells(cell_dofs::ArrayOfVectorViews, sp)
     nrows = getnrows(sp)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -688,6 +688,9 @@ end
 ## ================= ##
 
 # Full `AbstractSparsityPattern` interface not supported
+# For now, this remains a non-public fast-path for `allocate_matrix(MatrixType, dh)`,
+# but can be extended in the future or potentially replace `SparsityPattern`.
+# See #1302 for details.
 mutable struct FastSparsityPattern{Ti} <: AbstractSparsityPattern
     const rowlen::Vector{Ti} # Number of stored entries in each row
     const marker::Vector{Ti} # Marker if column has been "visited" by certain row

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -413,7 +413,7 @@ arguments `args` and keyword arguments `kwargs`.
     copy(K)`) instead.
 """
 function allocate_matrix(::Type{MatrixType}, dh::DofHandler, args...; kwargs...) where {MatrixType}
-    _can_use_fastsp(args...; kwargs...) && return allocate_matrix(MatrixType, FastSparsityPattern(dh, args...; kwargs...))
+    _can_use_fastsp(MatrixType, args...; kwargs...) && return allocate_matrix(MatrixType, FastSparsityPattern(dh, args...; kwargs...))
     sp = init_sparsity_pattern(dh)
     add_sparsity_entries!(sp, dh, args...; kwargs...)
     return allocate_matrix(MatrixType, sp)
@@ -706,17 +706,20 @@ function FastSparsityPattern(::Type{Ti}, ncols, nrows) where {Ti <: Integer}
     return FastSparsityPattern(rowlen, marker, rowptr, colidx, false)
 end
 
-# _can_use_fastsp(args...; kwargs...) where args and kwargs are those passed to
+# _can_use_fastsp(MatrixType, args...; kwargs...) where args and kwargs are those passed to
 # `allocate_matrix`. See `add_sparsity_entries!` for a description of args/kwargs.
 function _can_use_fastsp(
+        ::Type{MatrixType},
         ch = nothing;
         topology = nothing,
         keep_constrained = true,
         coupling = nothing,
         interface_coupling = nothing
-    )
+    ) where {MatrixType}
     if ch === topology === coupling === interface_coupling === nothing
-        return keep_constrained
+        if MatrixType <: AbstractSparseMatrix # Symmetric/Block matrices not supported
+            return keep_constrained
+        end
     end
     return false
 end

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -692,10 +692,19 @@ end
 # FastSparsityPattern #
 ## ================= ##
 
-# Full `AbstractSparsityPattern` interface not supported
-# For now, this remains a non-public fast-path for `allocate_matrix(MatrixType, dh)`,
-# but can be extended in the future or potentially replace `SparsityPattern`.
-# See #1302 for details.
+"""
+    FastSparsityPattern([Ti = Int64], dh::DofHandler)
+
+This sparsity does not currently support the full `AbstractSparsityPattern` interface,
+but is used as an internal fast-path for `allocate_matrix(MatrixType, dh)` for some
+supported `MatrixType`s. It can be extended in the future or potentially be merged
+with `SparsityPattern`. See #1302 for details.
+
+!!! warning "Internal"
+    `FastSparsityPattern` is strictly internal and its interface and implementation
+    may change at any time.
+
+"""
 mutable struct FastSparsityPattern{Ti} <: AbstractSparsityPattern
     const rowlen::Vector{Ti} # Number of stored entries in each row
     const marker::Vector{Ti} # Marker if column has been "visited" by certain row

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -413,6 +413,7 @@ arguments `args` and keyword arguments `kwargs`.
     copy(K)`) instead.
 """
 function allocate_matrix(::Type{MatrixType}, dh::DofHandler, args...; kwargs...) where {MatrixType}
+    _can_use_fastsp(args...; kwargs...) && return allocate_matrix(MatrixType, FastSparsityPattern(dh, args...; kwargs...))
     sp = init_sparsity_pattern(dh)
     add_sparsity_entries!(sp, dh, args...; kwargs...)
     return allocate_matrix(MatrixType, sp)
@@ -700,6 +701,21 @@ function FastSparsityPattern(::Type{Ti}, ncols, nrows) where {Ti <: Integer}
     rowptr = Vector{Ti}(undef, nrows + 1)
     colidx = Vector{Ti}(undef, 0) # To be resized later
     return FastSparsityPattern(rowlen, marker, rowptr, colidx, false)
+end
+
+# _can_use_fastsp(args...; kwargs...) where args and kwargs are those passed to
+# `allocate_matrix`. See `add_sparsity_entries!` for a description of args/kwargs.
+function _can_use_fastsp(
+        ch = nothing;
+        topology = nothing,
+        keep_constrained = true,
+        coupling = nothing,
+        interface_coupling = nothing
+    )
+    if ch === topology === coupling === interface_coupling === nothing
+        return keep_constrained
+    end
+    return false
 end
 
 FastSparsityPattern(dh::DofHandler) = FastSparsityPattern(Int, dh)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -130,7 +130,6 @@ export
     # Sparsity pattern
     # AbstractSparsityPattern,
     SparsityPattern,
-    FastSparsityPattern,
     BlockSparsityPattern,
     init_sparsity_pattern,
     add_sparsity_entries!,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -130,6 +130,7 @@ export
     # Sparsity pattern
     # AbstractSparsityPattern,
     SparsityPattern,
+    FastSparsityPattern,
     BlockSparsityPattern,
     init_sparsity_pattern,
     add_sparsity_entries!,

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -331,3 +331,29 @@ end
         @test_throws ErrorException add_sparsity_entries!(p, dh, ch_bad; keep_constrained = false)
     end
 end
+
+@testset "FastSparsityPattern" begin
+    # Internal fast-path for supported cases
+    for CT in (Line, Quadrilateral, Tetrahedron)
+        RS = getrefshape(CT)
+        dim = Ferrite.getrefdim(RS)
+        grid = generate_grid(CT, ntuple(_ -> 5, dim))
+        dh = DofHandler(grid)
+        add!(dh, :a, Lagrange{RS, 1}())
+        add!(dh, :b, Lagrange{RS, 2}()^dim)
+        close!(dh)
+        sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
+        fsp = Ferrite.FastSparsityPattern(dh)
+        K1 = allocate_matrix(sp)
+        K2 = allocate_matrix(fsp)
+        compare_matrices(K1, K2) # For CSC only
+
+        sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
+        fsp = Ferrite.FastSparsityPattern(dh)
+        K1_csr = allocate_matrix(SparseMatrixCSR, sp)
+        K2_csr = allocate_matrix(SparseMatrixCSR, fsp)
+        K1_csr.nzval .= 1:length(K1_csr.nzval)
+        K2_csr.nzval .= 1:length(K2_csr.nzval)
+        @test K1_csr == K2_csr
+    end
+end

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -1,4 +1,5 @@
 using Ferrite, Test, SparseArrays, Random
+using SparseMatricesCSR: SparseMatrixCSR
 
 # Minimal implementation of a custom sparsity pattern
 struct TestPattern <: Ferrite.AbstractSparsityPattern

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -1,5 +1,6 @@
 using Ferrite, Test, SparseArrays, Random
 using SparseMatricesCSR: SparseMatrixCSR
+using LinearAlgebra
 
 # Minimal implementation of a custom sparsity pattern
 struct TestPattern <: Ferrite.AbstractSparsityPattern
@@ -334,15 +335,18 @@ end
 end
 
 @testset "FastSparsityPattern" begin
-    # Internal fast-path for supported cases
-    for CT in (Line, Quadrilateral, Tetrahedron)
+    function fsp_test_create_dh(CT)
         RS = getrefshape(CT)
         dim = Ferrite.getrefdim(RS)
         grid = generate_grid(CT, ntuple(_ -> 5, dim))
         dh = DofHandler(grid)
         add!(dh, :a, Lagrange{RS, 1}())
         add!(dh, :b, Lagrange{RS, 2}()^dim)
-        close!(dh)
+        return close!(dh)
+    end
+    # Internal fast-path for supported cases
+    for CT in (Line, Quadrilateral, Tetrahedron)
+        dh = fsp_test_create_dh(CT)
         sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
         fsp = Ferrite.FastSparsityPattern(dh)
         K1 = allocate_matrix(sp)
@@ -356,5 +360,29 @@ end
         K1_csr.nzval .= 1:length(K1_csr.nzval)
         K2_csr.nzval .= 1:length(K2_csr.nzval)
         @test K1_csr == K2_csr
+    end
+    # Test different number types (Int32, Float32)
+    for Tv in (Float32, Float64)
+        for Ti in (Int32, Int64)
+            dh = fsp_test_create_dh(Quadrilateral)
+            MatrixType = SparseMatrixCSC{Float64, Ti}
+            K1 = allocate_matrix(MatrixType, dh)
+            @test isa(K1, MatrixType)
+            compare_matrices(K1, allocate_matrix(dh))
+
+            MatrixTypeCSR = SparseMatrixCSR{1, Tv, Ti}
+            K1_csr = allocate_matrix(MatrixTypeCSR, dh)
+            @test isa(K1_csr, MatrixTypeCSR)
+        end
+    end
+
+    # Test logic for Symmetric matrices works (will use SparsityPattern)
+    dh = fsp_test_create_dh(Triangle)
+    for MatrixType in (
+            Symmetric{Float64, SparseMatrixCSC{Float64, Int}},
+            # Symmetric{Float64, SparseMatrixCSR{1, Float64, Int}} # Does not work, see #1311
+        )
+        K1 = allocate_matrix(MatrixType, dh)
+        @test isa(K1, MatrixType)
     end
 end


### PR DESCRIPTION
I noticed during benchmarking that our general sparsity pattern is quite slow for larger systems. After some AI-assisted research I found a faster algorithm that is applicable in standard cases. Currently, it is only implemented for the standard cell coupling, but it should be possible to extend to interface coupling and constraints as well.

Update - **suggested plan:**
1) This is ready for review and can be merged from my PoV. `FastSparsityPattern` is **internal** and used as fastpath when possible. This gives a good speedup for standard cases.
2) We can successively add features with this algorithm (see [comment](https://github.com/Ferrite-FEM/Ferrite.jl/pull/1302#issuecomment-4076932850) below)
3) It could potentially replace the current `SparsityPattern`, but it is too soon to say which strategy will be more performant for the more complicated sparsity patterns that the current `SparsityPattern` supports.

<details> <summary> Old notes </summary>
However, it is a two-pass algorithm, requiring that all information is there when doing the first pass. So while not implemented by this PR, my idea for closest approach to the current interface would be that every item is `add!`ed as for the current `SparsityPattern`, but that these steps are stored, and then we could call `close!` to actually create the pattern.

Need to add tests and docs. My idea is that this should replace `allocate_matrix(MatrixType, dh)` for `MatrixType` `SparseMatrixCSC` and `SparseMatrixCSR`, and the general pattern is used for more complicated cases. 

Timing results for allocating the default `SparseMatrixCSC` (script included below):
```julia
Triangle: nel = 10^4
ndofs_per_cell = 3, ndofs ≈ 10 k
SparsityPattern (master):   0.001921 seconds (43 allocations: 5.581 MiB)
FastSparsityPattern (PR):   0.000564 seconds (39 allocations: 3.251 MiB)
ndofs_per_cell = 18, ndofs ≈ 121 k
SparsityPattern (master):   0.066033 seconds (142 allocations: 129.310 MiB)
FastSparsityPattern (PR):   0.017080 seconds (39 allocations: 105.907 MiB)

Triangle: nel = 10^5
ndofs_per_cell = 3, ndofs ≈ 100 k
SparsityPattern (master):   0.028829 seconds (55 allocations: 26.643 MiB)
FastSparsityPattern (PR):   0.006261 seconds (39 allocations: 31.220 MiB)
ndofs_per_cell = 18, ndofs ≈ 1 M
SparsityPattern (master):   0.702183 seconds (1.07 k allocations: 1.264 GiB, 0.51% gc time)
FastSparsityPattern (PR):   0.178801 seconds (39 allocations: 1.029 GiB, 0.74% gc time)

Triangle: nel = 10^6
ndofs_per_cell = 3, ndofs ≈ 1 M
SparsityPattern (master):   0.309288 seconds (177 allocations: 222.022 MiB)
FastSparsityPattern (PR):   0.065926 seconds (39 allocations: 337.079 MiB)
ndofs_per_cell = 18, ndofs ≈ 12 M
SparsityPattern (master):  12.537659 seconds (10.32 k allocations: 12.493 GiB, 1.37% gc time)
FastSparsityPattern (PR):   2.231395 seconds (39 allocations: 10.279 GiB, 1.05% gc time)

Hexahedron: nel = 10^4
ndofs_per_cell = 8, ndofs ≈ 12 k
SparsityPattern (master):   0.008291 seconds (52 allocations: 16.573 MiB)
FastSparsityPattern (PR):   0.001680 seconds (39 allocations: 13.688 MiB)
ndofs_per_cell = 108, ndofs ≈ 364 k
SparsityPattern (master):   1.904070 seconds (2.42 k allocations: 2.681 GiB, 1.97% gc time)
FastSparsityPattern (PR):   0.327835 seconds (39 allocations: 2.030 GiB, 0.37% gc time)

Hexahedron: nel = 10^5
ndofs_per_cell = 8, ndofs ≈ 103 k
SparsityPattern (master):   0.084524 seconds (130 allocations: 90.648 MiB, 0.61% gc time)
FastSparsityPattern (PR):   0.017978 seconds (39 allocations: 75.798 MiB)
ndofs_per_cell = 108, ndofs ≈ 3 M
SparsityPattern (master):  29.977094 seconds (21.53 k allocations: 24.126 GiB, 1.08% gc time)
FastSparsityPattern (PR):   5.577470 seconds (39 allocations: 18.241 GiB, 0.85% gc time)

Hexahedron: nel = 10^6
ndofs_per_cell = 8, ndofs ≈ 1 M
SparsityPattern (master):   0.863224 seconds (813 allocations: 885.615 MiB, 5.52% gc time)
FastSparsityPattern (PR):   0.179126 seconds (39 allocations: 767.470 MiB, 0.51% gc time)
ndofs_per_cell = 51, ndofs ≈ 11 M
SparsityPattern (master):  76.650587 seconds (43.36 k allocations: 47.272 GiB, 1.04% gc time)
FastSparsityPattern (PR):  16.670520 seconds (39 allocations: 34.905 GiB, 0.29% gc time)
```

<details> <summary> Benchmarking script </summary>

```julia
using Ferrite

function timeit(dh; check, compile)
    if compile
        allocate_matrix(dh)
        allocate_matrix_pr(dh)
    end
    print("SparsityPattern (master): ")
    GC.gc() # Ensure fair comparison
    K1 = @time allocate_matrix(dh)
    
    print("FastSparsityPattern (PR): ")
    GC.gc()
    K2 = @time allocate_matrix_pr(dh)
    if check
        # Validate that they are the same
        map!(identity, K1.nzval, 1:length(K1.nzval))
        map!(identity, K2.nzval, 1:length(K2.nzval))
        K1 == K2 || error("Results are not the same")
    end
    return nothing
end

for CT in (Triangle, Hexahedron)
    for nel in (10^4, 10^5, 10^6)
        RefShape = getrefshape(CT)
        dim = Ferrite.getrefdim(CT)
        nel_i = round(Int, nel^(1//dim))
        grid = generate_grid(CT, ntuple(_->nel_i, dim))
        println("$CT: nel = 10^", round(Int, log10(nel)))
        # Case 1, single 1st order scalar interpolation (few dofs per cell)
        dh = close!(add!(DofHandler(grid), :u, Lagrange{RefShape, 1}()))
        dofstr(n) = n > 10^6 ? string(n ÷ 10^6, " M") : (n > 10^3 ? string(n ÷ 10^3, " k") : string(n))
        println("ndofs_per_cell = ", ndofs_per_cell(dh), ", ndofs ≈ ", dofstr(ndofs(dh)))
        timeit(dh; compile = nel == 10^4, check = false)

        # Case 2, multiple and higher order interpolations (more dofs per cell)
        dh = DofHandler(grid)
        order = nel == 10^6 && CT == Hexahedron ? 1 : 2 # 2nd order vector for large 3d grid not feasible
        add!(dh, :u, Lagrange{RefShape, order}()^dim)
        add!(dh, :p, Lagrange{RefShape, 2}())
        close!(dh)
        println("ndofs_per_cell = ", ndofs_per_cell(dh), ", ndofs ≈ ", dofstr(ndofs(dh)))
        timeit(dh; compile = nel == 10^4, check = false)
        println()
    end
end
```
</details>

</details>