### PR TITLE
Fix FacetIterator constructor for Vector and Set input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next] - xxxx-xx-xx
 
+### Fixes
+ - `FacetIterator` now works with `AbstractVector{FacetIndex}` and `AbstractSet{FacetIndex}` inputs as documented, instead of requiring an `OrderedSet` ([#1384])
 
 ## [v1.5.0] - 2026-07-13
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -312,7 +312,7 @@ function FacetIterator(
         # Keep here to maintain same settings as for CellIterator
         _check_same_celltype(get_grid(gridordh), set)
     end
-    return FacetIterator(FacetCache(gridordh, flags), set)
+    return FacetIterator(FacetCache(gridordh, flags), convert_to_orderedset(set))
 end
 
 @inline _getcache(fi::FacetIterator) = fi.fc

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -229,17 +229,20 @@ end
         dh = DofHandler(grid); add!(dh, :u, ip); close!(dh)
         facetset = getfacetset(grid, "right")
         for dh_or_grid in (grid, dh)
-            @test first(FacetIterator(dh_or_grid, facetset)) isa FacetCache
-            area = 0.0
-            for face in FacetIterator(dh_or_grid, facetset)
-                reinit!(fv, face)
-                for q_point in 1:getnquadpoints(fv)
-                    area += getdetJdV(fv, q_point)
+            # The set can be passed as an OrderedSet, Set, or Vector
+            for set in (facetset, Set(facetset), collect(facetset))
+                @test first(FacetIterator(dh_or_grid, set)) isa FacetCache
+                area = 0.0
+                for face in FacetIterator(dh_or_grid, set)
+                    reinit!(fv, face)
+                    for q_point in 1:getnquadpoints(fv)
+                        area += getdetJdV(fv, q_point)
+                    end
                 end
+                dim == 1 && @test area ≈ 1.0
+                dim == 2 && @test area ≈ 2.0
+                dim == 3 && @test area ≈ 4.0
             end
-            dim == 1 && @test area ≈ 1.0
-            dim == 2 && @test area ≈ 2.0
-            dim == 3 && @test area ≈ 4.0
         end
     end
 


### PR DESCRIPTION
The outer `FacetIterator` constructor accepts `AbstractVecOrSet{FacetIndex}`, but the struct field requires an `OrderedSet{FacetIndex}`, so passing a `Vector` or `Set` threw a `MethodError`. Convert the set in the constructor (only `getfacetset`-returned `OrderedSet`s worked before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014QPLdDse855WFT4yXHdCgw)_