### PR TITLE
Typo in apply! docs

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -590,7 +590,7 @@ conditions specified in `ch` such that `K \\ rhs` gives the expected solution.
 !!! note
     `apply!(K, rhs, ch)` essentially calculates
     ```julia
-    rhs[free] = rhs[free] - K[constrained, constrained] * a[constrained]
+    rhs[free] = rhs[free] - K[free, constrained] * a[constrained]
     ```
     where `a[constrained]` are the inhomogeneities. Consequently, the sign of `rhs` matters
     (in contrast with `apply_zero!`).


### PR DESCRIPTION
Typo in `apply!` doc when explaining which part of the stiffness matrix is used during mutation of the `rhs`.