### PR TITLE
Introduce isconstrained bitvector in ConstraintHandler

### DIFF
--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -67,7 +67,7 @@ function Ferrite.zero_out_rows!(K::SparseMatrixCSR, ch::ConstraintHandler)
 end
 
 function Ferrite.zero_out_columns!(K::SparseMatrixCSR, ch::ConstraintHandler)
-    @boundscheck checkbounds(ch.isconstrained, Base.OneTo(size(K, 2)))
+    @boundscheck checkbounds(ch.isconstrained, axes(K, 2))
     colval = K.colval
     nzval = K.nzval
     return @inbounds for (i, col) in pairs(colval)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -913,7 +913,7 @@ function zero_out_columns!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler) # 
 end
 
 function zero_out_rows!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler)
-    @boundscheck checkbounds(ch.isconstrained, Base.OneTo(size(K, 1)))
+    @boundscheck checkbounds(ch.isconstrained, axes(K, 1))
     rowval = K.rowval
     nzval = K.nzval
     @inbounds for (i, row) in pairs(rowval)


### PR DESCRIPTION
This makes it easier and faster to check if a dof is constrained. 
Previous check was `haskey(ch.dof_mapping, dofnr)`, now just `ch.isconstrained[dofnr]`.

This speeds up `zero_out_rows!` and makes creating `free_dofs` easier (and a tiny bit faster). 

Benchmarks
```julia
# close!
4.963 ms (59 allocations: 25.78 MiB) # PR
5.075 ms (57 allocations: 25.41 MiB) # master

# apply!
293.966 ms (0 allocations: 0 bytes) # PR
1.333 s (0 allocations: 0 bytes)    # master
```

<details> <summary> benchmark code </summary>

```julia
using Ferrite, BenchmarkTools
grid = generate_grid(Hexahedron, (100,100,100));
dh = close!(add!(DofHandler(grid), :u, Lagrange{RefHexahedron, 1}()^3));
@btime close!(ch) setup = (ch = add!(ConstraintHandler(dh), Dirichlet(:u, getfacetset(grid,"left"), Returns(zero(Vec{3}))))) evals = 1;

ch = close!(add!(ConstraintHandler(dh), Dirichlet(:u, getfacetset(grid,"left"), Returns(zero(Vec{3})))));
K = allocate_matrix(dh); 
f = zeros(ndofs(dh));
@btime apply!($K, $f, $ch);
```

Extra runs for close!:

```julia
# PR 
  5.007 ms (59 allocations: 25.78 MiB)
  5.025 ms (59 allocations: 25.78 MiB)
  5.052 ms (59 allocations: 25.78 MiB)
  
# master
  5.100 ms (57 allocations: 25.41 MiB)
  5.121 ms (57 allocations: 25.41 MiB)
  5.111 ms (57 allocations: 25.41 MiB)
```

</details>