### PR TITLE
Make externally defined interpolations work easier with ConstraintHandler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next] - xxxx-xx-xx
 
+### Fixes
+ - Make default `edgedof_indices` and `facedof_indices` implementation work for externally defined interpolations ([#1365])
+
 ### Documentation
 
 - Landau example in code gallery now shows how to use DifferentiationInterface and HyperHessians as a backend. (#1345)

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -143,12 +143,7 @@ following the same convention, matching how we defined it above,
 ```@example InterpolationExample
 Ferrite.edgedof_interior_indices(::QTI) = ((4,), (5,), (6,))
 compare_test(Ferrite.edgedof_interior_indices) # hide
-Ferrite.edgedof_indices(::QTI) = ((1, 2, 4,), (2, 3, 5,), (3, 1, 6,))
-compare_test(Ferrite.edgedof_indices) # hide
 ```
-But here we need two functions, one for the `interior` indices (those that
-have not yet been included in lower-dimensional entities (vertices in this
-case)), and one for all indices for dofs that belong to the edge.
 
 For the triangle, we only have a single face. However, all the dofs that
 belong to the face, also belongs to either the vertices or edges,
@@ -156,8 +151,6 @@ hence we have no "interior" face dofs. So we get,
 ```@example InterpolationExample
 Ferrite.facedof_interior_indices(::QTI) = ((),)
 compare_test(Ferrite.facedof_interior_indices) # hide
-Ferrite.facedof_indices(::QTI) = ((1, 2, 3, 4, 5, 6),)
-compare_test(Ferrite.facedof_indices) # hide
 ```
 
 Finally, since this is a 2d element, we have no `volumedofs`, and thus

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -209,5 +209,13 @@ N_qti, N_lag = shape_value.((cv_qti, cv_lag), 1, 1)         # hide
 @test N_qti ≈ N_lag                                         # hide
 dNdx_qti, dNdx_lag = shape_gradient.((cv_qti, cv_lag), 1, 1)# hide
 @test dNdx_qti ≈ dNdx_lag                                   # hide
+dbc = Dirichlet(:u, getfacetset(grid, "left"), x->x[2])     # hide
+ch_qti = close!(add!(ConstraintHandler(dh_qti), dbc))       # hide
+ch_lag = close!(add!(ConstraintHandler(dh_lag), dbc))       # hide
+a_qti = zeros(ndofs(dh_qti))                                # hide
+a_lag = zeros(ndofs(dh_lag))                                # hide
+apply!(a_qti, ch_qti)                                       # hide
+apply!(a_lag, ch_lag)                                       # hide
+@test a_qti ≈ a_lag                                         # hide
 nothing                                                     # hide
 ```

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -143,6 +143,7 @@ following the same convention, matching how we defined it above,
 ```@example InterpolationExample
 Ferrite.edgedof_interior_indices(::QTI) = ((4,), (5,), (6,))
 compare_test(Ferrite.edgedof_interior_indices) # hide
+compare_test(Ferrite.edgedof_indices)          # hide
 ```
 
 For the triangle, we only have a single face. However, all the dofs that
@@ -157,6 +158,7 @@ Finally, since this is a 2d element, we have no `volumedofs`, and thus
 ```@example InterpolationExample
 Ferrite.volumedof_interior_indices(::QTI) = ()
 compare_test(Ferrite.volumedof_interior_indices)            # hide
+compare_test(Ferrite.facedof_indices)                       # hide
 ```
 
 It is necessary to tell Ferrite the total number of base functions, e.g.,

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -442,8 +442,8 @@ Tuple containing the dof indices associated with the interior of a volume.
 volumedof_interior_indices(::Interpolation) = ()
 
 # Some helpers to skip boilerplate
-edgedof_interior_indices(ip::Interpolation) = ntuple(_ -> (), nedges(ip))
-facedof_interior_indices(ip::Interpolation) = ntuple(_ -> (), nfaces(ip))
+edgedof_interior_indices(ip::Interpolation) = ntuple(_ -> (), Val(nedges(ip)))
+facedof_interior_indices(ip::Interpolation) = ntuple(_ -> (), Val(nfaces(ip)))
 
 """
     boundarydof_indices(::Type{<:BoundaryIndex})

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -323,6 +323,12 @@ Used internally in [`ConstraintHandler`](@ref) and defaults to [`vertexdof_indic
 """
 dirichlet_vertexdof_indices(ip::Interpolation) = vertexdof_indices(ip)
 
+# We need to have this defined outside the `@generated` function, otherwise it is
+# not compatible with defining new interpolation types in a later world-age,
+# since this creates a new function that didn't exist when the `@generated` function
+# was first defined.
+_create_ip_from_type(::Type{IP}) where {IP <: Interpolation} = IP()
+
 """
     edgedof_indices(ip::Interpolation)
 
@@ -334,7 +340,7 @@ The dofs are guaranteed to be aligned with the local ordering of the entities on
 Here the first entries are the vertex dofs, followed by the edge interior dofs.
 """
 @generated function edgedof_indices(IP::Interpolation{RefShape}) where {RefShape}
-    ip = IP() # we get IP as the type of interpolation
+    ip = _create_ip_from_type(IP)
     vdofs = vertexdof_indices(ip)
     edofs = edgedof_interior_indices(ip)
     expr = Expr(:tuple)
@@ -384,7 +390,7 @@ enumeration on a cell defined by [`faces(::Cell)`](@ref). The face enumeration m
 the face enumeration of the corresponding geometrical cell.
 """
 @generated function facedof_indices(IP::Interpolation{RefShape}) where {RefShape}
-    ip = IP() # we get IP as the type of interpolation
+    ip = _create_ip_from_type(IP)
     vdofs = vertexdof_indices(ip)
     edofs = edgedof_interior_indices(ip)
     fdofs = facedof_interior_indices(ip)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -323,12 +323,6 @@ Used internally in [`ConstraintHandler`](@ref) and defaults to [`vertexdof_indic
 """
 dirichlet_vertexdof_indices(ip::Interpolation) = vertexdof_indices(ip)
 
-# We need to have this defined outside the `@generated` function, otherwise it is
-# not compatible with defining new interpolation types in a later world-age,
-# since this creates a new function that didn't exist when the `@generated` function
-# was first defined.
-_create_ip_from_type(::Type{IP}) where {IP <: Interpolation} = IP()
-
 """
     edgedof_indices(ip::Interpolation)
 
@@ -339,20 +333,22 @@ enumeration of the corresponding geometrical cell.
 The dofs are guaranteed to be aligned with the local ordering of the entities on the oriented edge.
 Here the first entries are the vertex dofs, followed by the edge interior dofs.
 """
-@generated function edgedof_indices(IP::Interpolation{RefShape}) where {RefShape}
-    ip = _create_ip_from_type(IP)
-    vdofs = vertexdof_indices(ip)
-    edofs = edgedof_interior_indices(ip)
+@generated function edgedof_indices(ip::Interpolation{RefShape}) where {RefShape}
     expr = Expr(:tuple)
-    for (i, edge) in enumerate(reference_edges(RefShape))
-        expr_i = Expr(:tuple)
+    for (edgenr, edge) in enumerate(reference_edges(RefShape))
+        expr_edge = Expr(:tuple)
         for vertexnr in edge
-            foreach(vdof -> push!(expr_i.args, vdof), vdofs[vertexnr])
+            push!(expr_edge.args, :(vdofs[$vertexnr]...))
         end
-        foreach(edof -> push!(expr_i.args, edof), edofs[i])
-        push!(expr.args, expr_i)
+        push!(expr_edge.args, :(edofs[$edgenr]...))
+        push!(expr.args, expr_edge)
     end
-    return :(return $expr)
+
+    return quote
+        vdofs = vertexdof_indices(ip)
+        edofs = edgedof_interior_indices(ip)
+        return $expr
+    end
 end
 
 """
@@ -390,23 +386,24 @@ enumeration on a cell defined by [`faces(::Cell)`](@ref). The face enumeration m
 the face enumeration of the corresponding geometrical cell.
 """
 @generated function facedof_indices(IP::Interpolation{RefShape}) where {RefShape}
-    ip = _create_ip_from_type(IP)
-    vdofs = vertexdof_indices(ip)
-    edofs = edgedof_interior_indices(ip)
-    fdofs = facedof_interior_indices(ip)
     expr = Expr(:tuple)
-    for (i, face) in enumerate(reference_faces(RefShape))
-        expr_i = Expr(:tuple)
+    for (facenr, face) in enumerate(reference_faces(RefShape))
+        expr_facenr = Expr(:tuple)
         for vertexnr in face
-            foreach(vdof -> push!(expr_i.args, vdof), vdofs[vertexnr])
+            push!(expr_facenr.args, :(vdofs[$vertexnr]...))
         end
-        for edgenr in reference_face_edgenrs(RefShape)[i]
-            foreach(edof -> push!(expr_i.args, edof), edofs[edgenr])
+        for edgenr in reference_face_edgenrs(RefShape)[facenr]
+            push!(expr_facenr.args, :(edofs[$edgenr]...))
         end
-        foreach(fdof -> push!(expr_i.args, fdof), fdofs[i])
-        push!(expr.args, expr_i)
+        push!(expr_facenr.args, :(fdofs[$facenr]...))
+        push!(expr.args, expr_facenr)
     end
-    return :(return $expr)
+    return quote
+        vdofs = vertexdof_indices(ip)
+        edofs = edgedof_interior_indices(ip)
+        fdofs = facedof_interior_indices(ip)
+        return $expr
+    end
 end
 
 """

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -385,7 +385,7 @@ A tuple containing tuples of all local dof indices for the respective face in lo
 enumeration on a cell defined by [`faces(::Cell)`](@ref). The face enumeration must match
 the face enumeration of the corresponding geometrical cell.
 """
-@generated function facedof_indices(IP::Interpolation{RefShape}) where {RefShape}
+@generated function facedof_indices(ip::Interpolation{RefShape}) where {RefShape}
     expr = Expr(:tuple)
     for (facenr, face) in enumerate(reference_faces(RefShape))
         expr_facenr = Expr(:tuple)


### PR DESCRIPTION
This PR makes the default `@generated` `edgedof_indices` and `facedof_indices` work also for inteprolations defined in a later world age than `using Ferrite`.
