### PR TITLE
Add extension point for custom assembly ops

### DIFF
--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -14,8 +14,9 @@ end
         K::SparseMatrixCSR, Ke::AbstractMatrix,
         rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
-        sym::Bool
-    )
+        sym::Bool,
+        op!::F = Ferrite.addindex!,
+    ) where {F}
     current_row = 1
     ld = length(coldofs)
     return @inbounds for Krow in sortedrowdofs
@@ -31,9 +32,7 @@ end
             val = Ke[Kerow, Kecol]
             if Kcol == coldofs[Kecol]
                 # Match: add the value (if non-zero) and advance the pointers
-                if !iszero(val)
-                    K.nzval[C] += val
-                end
+                op!(K.nzval, val, C)
                 ci += 1
                 Ci += 1
             elseif Kcol < coldofs[Kecol]

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -25,6 +25,7 @@ Fallback: `A[i, j] += v`.
 addindex!
 
 function addindex!(A::AbstractMatrix{T}, v, i::Integer, j::Integer) where {T}
+    iszero(v) && return A
     return addindex!(A, T(v), Int(i), Int(j))
 end
 function addindex!(A::AbstractMatrix{T}, v::T, i::Int, j::Int) where {T}
@@ -34,6 +35,7 @@ function addindex!(A::AbstractMatrix{T}, v::T, i::Int, j::Int) where {T}
 end
 
 function addindex!(b::AbstractVector{T}, v, i::Integer) where {T}
+    iszero(v) && return b
     return addindex!(b, T(v), Int(i))
 end
 function addindex!(b::AbstractVector{T}, v::T, i::Int) where {T}

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -152,11 +152,11 @@ end
 
 Assembles the element residual `ge` into the global residual vector `g`.
 """
-@propagate_inbounds function assemble!(g::AbstractVector{T}, dofs::AbstractVector{Int}, ge::AbstractVector{T}) where {T}
+@propagate_inbounds function assemble!(g::AbstractVector{T}, dofs::AbstractVector{Int}, ge::AbstractVector{T}, op!::F = addindex!) where {T, F <: Function}
     @boundscheck checkbounds(g, dofs)
     @boundscheck checkbounds(ge, keys(dofs))
     @inbounds for (i, dof) in pairs(dofs)
-        addindex!(g, ge[i], dof)
+        op!(g, ge[i], dof)
     end
     return
 end
@@ -259,16 +259,16 @@ function finish_assemble(a::Union{CSCAssembler, CSRAssembler, SymmetricCSCAssemb
 end
 
 """
-    assemble!(A::Ferrite.AbstractAssembler, dofs::AbstractVector{Int}, Ke::AbstractMatrix)
-    assemble!(A::Ferrite.AbstractAssembler, dofs::AbstractVector{Int}, Ke::AbstractMatrix, fe::AbstractVector)
+    assemble!(A::Ferrite.AbstractAssembler, dofs::AbstractVector{Int}, Ke::AbstractMatrix [, op! = Ferrite.addindex!])
+    assemble!(A::Ferrite.AbstractAssembler, dofs::AbstractVector{Int}, Ke::AbstractMatrix, fe::AbstractVector [, op! = Ferrite.addindex!])
 
 Assemble the square element stiffness matrix `Ke` (and optional force vector `fe`) into the global
 stiffness (and force) in `A`, given the element degrees of freedom `dofs`.
 
 This is equivalent to `K[dofs, dofs] += Ke` and `f[dofs] += fe`, where `K` is the global stiffness matrix and `f` the global force/residual vector, but more efficient.
 
-    assemble!(A::Ferrite.AbstractAssembler, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix)
-    assemble!(A::Ferrite.AbstractAssembler, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix, fe::AbstractVector)
+    assemble!(A::Ferrite.AbstractAssembler, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix [, op! = Ferrite.addindex!])
+    assemble!(A::Ferrite.AbstractAssembler, rowdofs::AbstractVector{Int}, coldofs::AbstractVector{Int}, Ke::AbstractMatrix, fe::AbstractVector [, op! = Ferrite.addindex!])
 
 Assemble the element stiffness matrix `Ke` (and optional force vector `fe`) into the global
 stiffness (and force) in `A`, given the element row degrees of freedom, `rowdofs`, and element column degrees of freedom, `coldofs`.
@@ -276,15 +276,25 @@ This is equivalent to `K[rowdofs, coldofs] += Ke` and `f[rowdofs] += fe`, but mo
 """
 assemble!(::AbstractAssembler, ::AbstractVector{<:Integer}, ::AbstractMatrix, ::AbstractVector)
 
-@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
+@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector, op!::F = addindex!) where {F <: Function}
     size(Ke, 1) == size(Ke, 2) || throw(ArgumentError("Ke is rectangular, but only a single `dofs` vector is provided. Please call assemble!(A, rowdofs, coldofs, Ke, fe) instead."))
-    return _assemble!(A, dofs, dofs, Ke, fe, false)
+    return _assemble!(A, dofs, dofs, Ke, fe, false, op!)
 end
-@propagate_inbounds function assemble!(A::AbstractAssembler, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
-    return _assemble!(A, rowdofs, coldofs, Ke, fe, false)
+@propagate_inbounds function assemble!(A::AbstractAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, op!::F = addindex!) where {F <: Function}
+    size(Ke, 1) == size(Ke, 2) || throw(ArgumentError("Ke is rectangular, but only a single `dofs` vector is provided. Please call assemble!(A, rowdofs, coldofs, Ke) instead."))
+    return _assemble!(A, dofs, dofs, Ke, nothing, false, op!)
 end
-@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
-    return _assemble!(A, dofs, dofs, Ke, fe, true)
+@propagate_inbounds function assemble!(A::AbstractAssembler, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector, op!::F = addindex!) where {F <: Function}
+    return _assemble!(A, rowdofs, coldofs, Ke, fe, false, op!)
+end
+@propagate_inbounds function assemble!(A::AbstractAssembler, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, op!::F = addindex!) where {F <: Function}
+    return _assemble!(A, rowdofs, coldofs, Ke, nothing, false, op!)
+end
+@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::AbstractVector, op!::F = addindex!) where {F <: Function}
+    return _assemble!(A, dofs, dofs, Ke, fe, true, op!)
+end
+@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, op!::F = addindex!) where {F <: Function}
+    return _assemble!(A, dofs, dofs, Ke, nothing, true, op!)
 end
 
 """
@@ -301,12 +311,12 @@ Sorts the dofs into a separate buffer and returns it together with a permutation
     return sorteddofs, permutation
 end
 
-@propagate_inbounds function _assemble!(A::Union{AbstractCSCAssembler, AbstractCSRAssembler}, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing}, sym::Bool)
+@propagate_inbounds function _assemble!(A::Union{AbstractCSCAssembler, AbstractCSRAssembler}, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing}, sym::Bool, op!::F = addindex!) where {F <: Function}
     @boundscheck checkbounds(Ke, keys(rowdofs), keys(coldofs))
     if fe !== nothing
         @boundscheck checkbounds(fe, keys(rowdofs))
         @boundscheck checkbounds(A.f, rowdofs)
-        @inbounds assemble!(A.f, rowdofs, fe)
+        @inbounds assemble!(A.f, rowdofs, fe, op!)
     end
 
     K = matrix_handle(A)
@@ -322,15 +332,16 @@ end
         sortedcoldofs, colpermutation
     end
 
-    return _assemble_inner!(K, Ke, rowdofs, sortedrowdofs, rowpermutation, coldofs, sortedcoldofs, colpermutation, sym)
+    return _assemble_inner!(K, Ke, rowdofs, sortedrowdofs, rowpermutation, coldofs, sortedcoldofs, colpermutation, sym, op!)
 end
 
 @propagate_inbounds function _assemble_inner!(
         K::SparseMatrixCSC, Ke::AbstractMatrix,
         rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
-        sym::Bool
-    )
+        sym::Bool,
+        op!::F,
+    ) where {F}
     current_col = 1
     Krows = rowvals(K)
     Kvals = nonzeros(K)
@@ -348,9 +359,7 @@ end
             val = Ke[Kerow, Kecol]
             if Krow == rowdofs[Kerow]
                 # Match: add the value (if non-zero) and advance the pointers
-                if !iszero(val)
-                    Kvals[R] += val
-                end
+                op!(Kvals, val, R)
                 ri += 1
                 Ri += 1
             elseif Krow < rowdofs[Kerow]

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -167,6 +167,10 @@ function Base.:+(y::Float64, x::IgnoreMeIfZero)
     @test !iszero(x.x)
     return y + x.x
 end
+function Base.Float64(x::IgnoreMeIfZero)
+    @test !iszero(x.x)
+    return x.x
+end
 
 @testset "assemble! ignoring zeros" begin
     store_dofs = [1, 5, 2, 8]


### PR DESCRIPTION
This allows us to simply add stuff like #1331 .

The alternative design here is to add the operation as a field to the assembler struct instead of passing it into `assemble!`.

For the first tutorial I get on the branch

```julia
julia> include("src/literate-tutorials/heat_equation.jl")
  69.279 μs (20 allocations: 4.49 KiB)
Test Passed
```

and on master

```julia
julia> include("src/literate-tutorials/heat_equation.jl")
  69.420 μs (20 allocations: 4.49 KiB)
Test Passed
```
