### PR TITLE
Fix Stokes flow rotation comment

### DIFF
--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -191,8 +191,9 @@ function setup_grid(h = 0.05)
     ## Add the periodicity constraint using 4x4 affine transformation matrix,
     ## see https://en.wikipedia.org/wiki/Transformation_matrix#Affine_transformations
     transformation_matrix = zeros(4, 4)
+    ## In the 2D rotation block, cos(-pi/2) gives the zero diagonal entries.
     transformation_matrix[1, 2] = 1  # -sin(-pi/2)
-    transformation_matrix[2, 1] = -1 #  cos(-pi/2)
+    transformation_matrix[2, 1] = -1 #  sin(-pi/2)
     transformation_matrix[3, 3] = 1
     transformation_matrix[4, 4] = 1
     transformation_matrix = vec(transformation_matrix')


### PR DESCRIPTION
## Summary
- correct the Stokes flow tutorial rotation-matrix comment for the `sin(-pi/2)` entry
- note that `cos(-pi/2)` corresponds to the zero diagonal entries in the 2D rotation block

Fixes #1357.

## Verification
- `git diff --check HEAD^ HEAD`
- Confirmed the issue discussion: maintainer noted the `-1` entry should be annotated as `sin`, and suggested annotating the zero cosine entries for symmetry.
- Duplicate checks before PR creation returned no open PRs for issue #1357 or this branch.

This is a comment-only tutorial source change; I did not run the full documentation build.