### PR TITLE
tutorials/stokes-flow: fix typo related to sine vs cosine in mesh transformation matrix section

### DIFF
--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -192,9 +192,10 @@ function setup_grid(h = 0.05)
     ## see https://en.wikipedia.org/wiki/Transformation_matrix#Affine_transformations
     transformation_matrix = zeros(4, 4)
     transformation_matrix[1, 2] = 1  # -sin(-pi/2)
-    transformation_matrix[2, 1] = -1 #  cos(-pi/2)
-    transformation_matrix[3, 3] = 1
-    transformation_matrix[4, 4] = 1
+    transformation_matrix[2, 1] = -1 #  sin(-pi/2)
+    # cos(-pi/2) = 0, so we omit setting rest of the upper left block here.
+    transformation_matrix[3, 3] = 1 # translation ?
+    transformation_matrix[4, 4] = 1 # translation
     transformation_matrix = vec(transformation_matrix')
     gmsh.model.mesh.set_periodic(1, [l1], [l3], transformation_matrix)
 


### PR DESCRIPTION
Note that there is still one question mark related to the index (3,3) related to the transformation matrix. What is its meaning? If the current interpretation is wrong, it can be fixed in another commit to this PR.

Fixes https://github.com/Ferrite-FEM/Ferrite.jl/issues/1357.