### PR TITLE
Refactor evaluate_at_grid_nodes for L2Projector

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -943,7 +943,7 @@ function_value_init(::ScalarInterpolation, ::AbstractVector{T}) where {T} = zero
 function_value_init(::VectorInterpolation{vdim}, ::AbstractVector{T}) where {vdim, T <: Number} = zero(Vec{vdim, T})
 
 # Internal method that have the vtk option to allocate the output differently
-function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fieldname::Symbol, ::Val{vtk} = Val(false)) where {T, vtk, sdim}
+function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{S}, fieldname::Symbol, ::Val{vtk} = Val(false)) where {order, sdim, dim, T<:Number, M, S <: Union{T, Tensor{order, dim, T, M}, SymmetricTensor{order, dim, T, M}}, vtk}
     # Make sure the field exists
     fieldname ∈ getfieldnames(dh) || error("Field $fieldname not found.")
     # Figure out the return type (scalar or vector)
@@ -952,13 +952,18 @@ function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{T}, fie
     if vtk
         # VTK output of solution field (or L2 projected scalar data)
         n_c = n_components(ip)
-        vtk_dim = n_c == 2 ? 3 : n_c # VTK wants vectors padded to 3D
+        vtk_dim = if S <: Number
+            n_c == 2 ? 3 : n_c # VTK wants vectors padded to 3D
+        else
+            @assert n_c == 1
+            S <: Vec{2} ? 3 : M # Pad 2D Vec to 3D
+        end
         # Float32 is the smallest float type supported by VTK
         TT = promote_type(T, Float32)
         data = fill!(Matrix{TT}(undef, vtk_dim, getnnodes(get_grid(dh))), NaN)
     else
         # Just evaluation at grid nodes
-        RT = typeof(function_value_init(ip, u))
+        RT = S <: Number ? typeof(function_value_init(ip, u)) : S
         data = fill(T(NaN) * zero(RT), getnnodes(get_grid(dh)))
     end
     # Loop over the subdofhandlers
@@ -993,10 +998,14 @@ function _evaluate_at_grid_nodes!(
             ue[i] = u[cell.dofs[I]]
         end
         for (qp, nodeid) in pairs(cell.nodes)
-            val = function_value(cv, qp, ue)
+            val = zero(T)
+            for i in 1:getnbasefunctions(cv)
+                val += shape_value(cv, qp, i) * ue[i]
+            end
             if data isa Matrix # VTK
-                data[1:length(val), nodeid] .= val
-                data[(length(val) + 1):end, nodeid] .= 0 # purge the NaN
+                dataview = @view data[:, nodeid]
+                fill!(dataview, 0) # purge the NaN
+                toparaview!(dataview, val)
             else
                 data[nodeid] = val
             end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -943,7 +943,7 @@ function_value_init(::ScalarInterpolation, ::AbstractVector{T}) where {T} = zero
 function_value_init(::VectorInterpolation{vdim}, ::AbstractVector{T}) where {vdim, T <: Number} = zero(Vec{vdim, T})
 
 # Internal method that have the vtk option to allocate the output differently
-function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{S}, fieldname::Symbol, ::Val{vtk} = Val(false)) where {order, sdim, dim, T<:Number, M, S <: Union{T, Tensor{order, dim, T, M}, SymmetricTensor{order, dim, T, M}}, vtk}
+function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{S}, fieldname::Symbol, ::Val{vtk} = Val(false)) where {order, sdim, dim, T <: Number, M, S <: Union{T, Tensor{order, dim, T, M}, SymmetricTensor{order, dim, T, M}}, vtk}
     # Make sure the field exists
     fieldname ∈ getfieldnames(dh) || error("Field $fieldname not found.")
     # Figure out the return type (scalar or vector)
@@ -955,7 +955,7 @@ function _evaluate_at_grid_nodes(dh::DofHandler{sdim}, u::AbstractVector{S}, fie
         vtk_dim = if S <: Number
             n_c == 2 ? 3 : n_c # VTK wants vectors padded to 3D
         else
-            @assert n_c == 1
+            @assert n_c == 1 # L2Projector always stores scalar field
             S <: Vec{2} ? 3 : M # Pad 2D Vec to 3D
         end
         # Float32 is the smallest float type supported by VTK

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -149,7 +149,7 @@ function create_vtk_grid(filename::AbstractString, grid::AbstractGrid, write_dis
     return WriteVTK.vtk_grid(filename, coords, cls; kwargs...), cellnodes, node_mapping
 end
 
-function toparaview!(v, x::Number) 
+function toparaview!(v, x::Number)
     v[1] = x
     return v
 end

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -149,6 +149,10 @@ function create_vtk_grid(filename::AbstractString, grid::AbstractGrid, write_dis
     return WriteVTK.vtk_grid(filename, coords, cls; kwargs...), cellnodes, node_mapping
 end
 
+function toparaview!(v, x::Number) 
+    v[1] = x
+    return v
+end
 function toparaview!(v, x::Vec{D}) where {D}
     v[1:D] .= x
     return v
@@ -228,7 +232,7 @@ function write_projection(vtk::VTKGridFile, proj::L2Projector, vals, name)
     if write_discontinuous(vtk)
         data = evaluate_at_discontinuous_vtkgrid_nodes(proj.dh, vals, only(getfieldnames(proj.dh)), vtk.cellnodes)
     else
-        data = _evaluate_at_grid_nodes(proj, vals, #=vtk=# Val(true))::Matrix
+        data = evaluate_at_grid_nodes(proj, vals, Val(true))::Matrix
         @assert size(data, 2) == getnnodes(get_grid(proj.dh))
     end
 

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -332,62 +332,6 @@ function assemble_proj_rhs!(f::Matrix, cellvalues::CellValues, sdh::SubDofHandle
     return
 end
 
-evaluate_at_grid_nodes(proj::L2Projector, vals::AbstractVector) =
-    _evaluate_at_grid_nodes(proj, vals, Val(false))
-
 # Numbers can be handled by the method for DofHandler
-_evaluate_at_grid_nodes(proj::L2Projector, vals::AbstractVector{<:Number}, vtk) =
+evaluate_at_grid_nodes(proj::L2Projector, vals::AbstractVector, vtk = Val(false)) =
     _evaluate_at_grid_nodes(proj.dh, vals, only(getfieldnames(proj.dh)), vtk)
-
-# Deal with projected tensors
-function _evaluate_at_grid_nodes(
-        proj::L2Projector, vals::AbstractVector{S}, ::Val{vtk}
-    ) where {order, dim, T, M, S <: Union{Tensor{order, dim, T, M}, SymmetricTensor{order, dim, T, M}}, vtk}
-    dh = proj.dh
-    # The internal dofhandler in the projector is a scalar field, but the values in vals
-    # can be any tensor field, however, the number of dofs should always match the length of vals
-    @assert ndofs(dh) == length(vals)
-    if vtk
-        nout = S <: Vec{2} ? 3 : M # Pad 2D Vec to 3D
-        data = fill(T(NaN), nout, getnnodes(get_grid(dh)))
-    else
-        data = fill(T(NaN) * zero(S), getnnodes(get_grid(dh)))
-    end
-    for sdh in dh.subdofhandlers
-        ip = only(sdh.field_interpolations)
-        gip = geometric_interpolation(getcelltype(sdh))
-        RefShape = getrefshape(ip)
-        local_node_coords = reference_coordinates(gip)
-        qr = QuadratureRule{RefShape}(zeros(length(local_node_coords)), local_node_coords)
-        cv = CellValues(qr, ip, gip; update_detJdV = false, update_gradients = false)
-        _evaluate_at_grid_nodes!(data, cv, sdh, vals)
-    end
-    return data
-end
-
-function _evaluate_at_grid_nodes!(data, cv, sdh, u::AbstractVector{S}) where {S}
-    ue = zeros(S, getnbasefunctions(cv))
-    for cell in CellIterator(sdh)
-        reinit!(cv, cell)
-        @assert getnquadpoints(cv) == length(cell.nodes)
-        for (i, I) in pairs(cell.dofs)
-            ue[i] = u[I]
-        end
-        for (qp, nodeid) in pairs(cell.nodes)
-            # Loop manually over the shape functions since function_value
-            # doesn't like scalar base functions with tensor dofs
-            val = zero(S)
-            for i in 1:getnbasefunctions(cv)
-                val += shape_value(cv, qp, i) * ue[i]
-            end
-            if data isa Matrix # VTK
-                dataview = @view data[:, nodeid]
-                fill!(dataview, 0) # purge the NaN
-                toparaview!(dataview, val)
-            else
-                data[nodeid] = val
-            end
-        end
-    end
-    return data
-end

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -332,6 +332,5 @@ function assemble_proj_rhs!(f::Matrix, cellvalues::CellValues, sdh::SubDofHandle
     return
 end
 
-# Numbers can be handled by the method for DofHandler
 evaluate_at_grid_nodes(proj::L2Projector, vals::AbstractVector, vtk = Val(false)) =
     _evaluate_at_grid_nodes(proj.dh, vals, only(getfieldnames(proj.dh)), vtk)

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -419,12 +419,12 @@ function test_export(; subset::Bool)
         end
         # The following test may fail due to floating point inaccuracies
         # These could occur due to e.g. changes in system architecture.
-        # if Sys.islinux() && Sys.ARCH === :x86_64
-        #     @test bytes2hex(open(SHA.sha1, fname * ".vtu", "r")) == (
-        #         subset ? "b3fef3de9f38ca9ddd92f2f67a1606d07ca56d67" :
-        #             "bc2ec8f648f9b8bccccf172c1fc48bf03340329b"
-        #     )
-        # end
+        if Sys.islinux() && Sys.ARCH === :x86_64
+            @test bytes2hex(open(SHA.sha1, fname * ".vtu", "r")) == (
+                subset ? "b3fef3de9f38ca9ddd92f2f67a1606d07ca56d67" :
+                    "bc2ec8f648f9b8bccccf172c1fc48bf03340329b"
+            )
+        end
     end
 
     return

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -365,7 +365,7 @@ function test_export(; subset::Bool)
     nindex = isnan.(fnodes)
     findex = (!isnan).(fnodes)
     let r = evaluate_at_grid_nodes(p, p_scalar),
-            rv = Ferrite._evaluate_at_grid_nodes(p, p_scalar, Val(true))
+            rv = Ferrite.evaluate_at_grid_nodes(p, p_scalar, Val(true))
         @test size(r) == (6,)
         @test all(isnan, r[nindex])
         @test all(isnan, rv[nindex])
@@ -375,7 +375,7 @@ function test_export(; subset::Bool)
         @test r[findex] == vec(rv)[findex]
     end
     let r = evaluate_at_grid_nodes(p, p_vec),
-            rv = Ferrite._evaluate_at_grid_nodes(p, p_vec, Val(true))
+            rv = Ferrite.evaluate_at_grid_nodes(p, p_vec, Val(true))
         @test size(r) == (6,)
         @test getindex.(r[findex], 1) ≈ fnodes[findex]
         @test getindex.(r[findex], 2) ≈ 2fnodes[findex]
@@ -385,7 +385,7 @@ function test_export(; subset::Bool)
         @test all(isnan, rv[:, nindex])
     end
     let r = evaluate_at_grid_nodes(p, p_tens),
-            rv = Ferrite._evaluate_at_grid_nodes(p, p_tens, Val(true))
+            rv = Ferrite.evaluate_at_grid_nodes(p, p_tens, Val(true))
         @test size(r) == (6,)
         @test getindex.(r[findex], 1) ≈ fnodes[findex] # 11-components
         @test getindex.(r[findex], 2) ≈ 2fnodes[findex] # 12-components
@@ -397,7 +397,7 @@ function test_export(; subset::Bool)
         @test all(isnan, rv[:, nindex])
     end
     let r = evaluate_at_grid_nodes(p, p_stens),
-            rv = Ferrite._evaluate_at_grid_nodes(p, p_stens, Val(true))
+            rv = Ferrite.evaluate_at_grid_nodes(p, p_stens, Val(true))
         @test size(r) == (6,)
         @test getindex.(r[findex], 1) ≈ fnodes[findex] # 11-components
         @test getindex.(r[findex], 2) ≈ 2fnodes[findex] # 21-components
@@ -419,12 +419,12 @@ function test_export(; subset::Bool)
         end
         # The following test may fail due to floating point inaccuracies
         # These could occur due to e.g. changes in system architecture.
-        if Sys.islinux() && Sys.ARCH === :x86_64
-            @test bytes2hex(open(SHA.sha1, fname * ".vtu", "r")) == (
-                subset ? "b3fef3de9f38ca9ddd92f2f67a1606d07ca56d67" :
-                    "bc2ec8f648f9b8bccccf172c1fc48bf03340329b"
-            )
-        end
+        # if Sys.islinux() && Sys.ARCH === :x86_64
+        #     @test bytes2hex(open(SHA.sha1, fname * ".vtu", "r")) == (
+        #         subset ? "b3fef3de9f38ca9ddd92f2f67a1606d07ca56d67" :
+        #             "bc2ec8f648f9b8bccccf172c1fc48bf03340329b"
+        #     )
+        # end
     end
 
     return


### PR DESCRIPTION
I noticed that there were a lot of overlap between the DofHandler and L2Projector's evaluate_at_grid_nodes, so I combined them.