### PR TITLE
assembler: avoid looking up the value in Ke until it is needed and look up row dof in a more cache friendly way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Make `shape_symmetric_gradient` work for `PointValues` ([#1325])
  - Make the internal function `getlowerorder` work for `VectorizedInterpolation` ([#1335])
 
+### Performance
+ - Small performance improvement to `SparseMatrixCSR` and `SparseMatrixCSR` assembly by avoiding
+   some reductions operations. (#1341)
+
 ## [v1.4.0] - 2026-04-20
 
 ### Added

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -27,22 +27,22 @@ end
         while Ci <= length(nzr) && ci <= maxlookups
             C = nzr[Ci]
             Kcol = K.colval[C]
-            Kecol = colpermutation[ci]
-            val = Ke[Kerow, Kecol]
-            if Kcol == coldofs[Kecol]
+            Kecol_dof = sortedcoldofs[ci]
+            if Kcol == Kecol_dof
                 # Match: add the value (if non-zero) and advance the pointers
+                val = Ke[Kerow, colpermutation[ci]]
                 if !iszero(val)
                     K.nzval[C] += val
                 end
                 ci += 1
                 Ci += 1
-            elseif Kcol < coldofs[Kecol]
+            elseif Kcol < Kecol_dof
                 # No match yet: advance the global matrix row pointer
                 Ci += 1
-            else # Kcol > coldofs[Kecol]
+            else # Kcol > Kecol_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(val) || Ferrite._missing_sparsity_pattern_error(Krow, Kcol)
+                iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kcol)
                 # Advance the local matrix row pointer
                 ci += 1
             end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -344,22 +344,22 @@ end
         while Ri <= length(nzr) && ri <= maxlookups
             R = nzr[Ri]
             Krow = Krows[R]
-            Kerow = rowpermutation[ri]
-            val = Ke[Kerow, Kecol]
-            if Krow == rowdofs[Kerow]
+            Kerow_dof = sortedrowdofs[ri]
+            if Krow == Kerow_dof
                 # Match: add the value (if non-zero) and advance the pointers
+                val = Ke[rowpermutation[ri], Kecol]
                 if !iszero(val)
                     Kvals[R] += val
                 end
                 ri += 1
                 Ri += 1
-            elseif Krow < rowdofs[Kerow]
+            elseif Krow < Kerow_dof
                 # No match yet: advance the global matrix row pointer
                 Ri += 1
-            else # Krow > rowdofs[Kerow]
+            else # Krow > Kerow_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(val) || _missing_sparsity_pattern_error(Krow, Kcol)
+                iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Krow, Kcol)
                 # Advance the local matrix row pointer
                 ri += 1
             end


### PR DESCRIPTION
Since we have the sorted column dofs we can just grab it from there (in a linear cache friendly way) instead of doing a "gather" operation.

For the following benchmark:

```julia
using Ferrite, SparseArrays, BenchmarkTools, LinearAlgebra

function setup(CT, RS, ord, dims; vec = false)
    grid = generate_grid(CT, dims)
    ip = vec ? Lagrange{RS, ord}()^Ferrite.getrefdim(CT) : Lagrange{RS, ord}()
    qr = QuadratureRule{RS}(2 * ord)
    cv = CellValues(qr, ip)
    dh = DofHandler(grid); add!(dh, :u, ip); close!(dh)
    ch = ConstraintHandler(dh)
    ∂Ω = union((getfacetset(grid, s) for s in ("left", "right"))...)
    add!(ch, Dirichlet(:u, ∂Ω, (x, t) -> vec ? zeros(Ferrite.getrefdim(CT)) : 0.0)); close!(ch)
    return grid, dh, cv, ch
end

# scatter-only assembly (fixed element matrix) — isolates the global insert cost
function scatter!(K, f, dh, Ke, fe)
    asm = start_assemble(K, f)
    for cell in CellIterator(dh)
        assemble!(asm, celldofs(cell), Ke, fe)
    end
    return K
end

const CASES = (
    ("3D Hex Q2 scalar", Hexahedron, RefHexahedron, 2, (10, 10, 10), false),
    ("3D Tet P1 vector", Tetrahedron, RefTetrahedron, 1, (15, 15, 15), true),
    ("2D Quad Q1 scalar", Quadrilateral, RefQuadrilateral, 1, (100, 100), false),
)

println("="^64)
println("(1) Scatter assemble!  -- src/assembler.jl _assemble_inner!")
println("="^64)
for (nm, CT, RS, ord, dims, vec) in CASES
    grid, dh, cv, _ = setup(CT, RS, ord, dims; vec = vec)
    n = getnbasefunctions(cv)
    K = allocate_matrix(dh); f = zeros(ndofs(dh))
    Ke = rand(n, n); fe = rand(n)
    print("  [$nm] $(ndofs(dh)) dofs, $n/cell: ")
    @btime scatter!($K, $f, $dh, $Ke, $fe)
end
```

It gives

```
# Before
================================================================
(1) Scatter assemble!  -- src/assembler.jl _assemble_inner!
================================================================
  [3D Hex Q2 scalar] 9261 dofs, 27/cell:   1.503 ms (13 allocations: 1.30 KiB)
  [3D Tet P1 vector] 12288 dofs, 12/cell:   8.058 ms (13 allocations: 864 bytes)
  [2D Quad Q1 scalar] 10201 dofs, 4/cell:   526.791 μs (13 allocations: 640 bytes)

# After
================================================================
(1) Scatter assemble!  -- src/assembler.jl _assemble_inner!
================================================================
  [3D Hex Q2 scalar] 9261 dofs, 27/cell:   1.459 ms (13 allocations: 1.30 KiB)
  [3D Tet P1 vector] 12288 dofs, 12/cell:   6.950 ms (13 allocations: 864 bytes)
  [2D Quad Q1 scalar] 10201 dofs, 4/cell:   481.000 μs (13 allocations: 640 bytes)
```

Idea hinted at by a bot. 