### PR TITLE
DofHandler: avoid large amount of rehashing when distributing dofs by sizehinting them to roughly the correct sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Make `shape_symmetric_gradient` work for `PointValues` ([#1325])
  - Make the internal function `getlowerorder` work for `VectorizedInterpolation` ([#1335])
 
+### Performance
+ - Distributing DoFs got a small performance gain by `sizehint`ing dictionaries, avoiding
+   excessive rehashing (#1342)
+
 ## [v1.4.0] - 2026-04-20
 
 ### Added

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -386,6 +386,17 @@ function __close!(dh::DofHandler{dim}) where {dim}
     # A face is uniquely determined by 3 vertex nodes, see sortface
     facedicts = [Dict{NTuple{3, Int}, Int}() for _ in 1:numfields]
 
+    # The edge/face dicts above are shared between all SubDofHandlers that contain a given
+    # field, so `field_ncells[gidx]` counts the total number of cells carrying field `gidx`.
+    # This is used to reserve the dict capacity up front (see `_close_subdofhandler!`).
+    field_ncells = zeros(Int, numfields)
+    for sdh in dh.subdofhandlers
+        n = length(sdh.cellset)
+        for name in sdh.field_names
+            field_ncells[findfirst(==(name), dh.field_names)::Int] += n
+        end
+    end
+
     # Set initial values
     nextdof = 1  # next free dof to distribute
 
@@ -399,9 +410,10 @@ function __close!(dh::DofHandler{dim}) where {dim}
             vertexdicts,
             edgedicts,
             facedicts,
+            field_ncells,
         )
     end
-    dh.ndofs = maximum(dh.cell_dofs; init = 0)
+    dh.ndofs = nextdof - 1
     dh.closed = true
 
     return dh, vertexdicts, edgedicts, facedicts
@@ -413,7 +425,7 @@ end
 
 Main entry point to distribute dofs for a single [`SubDofHandler`](@ref) on its subdomain.
 """
-function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts) where {sdim}
+function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_index::Int, nextdof::Int, vertexdicts, edgedicts, facedicts, field_ncells) where {sdim}
     ip_infos = InterpolationInfo[]
     for interpolation in sdh.field_interpolations
         ip_info = InterpolationInfo(interpolation)
@@ -459,6 +471,29 @@ function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_ind
     # Mapping between the local field index and the global field index
     global_fidxs = Int[findfirst(gname -> gname === lname, dh.field_names) for lname in sdh.field_names]
 
+    # Reserve capacity in the edge/face dicts up front to avoid repeatedly rehashing them
+    # while dofs are distributed. The number of unique edges/faces is within a small factor
+    # of the number of cells carrying the field (`field_ncells`, which spans all the
+    # SubDofHandlers sharing the dict). Edges (and faces in 3D) are shared between
+    # neighbouring cells, so the unique count is a couple of times the cell count; a 2D cell
+    # owns a single unshared face, so there the face dict reaches exactly the cell count.
+    # These hints are chosen to land in the same power-of-two bucket the dict reaches anyway
+    # (so no extra memory is reserved in the common cases), while skipping the intermediate
+    # rehashes during distribution. We only size a dict the first time it is touched (while
+    # still empty) so that a second SubDofHandler does not re-hint — and possibly shrink — a
+    # dict that another SubDofHandler already filled.
+    ncells = length(sdh.cellset)
+    for (lidx, gidx) in pairs(global_fidxs)
+        info = ip_infos[lidx]
+        ncf = field_ncells[gidx]
+        if any(>(0), info.nedgedofs) && isempty(edgedicts[gidx])
+            sizehint!(edgedicts[gidx], 2 * ncf)
+        end
+        if any(>(0), info.nfacedofs) && isempty(facedicts[gidx])
+            sizehint!(facedicts[gidx], info.reference_dim == 3 ? 2 * ncf : ncf)
+        end
+    end
+
     # loop over all the cells, and distribute dofs for all the fields
     for ci in sdh.cellset
         @debug println("Creating dofs for cell #$ci")
@@ -489,6 +524,7 @@ function _close_subdofhandler!(dh::DofHandler{sdim}, sdh::SubDofHandler, sdh_ind
             ndofs_per_cell = length(dh.cell_dofs) - len_cell_dofs_start
             sdh.ndofs_per_cell = ndofs_per_cell
             first_cell = false
+            sizehint!(dh.cell_dofs, len_cell_dofs_start + ndofs_per_cell * ncells)
         else
             @assert ndofs_per_cell == length(dh.cell_dofs) - len_cell_dofs_start
         end


### PR DESCRIPTION
Done together with Claude code 🤖 . For the benchmark:

```julia
using Ferrite
using BenchmarkTools
using Printf

# Build a fresh (unclosed) DofHandler for a given grid + list of (name, ip) fields.
function build_dh(grid, fields)
    dh = DofHandler(grid)
    for (name, ip) in fields
        add!(dh, name, ip)
    end
    return dh
end

# Build a fresh DofHandler with two subdomains (two SubDofHandlers).
function build_dh_sub(grid, ip_a, ip_b)
    dh = DofHandler(grid)
    nc = getncells(grid)
    half = nc ÷ 2
    sdh1 = SubDofHandler(dh, collect(1:half))
    add!(sdh1, :u, ip_a)
    sdh2 = SubDofHandler(dh, collect((half + 1):nc))
    add!(sdh2, :u, ip_b)
    return dh
end

const CASES = Tuple{String, Function}[]

# ---- 3D Hexahedron (heavy edge + face dict usage) ----
let grid = generate_grid(Hexahedron, (30, 30, 30))   # 27_000 cells
    push!(CASES, ("Hex30 Lagrange{1} vec(3)", () -> build_dh(grid, [(:u, Lagrange{RefHexahedron, 1}()^3)])))
    push!(CASES, ("Hex30 Lagrange{2} vec(3)", () -> build_dh(grid, [(:u, Lagrange{RefHexahedron, 2}()^3)])))
    push!(CASES, ("Hex30 two-field u2/p1", () -> build_dh(grid, [(:u, Lagrange{RefHexahedron, 2}()^3), (:p, Lagrange{RefHexahedron, 1}())])))
end

# ---- 3D Tetrahedron ----
let grid = generate_grid(Tetrahedron, (24, 24, 24))   # ~ 5*24^3 cells
    push!(CASES, ("Tet24 Lagrange{1} vec(3)", () -> build_dh(grid, [(:u, Lagrange{RefTetrahedron, 1}()^3)])))
    push!(CASES, ("Tet24 Lagrange{2} vec(3)", () -> build_dh(grid, [(:u, Lagrange{RefTetrahedron, 2}()^3)])))
end

# ---- 2D Quadrilateral (large) ----
let grid = generate_grid(Quadrilateral, (300, 300))   # 90_000 cells
    push!(CASES, ("Quad300 Lagrange{2} vec(2)", () -> build_dh(grid, [(:u, Lagrange{RefQuadrilateral, 2}()^2)])))
end

# ---- Subdomains ----
let grid = generate_grid(Hexahedron, (30, 30, 30))
    push!(CASES, ("Hex30 subdomains u2/u2", () -> build_dh_sub(grid, Lagrange{RefHexahedron, 2}()^3, Lagrange{RefHexahedron, 2}()^3)))
end

function run_bench()
    for (name, builder) in CASES
        dh0 = builder()
        close!(dh0)
        print(rpad(name, 30), " (ndofs=", ndofs(dh0), "): ")
        @btime close!(dh) setup = (dh = ($builder)()) evals = 1
    end
    return
end

run_bench()
```

```
Before:
Hex30 Lagrange{1} vec(3)       (ndofs=89373):   1.226 ms (105 allocations: 17.14 MiB)
Hex30 Lagrange{2} vec(3)       (ndofs=680943):   10.203 ms (240 allocations: 68.46 MiB)
Hex30 two-field u2/p1          (ndofs=710734):   11.380 ms (306 allocations: 68.70 MiB)
Tet24 Lagrange{1} vec(3)       (ndofs=46875):   2.771 ms (79 allocations: 28.52 MiB)
Tet24 Lagrange{2} vec(3)       (ndofs=352947):   10.935 ms (141 allocations: 89.09 MiB)
Quad300 Lagrange{2} vec(2)     (ndofs=722402):   12.410 ms (177 allocations: 81.46 MiB)
Hex30 subdomains u2/u2         (ndofs=680943):   10.275 ms (356 allocations: 68.47 MiB)

After:
Hex30 Lagrange{1} vec(3)       (ndofs=89373):   1.050 ms (84 allocations: 5.19 MiB)
Hex30 Lagrange{2} vec(3)       (ndofs=680943):   8.848 ms (148 allocations: 26.13 MiB)
Hex30 two-field u2/p1          (ndofs=710734):   9.953 ms (214 allocations: 28.02 MiB)
Tet24 Lagrange{1} vec(3)       (ndofs=46875):   2.366 ms (56 allocations: 7.72 MiB)
Tet24 Lagrange{2} vec(3)       (ndofs=352947):   8.574 ms (80 allocations: 26.32 MiB)
Quad300 Lagrange{2} vec(2)     (ndofs=722402):   7.568 ms (78 allocations: 40.69 MiB)
Hex30 subdomains u2/u2         (ndofs=680943):   9.358 ms (268 allocations: 57.79 MiB)
```

I don't actually know if the dof distribution is a bottleneck anywhere anymore, but https://github.com/Ferrite-FEM/Ferrite.jl/issues/632 still lives in my mind...