### PR TITLE
Correct formula for d^2 N / dx^2 in docs

### DIFF
--- a/docs/src/topics/FEValues.md
+++ b/docs/src/topics/FEValues.md
@@ -47,7 +47,7 @@ Second order gradients of the shape functions are computed as
 
 ```math
 \begin{align*}
-    \mathrm{grad}(\mathrm{grad}(N(\boldsymbol{x}))) = \frac{\mathrm{d}^2 N}{\mathrm{d}\boldsymbol{x}^2} = \boldsymbol{J}^{-T} \cdot \frac{\mathrm{d}^2\hat{N}}{\mathrm{d}\boldsymbol{\xi}^2} \cdot \boldsymbol{J}^{-1} -  \boldsymbol{J}^{-T} \cdot\mathrm{grad}(N) \cdot \boldsymbol{\mathcal{H}}  \cdot \boldsymbol{J}^{-1}
+    \mathrm{grad}(\mathrm{grad}(N(\boldsymbol{x}))) = \frac{\mathrm{d}^2 N}{\mathrm{d}\boldsymbol{x}^2} = \boldsymbol{J}^{-T} \cdot \left[\frac{\mathrm{d}^2\hat{N}}{\mathrm{d}\boldsymbol{\xi}^2} -  \mathrm{grad}(N) \cdot \boldsymbol{\mathcal{H}} \right]  \cdot \boldsymbol{J}^{-1}
 \end{align*}
 ```
 !!! details "Derivation"


### PR DESCRIPTION
Detected by @KristofferC's bot:

The identity-mapping second-derivative is typeset as

d²N/dx² = J⁻ᵀ · d²N̂/dξ² · J⁻¹ − J⁻ᵀ · dN/dx · H · J⁻¹

Read left-to-right, J⁻ᵀ · dN/dx contracts first, producing (dN/dx)ₖ (J⁻¹)ₖₗ H₍ₗₘₙ₎ (J⁻¹)ₙⱼ — which has the wrong free indices. The correct term is (J⁻ᵀ)ᵢₘ [(dN/dx)ₗ Hₗₘₙ] (J⁻¹)ₙⱼ, i.e. dN/dx · H must bind first.


## Index expression (from doc)
<img width="843" height="431" alt="image" src="https://github.com/user-attachments/assets/c9762de6-43ee-4dc4-a9b7-d6e57884bc82" />


## Code
https://github.com/Ferrite-FEM/Ferrite.jl/blob/23eccbe12a5687e89d678932d4b28d27dd6230a9/src/FEValues/FunctionValues.jl#L202-L206

## Old type-set equation
<img width="729" height="93" alt="image" src="https://github.com/user-attachments/assets/390337f3-9c30-406c-a780-fec1d7ff35ed" />

## Fixed type-set equation

<img width="643" height="98" alt="image" src="https://github.com/user-attachments/assets/dba291bf-9e90-4ed6-b256-04b207433d5b" />