### PR TITLE
Add VTKHDF export via VTKHDF.jl package extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    updated [howto on multi-threaded
    assembly](https://ferrite-fem.github.io/Ferrite.jl/stable/howto/threaded_assembly/).
    ([#1417])
+ - `VTKHDFGridFile` for exporting to the HDF5-based VTKHDF file format via the
+   new package extension for [VTKHDF.jl](https://github.com/Ferrite-FEM/VTKHDF.jl).
+   A whole simulation can be stored in a single file, with the grid written
+   only once for time series on a fixed mesh. ([#1381])
 
 ### Changed
  - `interface_coupling` in `allocate_matrix`/`add_sparsity_entries!`/`add_interface_entries!`

--- a/Project.toml
+++ b/Project.toml
@@ -18,11 +18,13 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
+VTKHDF = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
 
 [extensions]
 FerriteBlockArrays = "BlockArrays"
 FerriteMetis = "Metis"
 FerriteSparseMatrixCSR = "SparseMatricesCSR"
+FerriteVTKHDF = "VTKHDF"
 
 [compat]
 BlockArrays = "0.16, 1"
@@ -37,6 +39,7 @@ ParallelTestRunner = "2.6"
 Preferences = "1"
 Reexport = "1"
 Tensors = "1.17"
+VTKHDF = "0.1"
 WriteVTK = "1.13"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ ParallelTestRunner = "2.6"
 Preferences = "1"
 Reexport = "1"
 Tensors = "1.17"
-VTKHDF = "0.1"
+VTKHDF = "1"
 WriteVTK = "1.13"
 julia = "1.10"
 
@@ -64,6 +64,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+VTKHDF = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
 
 [targets]
-test = ["BlockArrays", "Downloads", "FerriteGmsh", "ForwardDiff", "Gmsh", "IterativeSolvers", "Metis", "NBInclude", "OhMyThreads", "ParallelTestRunner", "ProgressMeter", "Random", "SHA", "SparseMatricesCSR", "StaticArrays", "TaskLocalValues", "Test", "TimerOutputs", "Logging", "HCubature"]
+test = ["BlockArrays", "Downloads", "FerriteGmsh", "ForwardDiff", "Gmsh", "IterativeSolvers", "Metis", "NBInclude", "OhMyThreads", "ParallelTestRunner", "ProgressMeter", "Random", "SHA", "SparseMatricesCSR", "StaticArrays", "TaskLocalValues", "Test", "TimerOutputs", "Logging", "HCubature", "VTKHDF"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -650,11 +650,13 @@ version = "1.5.0"
     FerriteBlockArrays = "BlockArrays"
     FerriteMetis = "Metis"
     FerriteSparseMatrixCSR = "SparseMatricesCSR"
+    FerriteVTKHDF = "VTKHDF"
 
     [deps.Ferrite.weakdeps]
     BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
     Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
     SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
+    VTKHDF = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
 
 [[deps.FerriteGmsh]]
 deps = ["Ferrite", "Gmsh"]
@@ -881,6 +883,18 @@ version = "1.3.16+0"
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
 uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 version = "1.0.2"
+
+[[deps.HDF5]]
+deps = ["Compat", "HDF5_jll", "Libdl", "MPIPreferences", "Mmap", "Preferences", "Printf", "Random", "Requires", "UUIDs"]
+git-tree-sha1 = "491ea627ac824619f34168e29a0427a9e00e3e40"
+uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+version = "0.17.3"
+
+    [deps.HDF5.extensions]
+    MPIExt = "MPI"
+
+    [deps.HDF5.weakdeps]
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "aws_c_s3_jll", "dlfcn_win32_jll", "libaec_jll", "mpif_jll"]
@@ -2278,6 +2292,14 @@ version = "0.6.0"
     Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
     Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.VTKHDF]]
+deps = ["HDF5", "VTKBase"]
+git-tree-sha1 = "133bed37f81058598a2958d16adec40c15f9d1a3"
+repo-rev = "master"
+repo-url = "https://github.com/Ferrite-FEM/VTKHDF.jl"
+uuid = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
+version = "0.1.0"
 
 [[deps.Vulkan_Loader_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Wayland_jll", "Xorg_libX11_jll", "Xorg_libXrandr_jll", "xkbcommon_jll"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "efc8ea969a3f1659ad6b2e82f89041c4045794dd"
+project_hash = "8bc9f5c0108d82776caf192618c5ffa1b7222253"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -2275,6 +2275,12 @@ git-tree-sha1 = "c2d0db3ef09f1942d08ea455a9e252594be5f3b6"
 uuid = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 version = "1.0.1"
 
+[[deps.VTKHDF]]
+deps = ["HDF5", "VTKBase"]
+git-tree-sha1 = "631f0913cc368feee1323e6f031922b58f4aba6e"
+uuid = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
+version = "1.0.0"
+
 [[deps.VectorInterface]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "949dd28df19a5bf0973214e4a9d36c19079d4d45"
@@ -2292,14 +2298,6 @@ version = "0.6.0"
     Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
     Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-
-[[deps.VTKHDF]]
-deps = ["HDF5", "VTKBase"]
-git-tree-sha1 = "133bed37f81058598a2958d16adec40c15f9d1a3"
-repo-rev = "master"
-repo-url = "https://github.com/Ferrite-FEM/VTKHDF.jl"
-uuid = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
-version = "0.1.0"
 
 [[deps.Vulkan_Loader_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Wayland_jll", "Xorg_libX11_jll", "Xorg_libXrandr_jll", "xkbcommon_jll"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -38,6 +38,3 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 OrdinaryDiffEqRosenbrock = "2"
-
-[sources]
-VTKHDF = {url = "https://github.com/Ferrite-FEM/VTKHDF.jl"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -33,7 +33,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TaskLocalValues = "ed4db957-447d-4319-bfb6-7fa9ae7ecf34"
 Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+VTKHDF = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 OrdinaryDiffEqRosenbrock = "2"
+
+[sources]
+VTKHDF = {url = "https://github.com/Ferrite-FEM/VTKHDF.jl"}

--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -73,7 +73,7 @@
 # ## Implementation
 # We now get to the actual code. First, we import the respective packages
 
-using Ferrite, Tensors, ProgressMeter, WriteVTK
+using Ferrite, Tensors, ProgressMeter, VTKHDF
 using BlockArrays, SparseArrays, LinearAlgebra
 
 # and the corresponding `struct` to store our material properties.
@@ -312,8 +312,8 @@ function solve(interpolation_u, interpolation_p)
     Δt = 0.1
     NEWTON_TOL = 1.0e-8
 
-    pvd = paraview_collection("hyperelasticity_incomp_mixed")
-    for (step, t) in enumerate(0.0:Δt:Tf)
+    vtkhdf = VTKHDFGridFile("hyperelasticity_incomp_mixed.vtkhdf", dh; temporal = true)
+    for t in 0.0:Δt:Tf
         ## Perform Newton iterations
         Ferrite.update!(dbc, t)
         apply!(w, dbc)
@@ -342,12 +342,11 @@ function solve(interpolation_u, interpolation_p)
         end
 
         ## Save the solution fields
-        VTKGridFile("hyperelasticity_incomp_mixed_$step", grid) do vtk
+        write_timestep(vtkhdf, t) do vtk
             write_solution(vtk, dh, w)
-            pvd[t] = vtk
         end
     end
-    vtk_save(pvd)
+    close(vtkhdf)
     vol_def = calculate_volume_deformed_mesh(w, dh, cellvalues)
     print("Deformed volume is $vol_def")
     return vol_def

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -67,7 +67,7 @@
 #md # The full program, without comments, can be found in the next [section](@ref topology_optimization-plain-program).
 #
 # First we load all necessary packages.
-using Ferrite, SparseArrays, LinearAlgebra, Tensors, Printf
+using Ferrite, SparseArrays, LinearAlgebra, Tensors, Printf, VTKHDF
 # Next, we create a simple square grid of the size 2x1. We apply a fixed Dirichlet boundary condition
 # to the left facet set, called `clamped`. On the right facet, we create a small set `traction`, where we
 # will later apply a force in negative y-direction.
@@ -450,6 +450,10 @@ function topopt(ra, ρ, n, filename; output = false)
     NEWTON_TOL = 1.0e-8
     print("\n Starting Newton iterations\n")
 
+    ## When `output = true` the density of every iteration is stored as one time
+    ## step in a single temporal VTKHDF file so the evolution can be animated.
+    vtkhdf = output ? VTKHDFGridFile(string(filename, ".vtkhdf"), grid; temporal = true) : nothing
+
     for it in 1:i_max
         apply_zero!(u, dbc)
         newton_itr = -1
@@ -508,14 +512,13 @@ function topopt(ra, ρ, n, filename; output = false)
 
         ## output during calculation
         if output
-            i = @sprintf("%3.3i", it)
-            filename_it = string(filename, "_", i)
-
-            VTKGridFile(filename_it, grid) do vtk
+            write_timestep(vtkhdf, Float64(it)) do vtk
                 write_cell_data(vtk, χ, "density")
             end
         end
     end
+
+    output && close(vtkhdf)
 
     ## export converged results
     if !output

--- a/docs/src/literate-tutorials/ns_vs_diffeq.jl
+++ b/docs/src/literate-tutorials/ns_vs_diffeq.jl
@@ -120,7 +120,7 @@ nothing                    #hide
 # The full program, without comments, can be found in the next [section](@ref ns_vs_diffeq-plain-program).
 
 # First we load Ferrite and some other packages we need
-using Ferrite, SparseArrays, BlockArrays, LinearAlgebra, WriteVTK
+using Ferrite, SparseArrays, BlockArrays, LinearAlgebra, VTKHDF
 
 # We do not need the complete SciML/DifferentialEquations suite. We load DiffEqBase, which
 # provides most of the ODE infrastructure (which can also handle DAEs in mass matrix form),
@@ -557,8 +557,8 @@ end
 #     At the time of writing this [no Hessenberg index 2 initialization is implemented](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1019).
 #
 # To visualize the result we export the grid and our fields
-# to VTK-files, which can be viewed in [ParaView](https://www.paraview.org/)
-# by utilizing the corresponding pvd file.
+# to a single temporal VTKHDF file, which can be viewed in
+# [ParaView](https://www.paraview.org/).
 timestepper = Rodas5P(autodiff = AutoFiniteDiff(), step_limiter! = ferrite_limiter!);
 # timestepper = ImplicitEuler(nlsolve=NonlinearSolveAlg(OrdinaryDiffEq.NonlinearSolve.NewtonRaphson(autodiff=OrdinaryDiffEq.AutoFiniteDiff()); max_iter=50), step_limiter! = ferrite_limiter!) #src
 #NOTE!   This is left for future reference                                #src
@@ -585,14 +585,13 @@ integrator = init(
 # !!! note "Export of solution"
 #     Exporting interpolated solutions of problems containing mass matrices is currently broken.
 #     Thus, the `intervals` iterator is used. Note that `solve` holds all solutions in the memory.
-pvd = paraview_collection("vortex-street")
-for (step, (u, t)) in enumerate(intervals(integrator))
-    VTKGridFile("vortex-street-$step", dh) do vtk
+vtkhdf = VTKHDFGridFile("vortex-street.vtkhdf", dh; temporal = true)
+for (u, t) in intervals(integrator)
+    write_timestep(vtkhdf, t) do vtk
         write_solution(vtk, dh, u)
-        pvd[t] = vtk
     end
 end
-vtk_save(pvd);
+close(vtkhdf);
 
 
 using Test                                                                      #hide

--- a/docs/src/literate-tutorials/porous_media.jl
+++ b/docs/src/literate-tutorials/porous_media.jl
@@ -98,7 +98,7 @@
 #md # the final [section](@ref porous-media-plain-program)
 #
 # Required packages
-using Ferrite, FerriteMeshParser, Tensors, WriteVTK, Downloads
+using Ferrite, FerriteMeshParser, Tensors, VTKHDF, Downloads
 
 # ### Elasticity
 # We start by defining the elastic material type, containing the elastic stiffness,
@@ -342,8 +342,7 @@ function solve(dh, ch, domains; Δt = 0.025, t_total = 1.0)
     r = zeros(ndofs(dh))
     a = zeros(ndofs(dh))
     a_old = copy(a)
-    pvd = paraview_collection("porous_media")
-    step = 0
+    vtkhdf = VTKHDFGridFile("porous_media.vtkhdf", dh; temporal = true)
     for t in 0:Δt:t_total
         if t > 0
             update!(ch, t)
@@ -355,13 +354,11 @@ function solve(dh, ch, domains; Δt = 0.025, t_total = 1.0)
             a .+= Δa
             copyto!(a_old, a)
         end
-        step += 1
-        VTKGridFile("porous_media_$step", dh) do vtk
+        write_timestep(vtkhdf, t) do vtk
             write_solution(vtk, dh, a)
-            pvd[t] = vtk
         end
     end
-    vtk_save(pvd)
+    close(vtkhdf)
     return a
 end;
 

--- a/docs/src/literate-tutorials/reactive_surface.jl
+++ b/docs/src/literate-tutorials/reactive_surface.jl
@@ -78,7 +78,7 @@ nothing                    #hide
 # First we load Ferrite, and some other packages we need
 
 using Ferrite, FerriteGmsh
-using BlockArrays, SparseArrays, LinearAlgebra, WriteVTK
+using BlockArrays, SparseArrays, LinearAlgebra, VTKHDF
 
 # ### Assembly routines
 # Before we head into the assembly, we define a helper struct to control the dispatches.
@@ -274,11 +274,11 @@ function gray_scott_on_sphere(material::GrayScottMaterial, Δt::Real, T::Real, r
     uₜ₋₁ = ones(ndofs(dh))
     setup_initial_conditions!(uₜ₋₁, cellvalues, dh)
 
-    ## And prepare output for visualization.
-    pvd = paraview_collection("reactive-surface")
-    VTKGridFile("reactive-surface-0", dh) do vtk
+    ## And prepare output for visualization. The whole time series is stored in
+    ## a single temporal VTKHDF file, with the grid written only once.
+    vtkhdf = VTKHDFGridFile("reactive-surface.vtkhdf", dh; temporal = true)
+    write_timestep(vtkhdf, 0.0) do vtk
         write_solution(vtk, dh, uₜ₋₁)
-        pvd[0.0] = vtk
     end
 
     ## This is now the main solve loop.
@@ -299,19 +299,18 @@ function gray_scott_on_sphere(material::GrayScottMaterial, Δt::Real, T::Real, r
             rvₜ[2, i] += Δt * (r₁ * r₂^2 - r₂ * (F + k))
         end
 
-        ## The solution is then stored every 10th step to vtk files for
+        ## The solution is then stored every 10th step to the VTKHDF file for
         ## later visualization purposes.
         if (iₜ % 10) == 0
-            VTKGridFile("reactive-surface-$(iₜ)", dh) do vtk
+            write_timestep(vtkhdf, t) do vtk
                 write_solution(vtk, dh, uₜ)
-                pvd[t] = vtk
             end
         end
 
         ## Finally we rotate the solution to initialize the next timestep.
         uₜ₋₁ .= uₜ
     end
-    vtk_save(pvd)
+    close(vtkhdf)
     return
 end
 

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -58,7 +58,7 @@
 #md # The full program, without comments, can be found in the next [section](@ref transient_heat_equation-plain-program).
 #
 # First we load Ferrite, and some other packages we need.
-using Ferrite, SparseArrays, WriteVTK
+using Ferrite, SparseArrays, VTKHDF
 # We create the same grid as in the heat equation example.
 grid = generate_grid(Quadrilateral, (100, 100));
 
@@ -189,11 +189,13 @@ apply_analytical!(uₙ, dh, :u, x -> (x[1]^2 - 1) * (x[2]^2 - 1) * max_temp);
 # Here, we apply **once** the boundary conditions to the system matrix `A`.
 apply!(A, ch);
 
-# To store the solution, we initialize a paraview collection (.pvd) file,
-pvd = paraview_collection("transient-heat")
-VTKGridFile("transient-heat-0", dh) do vtk
+# To store the solution we open a single temporal VTKHDF file. Unlike the
+# XML-based formats — where every time step is a new `.vtu` file tied together
+# by a `.pvd` collection — the whole time series is stored in one file, and
+# the grid is written only once, no matter how many time steps we save.
+vtkhdf = VTKHDFGridFile("transient-heat.vtkhdf", dh; temporal = true)
+write_timestep(vtkhdf, 0.0) do vtk
     write_solution(vtk, dh, uₙ)
-    pvd[0.0] = vtk
 end
 
 # At this point everything is set up and we can finally approach the time loop.
@@ -209,15 +211,15 @@ for (step, t) in enumerate(Δt:Δt:T)
     #Finally, we can solve the time step and save the solution afterwards.
     u = A \ b
 
-    VTKGridFile("transient-heat-$step", dh) do vtk
+    write_timestep(vtkhdf, t) do vtk
         write_solution(vtk, dh, u)
-        pvd[t] = vtk
     end
     #At the end of the time loop, we set the previous solution to the current one and go to the next time step.
     uₙ .= u
 end
-# In order to use the .pvd file we need to store it to the disk, which is done by:
-vtk_save(pvd);
+# Finally we close the file, after which `transient-heat.vtkhdf` can be opened
+# directly in ParaView:
+close(vtkhdf);
 
 #md # ## [Plain program](@id transient_heat_equation-plain-program)
 #md #

--- a/docs/src/reference/export.md
+++ b/docs/src/reference/export.md
@@ -25,6 +25,7 @@ PointLocation
 ## VTK export
 ```@docs
 VTKGridFile
+VTKHDFGridFile
 write_solution
 write_projection
 write_cell_data

--- a/docs/src/topics/export.md
+++ b/docs/src/topics/export.md
@@ -42,10 +42,37 @@ close(vtk);
 
 The data written by `write_solution`, `write_cell_data`, `write_node_data`, and `write_projection` may be either scalar (`Vector{<:Number}`) or tensor (`Vector{<:AbstractTensor}`) data.
 
-For simulations with multiple time steps, typically one `VTK` (`.vtu`) file is written
-for each time step. In order to connect the actual time with each of these files,
-the `paraview_collection` function from `WriteVTK.jl` can be used. This will create
-one paraview datafile (`.pvd`) file and one `VTKGridFile` (`.vtu`) for each time step.
+For simulations with multiple time steps there are two options.
+
+## Time series with VTKHDF (recommended)
+
+A [`VTKHDFGridFile`](@ref) — the HDF5-based
+[VTKHDF format](https://docs.vtk.org/en/latest/vtk_file_formats/vtkhdf_file_format/index.html) —
+can hold a whole time series in a *single* file, with the grid stored only once,
+no matter how many steps are saved. This requires
+[VTKHDF.jl](https://github.com/Ferrite-FEM/VTKHDF.jl) to be loaded. Open the file
+with `temporal = true` and write each step with `write_timestep`:
+
+```julia
+using VTKHDF
+vtkhdf = VTKHDFGridFile("my_results.vtkhdf", dh; temporal = true)
+for t in range(0, 1, 5)
+    # Do calculations to update u
+    write_timestep(vtkhdf, t) do vtk
+        write_solution(vtk, dh, u)
+    end
+end
+close(vtkhdf);
+```
+The same data functions as above are supported. See
+[Transient heat equation](@ref tutorial-transient-heat-equation) for an example.
+
+## Time series with a Paraview collection (`.pvd`)
+
+Alternatively, with the XML-based formats one `VTK` (`.vtu`) file is written for
+each time step. To connect the actual time with each of these files, the
+`paraview_collection` function from `WriteVTK.jl` can be used. This creates one
+paraview datafile (`.pvd`) and one `VTKGridFile` (`.vtu`) for each time step.
 
 ```@example export
 using WriteVTK
@@ -59,4 +86,3 @@ for (step, t) in enumerate(range(0, 1, 5))
 end
 vtk_save(pvd);
 ```
-See [Transient heat equation](@ref tutorial-transient-heat-equation) for an example

--- a/ext/FerriteVTKHDF.jl
+++ b/ext/FerriteVTKHDF.jl
@@ -74,8 +74,8 @@ function VTKHDF.write_timestep(f::Function, vtk::VTKHDFGridFile, t::Real; kwargs
     return vtk
 end
 
-# ---- node data conversion (mirrors Ferrite's WriteVTK path, minus component
-# names, which the VTKHDF format does not support) ----
+# Node data conversion mirrors the WriteVTK path, minus component names,
+# which the VTKHDF format does not support.
 
 function _node_matrix(nodedata::Vector{S}) where {O, D, T, M, S <: Union{Tensor{O, D, T, M}, SymmetricTensor{O, D, T, M}}}
     noutputs = S <: Vec{2} ? 3 : M # pad 2D Vec to 3D

--- a/ext/FerriteVTKHDF.jl
+++ b/ext/FerriteVTKHDF.jl
@@ -1,0 +1,133 @@
+# Implementation of `Ferrite.VTKHDFGridFile` (see src/Export/VTKHDF.jl), the
+# VTKHDF counterpart of `VTKGridFile`, backed by VTKHDF.jl.
+module FerriteVTKHDF
+
+using Ferrite:
+    Ferrite, VTKHDFGridFile, DofHandler, AbstractDofHandler, AbstractGrid,
+    L2Projector, Vec, Tensor, SymmetricTensor,
+    get_grid, getfieldnames, getnnodes, conformity, H1Conformity
+import Ferrite: write_solution, write_projection, write_cell_data, write_node_data
+using VTKHDF: VTKHDF, vtkhdf_grid, VTKPointData, VTKCellData
+
+function Ferrite.VTKHDFGridFile(filename::String, dh::DofHandler; kwargs...)
+    for sdh in dh.subdofhandlers
+        for ip in sdh.field_interpolations
+            if !isa(conformity(ip), H1Conformity)
+                return VTKHDFGridFile(filename, get_grid(dh); write_discontinuous = true, kwargs...)
+            end
+        end
+    end
+    return VTKHDFGridFile(filename, get_grid(dh); kwargs...)
+end
+
+function Ferrite.VTKHDFGridFile(filename::String, grid::AbstractGrid; write_discontinuous = false, kwargs...)
+    if write_discontinuous
+        coords, cls, cellnodes, node_mapping = Ferrite.create_discontinuous_vtk_griddata(grid)
+    else
+        coords, cls = Ferrite.create_vtk_griddata(grid)
+        cellnodes = node_mapping = nothing
+    end
+    return VTKHDFGridFile(vtkhdf_grid(filename, coords, cls; kwargs...), cellnodes, node_mapping)
+end
+
+# do-block form
+function Ferrite.VTKHDFGridFile(f::Function, args...; kwargs...)
+    vtk = VTKHDFGridFile(args...; kwargs...)
+    try
+        f(vtk)
+    finally
+        close(vtk)
+    end
+    return vtk
+end
+
+hdf(vtk::VTKHDFGridFile) = vtk.vtk
+
+function Base.close(vtk::VTKHDFGridFile)
+    close(hdf(vtk))
+    return vtk
+end
+
+function Base.show(io::IO, ::MIME"text/plain", vtk::VTKHDFGridFile)
+    print(io, "VTKHDFGridFile (", hdf(vtk), ")")
+    return
+end
+
+"""
+    write_timestep(f::Function, vtk::VTKHDFGridFile, t::Real)
+
+Write one time step to a `VTKHDFGridFile` opened with `temporal = true`. The
+grid is stored once and shared by all steps. Inside the do-block the same
+data functions as for static files are used:
+
+```julia
+write_timestep(vtkhdf, t) do vtk
+    write_solution(vtk, dh, u)
+end
+```
+"""
+function VTKHDF.write_timestep(f::Function, vtk::VTKHDFGridFile, t::Real; kwargs...)
+    VTKHDF.write_timestep(_ -> f(vtk), hdf(vtk), t; kwargs...)
+    # flush each step so a hard kill (OOM, scheduler kill, segfault) still
+    # leaves a valid file with all completed steps
+    flush(hdf(vtk))
+    return vtk
+end
+
+# ---- node data conversion (mirrors Ferrite's WriteVTK path, minus component
+# names, which the VTKHDF format does not support) ----
+
+function _node_matrix(nodedata::Vector{S}) where {O, D, T, M, S <: Union{Tensor{O, D, T, M}, SymmetricTensor{O, D, T, M}}}
+    noutputs = S <: Vec{2} ? 3 : M # pad 2D Vec to 3D
+    out = zeros(T, noutputs, length(nodedata))
+    for i in eachindex(nodedata)
+        Ferrite.toparaview!(@view(out[:, i]), nodedata[i])
+    end
+    return out
+end
+
+_write_node_array(vtk::VTKHDFGridFile, data::Vector{<:Ferrite.Tensors.AbstractTensor}, name::AbstractString) =
+    setindex!(hdf(vtk), _node_matrix(data), name, VTKPointData())
+_write_node_array(vtk::VTKHDFGridFile, data::Union{Vector{<:Real}, Matrix{<:Real}}, name::AbstractString) =
+    setindex!(hdf(vtk), data, name, VTKPointData())
+
+function write_solution(vtk::VTKHDFGridFile, dh::AbstractDofHandler, u::AbstractVector, suffix = "")
+    fieldnames = getfieldnames(dh)
+    for name in fieldnames
+        if Ferrite.write_discontinuous(vtk)
+            data = Ferrite.evaluate_at_discontinuous_vtkgrid_nodes(dh, u, name, vtk.cellnodes)
+        else
+            data = Ferrite._evaluate_at_grid_nodes(dh, u, name, #= vtk =# Val(true))
+        end
+        _write_node_array(vtk, data, string(name, suffix))
+    end
+    return vtk
+end
+
+function write_projection(vtk::VTKHDFGridFile, proj::L2Projector, vals, name)
+    if Ferrite.write_discontinuous(vtk)
+        data = Ferrite.evaluate_at_discontinuous_vtkgrid_nodes(proj.dh, vals, only(getfieldnames(proj.dh)), vtk.cellnodes)
+    else
+        data = Ferrite._evaluate_at_grid_nodes(proj, vals, #= vtk =# Val(true))::Matrix
+        @assert size(data, 2) == getnnodes(get_grid(proj.dh))
+    end
+    _write_node_array(vtk, data, name)
+    return vtk
+end
+
+function write_cell_data(vtk::VTKHDFGridFile, celldata, name)
+    setindex!(hdf(vtk), celldata, name, VTKCellData())
+    return vtk
+end
+
+function write_node_data(vtk::VTKHDFGridFile, nodedata, name)
+    if Ferrite.write_discontinuous(vtk)
+        data = Ferrite._map_to_discontinuous_nodes(vtk.node_mapping, nodedata)
+    else
+        data = nodedata
+    end
+    _write_node_array(vtk, data, name)
+    return vtk
+end
+
+end # module FerriteVTKHDF

--- a/src/Export/VTKHDF.jl
+++ b/src/Export/VTKHDF.jl
@@ -1,0 +1,39 @@
+# VTKHDF export: the struct lives here so `Ferrite.VTKHDFGridFile` always
+# exists; all functionality is implemented in the FerriteVTKHDF package
+# extension, which loads together with VTKHDF.jl.
+
+"""
+    VTKHDFGridFile(filename::AbstractString, grid::AbstractGrid; kwargs...)
+    VTKHDFGridFile(filename::AbstractString, dh::DofHandler; kwargs...)
+
+Create a `VTKHDFGridFile`, the [VTKHDF file format](https://docs.vtk.org/en/latest/vtk_file_formats/vtkhdf_file_format/index.html)
+counterpart of [`VTKGridFile`](@ref). Requires
+[VTKHDF.jl](https://github.com/Ferrite-FEM/VTKHDF.jl) to be loaded.
+Keyword arguments are forwarded to `VTKHDF.vtkhdf_grid`.
+
+The same data functions as for [`VTKGridFile`](@ref) are supported
+([`write_solution`](@ref), [`write_cell_data`](@ref),
+[`write_projection`](@ref), [`write_node_data`](@ref),
+[`Ferrite.write_cellset`](@ref), ...), as well as the `do`-block form.
+
+Unlike the XML-based formats, a VTKHDF file can hold a whole time series in
+one file, with the grid stored only once. Open the file with `temporal = true`
+and write each step with `VTKHDF.write_timestep`:
+
+```julia
+vtkhdf = VTKHDFGridFile("simulation", dh; temporal = true)
+for (t, u) in timesteps
+    write_timestep(vtkhdf, t) do vtk
+        write_solution(vtk, dh, u)
+    end
+end
+close(vtkhdf)
+```
+"""
+struct VTKHDFGridFile{FT}
+    vtk::FT  # ::FT <: VTKHDF.VTKHDFFile (FT unrestricted since VTKHDF is a weak dependency)
+    cellnodes::Union{Vector{UnitRange{Int}}, Nothing}
+    node_mapping::Union{Vector{Int}, Nothing}
+end
+
+write_discontinuous(vtk::VTKHDFGridFile) = vtk.cellnodes !== nothing

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -157,6 +157,7 @@ include("L2_projection.jl")
 
 # Export
 include("Export/VTK.jl")
+include("Export/VTKHDF.jl")
 
 # Point Evaluation
 include("PointEvalHandler.jl")

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -184,6 +184,7 @@ export
 
     # exporting data
     VTKGridFile,
+    VTKHDFGridFile,
     write_solution,
     write_cell_data,
     write_projection,

--- a/test/test_vtkhdf_export.jl
+++ b/test/test_vtkhdf_export.jl
@@ -1,90 +1,82 @@
-# Tests for the FerriteVTKHDF extension (VTKHDFGridFile). Skipped when
-# VTKHDF.jl is not available (it is not a test dependency until it is
-# registered).
 using Ferrite, Test
+using VTKHDF
+using VTKHDF.HDF5
 
-if Base.find_package("VTKHDF") === nothing
-    @info "VTKHDF.jl not available; skipping VTKHDF export tests"
-else
-    using VTKHDF
-    using VTKHDF.HDF5
+@testset "VTKHDFGridFile" begin
+    grid = generate_grid(Quadrilateral, (4, 3))
+    ip = Lagrange{RefQuadrilateral, 1}()
+    dh = DofHandler(grid)
+    add!(dh, :u, ip)
+    add!(dh, :v, ip^2)
+    close!(dh)
+    u = rand(ndofs(dh))
+    dir = mktempdir()
 
-    @testset "VTKHDFGridFile" begin
-        grid = generate_grid(Quadrilateral, (4, 3))
-        ip = Lagrange{RefQuadrilateral, 1}()
-        dh = DofHandler(grid)
-        add!(dh, :u, ip)
-        add!(dh, :v, ip^2)
-        close!(dh)
-        u = rand(ndofs(dh))
-        dir = mktempdir()
+    @testset "static" begin
+        fn = joinpath(dir, "static.vtkhdf")
+        addcellset!(grid, "left", x -> x[1] < 0)
+        v = VTKHDFGridFile(fn, dh) do vtk
+            write_solution(vtk, dh, u)
+            write_cell_data(vtk, collect(1:getncells(grid)), "cellid")
+            write_node_data(vtk, rand(getnnodes(grid)), "nd")
+            Ferrite.write_cellset(vtk, grid, "left")
+        end
+        @test v isa VTKHDFGridFile
+        h5open(fn) do f
+            g = f["VTKHDF"]
+            @test attrs(g)["Type"] == "UnstructuredGrid"
+            @test size(g["Points"]) == (3, getnnodes(grid))
+            @test length(g["PointData/u"]) == getnnodes(grid)
+            @test size(g["PointData/v"]) == (3, getnnodes(grid))  # 2D Vec padded to 3
+            @test read(g["CellData/cellid"]) == 1:getncells(grid)
+            @test haskey(g, "CellData/left")
+        end
+    end
 
-        @testset "static" begin
-            fn = joinpath(dir, "static.vtkhdf")
-            addcellset!(grid, "left", x -> x[1] < 0)
-            v = VTKHDFGridFile(fn, dh) do vtk
-                write_solution(vtk, dh, u)
-                write_cell_data(vtk, collect(1:getncells(grid)), "cellid")
-                write_node_data(vtk, rand(getnnodes(grid)), "nd")
-                Ferrite.write_cellset(vtk, grid, "left")
-            end
-            @test v isa VTKHDFGridFile
-            h5open(fn) do f
-                g = f["VTKHDF"]
-                @test attrs(g)["Type"] == "UnstructuredGrid"
-                @test size(g["Points"]) == (3, getnnodes(grid))
-                @test length(g["PointData/u"]) == getnnodes(grid)
-                @test size(g["PointData/v"]) == (3, getnnodes(grid))  # 2D Vec padded to 3
-                @test read(g["CellData/cellid"]) == 1:getncells(grid)
-                @test haskey(g, "CellData/left")
+    @testset "temporal, grid stored once" begin
+        fn = joinpath(dir, "temporal.vtkhdf")
+        vtkhdf = VTKHDFGridFile(fn, dh; temporal = true)
+        nsteps = 4
+        for (step, t) in enumerate(range(0.0, 1.5; length = nsteps))
+            write_timestep(vtkhdf, t) do vtk
+                write_solution(vtk, dh, u .* step)
             end
         end
-
-        @testset "temporal, grid stored once" begin
-            fn = joinpath(dir, "temporal.vtkhdf")
-            vtkhdf = VTKHDFGridFile(fn, dh; temporal = true)
-            nsteps = 4
-            for (step, t) in enumerate(range(0.0, 1.5; length = nsteps))
-                write_timestep(vtkhdf, t) do vtk
-                    write_solution(vtk, dh, u .* step)
-                end
-            end
-            close(vtkhdf)
-            h5open(fn) do f
-                g = f["VTKHDF"]
-                @test size(g["Points"]) == (3, getnnodes(grid))       # exactly one copy
-                @test attrs(g["Steps"])["NSteps"] == nsteps
-                @test length(g["PointData/u"]) == nsteps * getnnodes(grid)
-                @test read(g["Steps/PointOffsets"]) == zeros(nsteps)
-            end
+        close(vtkhdf)
+        h5open(fn) do f
+            g = f["VTKHDF"]
+            @test size(g["Points"]) == (3, getnnodes(grid))       # exactly one copy
+            @test attrs(g["Steps"])["NSteps"] == nsteps
+            @test length(g["PointData/u"]) == nsteps * getnnodes(grid)
+            @test read(g["Steps/PointOffsets"]) == zeros(nsteps)
         end
+    end
 
-        @testset "discontinuous" begin
-            dhdg = DofHandler(grid)
-            add!(dhdg, :w, DiscontinuousLagrange{RefQuadrilateral, 1}())
-            close!(dhdg)
-            fn = joinpath(dir, "dg.vtkhdf")
-            VTKHDFGridFile(fn, dhdg) do vtk
-                write_solution(vtk, dhdg, rand(ndofs(dhdg)))
-            end
-            h5open(fn) do f
-                # nodes are duplicated per cell
-                @test size(f["VTKHDF/Points"]) == (3, sum(Ferrite.nnodes, getcells(grid)))
-            end
+    @testset "discontinuous" begin
+        dhdg = DofHandler(grid)
+        add!(dhdg, :w, DiscontinuousLagrange{RefQuadrilateral, 1}())
+        close!(dhdg)
+        fn = joinpath(dir, "dg.vtkhdf")
+        VTKHDFGridFile(fn, dhdg) do vtk
+            write_solution(vtk, dhdg, rand(ndofs(dhdg)))
         end
+        h5open(fn) do f
+            # nodes are duplicated per cell
+            @test size(f["VTKHDF/Points"]) == (3, sum(Ferrite.nnodes, getcells(grid)))
+        end
+    end
 
-        @testset "projection" begin
-            qr = QuadratureRule{RefQuadrilateral}(2)
-            proj = L2Projector(ip, grid)
-            qp_data = [[norm(x) for x in Ferrite.getpoints(qr)] for _ in 1:getncells(grid)]
-            projected = project(proj, qp_data, qr)
-            fn = joinpath(dir, "proj.vtkhdf")
-            VTKHDFGridFile(fn, grid) do vtk
-                write_projection(vtk, proj, projected, "p")
-            end
-            h5open(fn) do f
-                @test length(f["VTKHDF/PointData/p"]) == getnnodes(grid)
-            end
+    @testset "projection" begin
+        qr = QuadratureRule{RefQuadrilateral}(2)
+        proj = L2Projector(ip, grid)
+        qp_data = [[norm(x) for x in Ferrite.getpoints(qr)] for _ in 1:getncells(grid)]
+        projected = project(proj, qp_data, qr)
+        fn = joinpath(dir, "proj.vtkhdf")
+        VTKHDFGridFile(fn, grid) do vtk
+            write_projection(vtk, proj, projected, "p")
+        end
+        h5open(fn) do f
+            @test length(f["VTKHDF/PointData/p"]) == getnnodes(grid)
         end
     end
 end

--- a/test/test_vtkhdf_export.jl
+++ b/test/test_vtkhdf_export.jl
@@ -1,0 +1,90 @@
+# Tests for the FerriteVTKHDF extension (VTKHDFGridFile). Skipped when
+# VTKHDF.jl is not available (it is not a test dependency until it is
+# registered).
+using Ferrite, Test
+
+if Base.find_package("VTKHDF") === nothing
+    @info "VTKHDF.jl not available; skipping VTKHDF export tests"
+else
+    using VTKHDF
+    using VTKHDF.HDF5
+
+    @testset "VTKHDFGridFile" begin
+        grid = generate_grid(Quadrilateral, (4, 3))
+        ip = Lagrange{RefQuadrilateral, 1}()
+        dh = DofHandler(grid)
+        add!(dh, :u, ip)
+        add!(dh, :v, ip^2)
+        close!(dh)
+        u = rand(ndofs(dh))
+        dir = mktempdir()
+
+        @testset "static" begin
+            fn = joinpath(dir, "static.vtkhdf")
+            addcellset!(grid, "left", x -> x[1] < 0)
+            v = VTKHDFGridFile(fn, dh) do vtk
+                write_solution(vtk, dh, u)
+                write_cell_data(vtk, collect(1:getncells(grid)), "cellid")
+                write_node_data(vtk, rand(getnnodes(grid)), "nd")
+                Ferrite.write_cellset(vtk, grid, "left")
+            end
+            @test v isa VTKHDFGridFile
+            h5open(fn) do f
+                g = f["VTKHDF"]
+                @test attrs(g)["Type"] == "UnstructuredGrid"
+                @test size(g["Points"]) == (3, getnnodes(grid))
+                @test length(g["PointData/u"]) == getnnodes(grid)
+                @test size(g["PointData/v"]) == (3, getnnodes(grid))  # 2D Vec padded to 3
+                @test read(g["CellData/cellid"]) == 1:getncells(grid)
+                @test haskey(g, "CellData/left")
+            end
+        end
+
+        @testset "temporal, grid stored once" begin
+            fn = joinpath(dir, "temporal.vtkhdf")
+            vtkhdf = VTKHDFGridFile(fn, dh; temporal = true)
+            nsteps = 4
+            for (step, t) in enumerate(range(0.0, 1.5; length = nsteps))
+                write_timestep(vtkhdf, t) do vtk
+                    write_solution(vtk, dh, u .* step)
+                end
+            end
+            close(vtkhdf)
+            h5open(fn) do f
+                g = f["VTKHDF"]
+                @test size(g["Points"]) == (3, getnnodes(grid))       # exactly one copy
+                @test attrs(g["Steps"])["NSteps"] == nsteps
+                @test length(g["PointData/u"]) == nsteps * getnnodes(grid)
+                @test read(g["Steps/PointOffsets"]) == zeros(nsteps)
+            end
+        end
+
+        @testset "discontinuous" begin
+            dhdg = DofHandler(grid)
+            add!(dhdg, :w, DiscontinuousLagrange{RefQuadrilateral, 1}())
+            close!(dhdg)
+            fn = joinpath(dir, "dg.vtkhdf")
+            VTKHDFGridFile(fn, dhdg) do vtk
+                write_solution(vtk, dhdg, rand(ndofs(dhdg)))
+            end
+            h5open(fn) do f
+                # nodes are duplicated per cell
+                @test size(f["VTKHDF/Points"]) == (3, sum(Ferrite.nnodes, getcells(grid)))
+            end
+        end
+
+        @testset "projection" begin
+            qr = QuadratureRule{RefQuadrilateral}(2)
+            proj = L2Projector(ip, grid)
+            qp_data = [[norm(x) for x in Ferrite.getpoints(qr)] for _ in 1:getncells(grid)]
+            projected = project(proj, qp_data, qr)
+            fn = joinpath(dir, "proj.vtkhdf")
+            VTKHDFGridFile(fn, grid) do vtk
+                write_projection(vtk, proj, projected, "p")
+            end
+            h5open(fn) do f
+                @test length(f["VTKHDF/PointData/p"]) == getnnodes(grid)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Putting this up so the API can be reviewed, even though VTKHDF is not registered yet.

Adds VTKHDFGridFile, the VTKHDF (HDF5-based) counterpart of VTKGridFile, implemented in the new FerriteVTKHDF extension for https://github.com/Ferrite-FEM/VTKHDF.jl. Supports the same data functions (write_solution, write_cell_data, write_projection, write_node_data, set writers) including discontinuous grids, plus temporal files via VTKHDF.write_timestep: a whole simulation lands in a single file with the grid stored only once.

The transient heat equation tutorial now exports one temporal .vtkhdf file instead of a .pvd collection with one .vtu file per time step.