### PR TITLE
docs: fix Stokes flow transform comments

### DIFF
--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -191,8 +191,10 @@ function setup_grid(h = 0.05)
     ## Add the periodicity constraint using 4x4 affine transformation matrix,
     ## see https://en.wikipedia.org/wiki/Transformation_matrix#Affine_transformations
     transformation_matrix = zeros(4, 4)
-    transformation_matrix[1, 2] = 1  # -sin(-pi/2)
-    transformation_matrix[2, 1] = -1 #  cos(-pi/2)
+    transformation_matrix[1, 1] = 0   # cos(-pi/2)
+    transformation_matrix[1, 2] = 1   # -sin(-pi/2)
+    transformation_matrix[2, 1] = -1  # sin(-pi/2)
+    transformation_matrix[2, 2] = 0   # cos(-pi/2)
     transformation_matrix[3, 3] = 1
     transformation_matrix[4, 4] = 1
     transformation_matrix = vec(transformation_matrix')


### PR DESCRIPTION
## Summary\n- correct the sine/cosine annotation for the Stokes flow transformation matrix\n- explicitly annotate the zero cosine entries for symmetry, as suggested in the issue\n\n## Checks\n- git diff --check\n\nCloses #1357