### PR TITLE
Introduce AbstractCellCache

### DIFF
--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -159,7 +159,7 @@ function _assemble_L2_matrix(dh::DofHandler, qrs_lhs::Vector{<:QuadratureRule})
     return M
 end
 
-function _assemble_L2_matrix!(assembler, cellvalues::CellValues, sdh::SubDofHandler)
+function _assemble_L2_matrix!(assembler, cellvalues::AbstractCellValues, sdh::SubDofHandler)
 
     n = getnbasefunctions(cellvalues)
     Me = zeros(n, n)
@@ -295,7 +295,7 @@ function _project(proj::L2Projector, qrs_rhs::Vector{<:QuadratureRule}, vars::Un
     return T[make_T(x) for x in Base.eachrow(projected_vals)]
 end
 
-function assemble_proj_rhs!(f::Matrix, cellvalues::CellValues, sdh::SubDofHandler, vars::Union{AbstractVector, AbstractDict})
+function assemble_proj_rhs!(f::Matrix, cellvalues::AbstractCellValues, sdh::SubDofHandler, vars::Union{AbstractVector, AbstractDict})
     # Assemble the multi-column rhs, f = ∭( v ⋅ x̂ )dΩ
     # The number of columns corresponds to the length of the data-tuple in the tensor x̂.
     M = size(f, 2)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -242,7 +242,7 @@ end
     `CellIterator` is stateful and should not be used for things other than `for`-looping
     (e.g. broadcasting over, or collecting the iterator may yield unexpected results).
 """
-struct CellIterator{CC <: CellCache, IC <: IntegerCollection}
+struct CellIterator{CC, IC <: IntegerCollection}
     cc::CC
     set::IC
 end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -14,6 +14,8 @@ UpdateFlags(; nodes::Bool = true, coords::Bool = true, dofs::Bool = true) =
 ## CellCache ##
 ###############
 
+abstract type AbstractCellCache end
+
 """
     CellCache(grid::Grid)
     CellCache(dh::AbstractDofHandler)
@@ -32,7 +34,7 @@ cell. The cache is updated for a new cell by calling `reinit!(cache, cellid)` wh
 
 See also [`CellIterator`](@ref).
 """
-mutable struct CellCache{X, G <: AbstractGrid, DH <: Union{AbstractDofHandler, Nothing}}
+mutable struct CellCache{X, G <: AbstractGrid, DH <: Union{AbstractDofHandler, Nothing}} <: AbstractCellCache
     const flags::UpdateFlags
     const grid::G
     # Pretty useless to store this since you have it already for the reinit! call, but
@@ -121,7 +123,7 @@ calling `reinit!(cache, fi::FacetIndex)`.
 
 See also [`FacetIterator`](@ref).
 """
-mutable struct FacetCache{CC <: CellCache}
+mutable struct FacetCache{CC <: CellCache} <: AbstractCellCache
     const cc::CC  # const for julia > 1.8
     const dofs::Vector{Int} # aliasing cc.dofs
     current_facet_id::Int
@@ -170,7 +172,7 @@ interface. The cache is updated for a new cell by calling `reinit!(cache, facet_
 
 See also [`InterfaceIterator`](@ref).
 """
-struct InterfaceCache{FC <: FacetCache}
+struct InterfaceCache{FC <: FacetCache} <: AbstractCellCache
     a::FC
     b::FC
     dofs::Vector{Int}
@@ -242,7 +244,7 @@ end
     `CellIterator` is stateful and should not be used for things other than `for`-looping
     (e.g. broadcasting over, or collecting the iterator may yield unexpected results).
 """
-struct CellIterator{CC, IC <: IntegerCollection}
+struct CellIterator{CC <: AbstractCellCache, IC <: IntegerCollection}
     cc::CC
     set::IC
 end


### PR DESCRIPTION
With these changes, FerriteIGA.jl can use L2Projector without any additional code. It is able to do this by extending the CellIterator/CellCache "interface". 

It would be nice to have a documented interface for the CellIterator in the future so costum grids can use it. 