### PR TITLE
Force headless GR rendering in local docs builds

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,10 @@ const FerriteBlockArrays = Base.get_extension(Ferrite, :FerriteBlockArrays)
 
 const is_ci = haskey(ENV, "GITHUB_ACTIONS")
 
+# Plots/GR is used in some tutorials; make sure rendering is headless and does not
+# (try to) open a display window (CI sets this in the workflow file).
+haskey(ENV, "GKSwstype") || (ENV["GKSwstype"] = "100")
+
 # Generate tutorials and how-to guides
 include("generate.jl")
 


### PR DESCRIPTION
Some tutorials render plots with Plots/GR during the docs build. Without `GKSwstype` set, GR can spawn its `gksqt` display window, which pops up during local builds and can block the build until the window is closed.

CI already sets `GKSwstype: '100'` in `Documentation.yml`; this sets it (when unset) in `make.jl` as well, so local builds are headless too.

Fixes https://github.com/Ferrite-FEM/Ferrite.jl/issues/1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)