### PR TITLE
Modifying transient_heat_equation.jl

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\avina\\Documents\\GithubRepositories\\Ferrite.jl"
+}

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -116,16 +116,16 @@ function doassemble!(K::SparseMatrixCSC, M::SparseMatrixCSC, f::Vector, cellvalu
     Ke = zeros(n_basefuncs, n_basefuncs)
     Me = zeros(n_basefuncs, n_basefuncs)
     fe = zeros(n_basefuncs)
-    # initiate assembler for matrices and vector
+    #Initiate assembler for matrices and vector
     assembler = start_assemble(K, f)
     assembler_M = start_assemble(M)
-    # iterate over cells
+    #Iterate over cells
     for cell in CellIterator(dh)
         fill!(Ke, 0)
         fill!(Me, 0)
         fill!(fe, 0)
         reinit!(cellvalues, cell)
-        # assemble local contributions
+        #Assemble local contributions
         for q_point in 1:getnquadpoints(cellvalues)
             dΩ = getdetJdV(cellvalues, q_point)
             for i in 1:n_basefuncs
@@ -140,7 +140,7 @@ function doassemble!(K::SparseMatrixCSC, M::SparseMatrixCSC, f::Vector, cellvalu
                 end
             end
         end
-        # update global matrices
+        #Update global matrices
         assemble!(assembler, celldofs(cell), Ke, fe)
         assemble!(assembler_M, celldofs(cell), Me)
     end


### PR DESCRIPTION
- Added reference to fe_intro for derivation and discretisation. 
- Changed notation of trial functions to be consistent with previous tutorials (v -> δu).  
- Modified doassembly functions into one function for K, M and f. (If there is a reason why they were in two different function, please let me know since I am new to this library).