### PR TITLE
Add C1-continuous cubic Hermite interpolation Hermite{RefLine, 3}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `RefPyramid`, and extends tetrahedral quadrature beyond the previous maximum order 5 of
    the Keast rules. ([#1389])
  - `function_hessian` is now exported (`shape_hessian` already was). ([#1405])
+ - New interpolation `Hermite{RefLine, 3}`: a C1-continuous cubic Hermite interpolation
+   with value and derivative dofs, usable for fourth-order problems such as
+   Euler-Bernoulli beams. ([#1391])
 
 ### Documentation
  - The figures for the documentation are now programmatically generated and made to have a consistent look.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - New interpolation `Hermite{RefLine, 3}`: a C1-continuous cubic Hermite interpolation
    with value and derivative dofs, usable for fourth-order problems such as
    Euler-Bernoulli beams. ([#1391])
+ - `Dirichlet` now accepts a `kind` keyword argument to select which kind of dofs the
+   condition constrains, for interpolations with more than one kind (cf. the new
+   `Ferrite.dof_kinds` trait). The default `kind = :value` constrains value dofs as before;
+   for `Hermite` fields, `kind = :derivative` prescribes the derivative dofs, e.g. for
+   clamped beam ends. ([#1391])
 
 ### Documentation
  - The figures for the documentation are now programmatically generated and made to have a consistent look.

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -62,6 +62,14 @@ triangles), and Argyris/Morley type elements need a full ``M`` that additionally
 edge orientations (available through the `cell` argument, with
 `dof_transformation_needs_cell` returning `true`).
 
+#### Interpolations with multiple kinds of dofs
+For interpolations whose dofs are not all function values (e.g. `Hermite` with its
+derivative dofs), the kind of each dof must be specified so that `Dirichlet` can select
+which dofs to constrain.
+```@docs
+Ferrite.dof_kinds(::Interpolation)
+```
+
 #### Interpolations that cannot be constructed from their type
 For interpolations, `ip`, for which `ip == typeof(ip)()` is false (or doesn't work), the following must be implemented manually
 ```@docs

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -39,6 +39,29 @@ Ferrite.mapping_type
 Ferrite.get_direction
 ```
 
+#### Dof transformations
+For interpolations whose physical basis functions are a cell-dependent recombination of the
+mapped reference basis functions (e.g. `Hermite`, where the basis functions of derivative
+dofs are scaled by the cell Jacobian), the dof transformation must be specified.
+```@docs
+Ferrite.dof_transformation
+Ferrite.get_dof_scaling
+Ferrite.physical_basis_is_reference_basis
+```
+
+Currently only diagonal transformations (a per-basis-function scaling, sufficient for
+`Hermite` on the supported geometries) are implemented. The design extends to elements
+that need a non-diagonal ``M`` by adding a new transformation type returned from
+`dof_transformation` and a corresponding `apply_dof_transformation!` method: since the
+transformation stage runs after the mapping for each quadrature point, a method is free to
+recombine (not just scale) the mapped basis function values/gradients/hessians. For
+example, the tensor product Hermite elements (e.g. Bogner-Fox-Schmit on quadrilaterals)
+remain diagonal but only on axis-aligned cells, the cubic Hermite triangle needs 2×2
+blocks ``Jᵀ`` mixing the two gradient dofs of each vertex (valid on all affine
+triangles), and Argyris/Morley type elements need a full ``M`` that additionally uses the
+edge orientations (available through the `cell` argument, with
+`dof_transformation_needs_cell` returning `true`).
+
 #### Interpolations that cannot be constructed from their type
 For interpolations, `ip`, for which `ip == typeof(ip)()` is false (or doesn't work), the following must be implemented manually
 ```@docs

--- a/docs/src/reference/interpolations.md
+++ b/docs/src/reference/interpolations.md
@@ -22,4 +22,5 @@ DiscontinuousLagrange
 BubbleEnrichedLagrange
 CrouzeixRaviart
 RannacherTurek
+Hermite
 ```

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1,6 +1,6 @@
 # abstract type Constraint end
 """
-    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing)
+    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing; kind::Symbol = :value)
 
 Create a Dirichlet boundary condition on `u` on the `∂Ω` part of
 the boundary. `f` is a function of the form `f(x)` or `f(x, t)`
@@ -8,6 +8,18 @@ where `x` is the spatial coordinate and `t` is the current time,
 and returns the prescribed value. `components` specify the components
 of `u` that are prescribed by this condition. By default all components
 of `u` are prescribed.
+
+`kind` selects which kind of dofs the condition constrains, for interpolations that have
+more than one kind (cf. [`Ferrite.dof_kinds`](@ref)). The default, `:value`, constrains the
+dofs that represent the value of the function on the boundary. For example, for a field
+approximated with [`Hermite`](@ref) interpolation, `kind = :derivative` instead constrains
+the derivative dofs, and `f` then returns the prescribed derivative, e.g. for a clamped
+beam end:
+
+```julia
+add!(ch, Dirichlet(:w, ∂Ω, Returns(0.0)))                     # w = 0
+add!(ch, Dirichlet(:w, ∂Ω, Returns(0.0); kind = :derivative)) # dw/dx = 0
+```
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -43,11 +55,12 @@ struct Dirichlet # <: Constraint
     facets::OrderedSet{T} where {T <: Union{Int, FacetIndex, FaceIndex, EdgeIndex, VertexIndex}}
     field_name::Symbol
     components::Vector{Int} # components of the field
+    kind::Symbol # kind of dofs to constrain (cf. dof_kinds), :value by default
     local_facet_dofs::Vector{Int}
     local_facet_dofs_offset::Vector{Int}
 end
-function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing)
-    return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), Int[], Int[])
+function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; kind::Symbol = :value)
+    return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), kind, Int[], Int[])
 end
 
 # components=nothing is default and means that all components should be constrained
@@ -251,6 +264,7 @@ function Base.show(io::IO, ::MIME"text/plain", ch::ConstraintHandler)
         print(io, "  BCs:")
         for dbc in ch.dbcs
             print(io, "\n    ", "Field: ", dbc.field_name, ", ", "Components: ", dbc.components)
+            dbc.kind === :value || print(io, ", Kind: :", dbc.kind)
         end
     end
     return
@@ -378,7 +392,7 @@ end
 # Dirichlet on (facet|face|edge|vertex)set
 function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfacets::AbstractVecOrSet{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, _) where {Index <: BoundaryIndex}
     local_facet_dofs, local_facet_dofs_offset =
-        _local_facet_dofs_for_bc(interpolation, field_dim, dbc.components, offset, dirichlet_boundarydof_indices(eltype(bcfacets)))
+        _local_facet_dofs_for_bc(interpolation, field_dim, dbc.components, offset, dirichlet_boundarydof_indices(eltype(bcfacets)), dbc.kind)
     copy!(dbc.local_facet_dofs, local_facet_dofs)
     copy!(dbc.local_facet_dofs_offset, local_facet_dofs_offset)
 
@@ -403,14 +417,18 @@ end
 
 # Calculate which local dof index live on each facet:
 # facet `i` have dofs `local_facet_dofs[local_facet_dofs_offset[i]:local_facet_dofs_offset[i+1]-1]
-function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, boundaryfunc::F = dirichlet_facetdof_indices) where {F}
+function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, boundaryfunc::F = dirichlet_facetdof_indices, kind::Symbol = :value) where {F}
     @assert issorted(components)
+    kinds = dof_kinds(interpolation)
     local_facet_dofs = Int[]
     local_facet_dofs_offset = Int[1]
-    for (_, facet) in enumerate(boundaryfunc(interpolation))
-        for fdof in facet, d in 1:field_dim
-            if d in components
-                push!(local_facet_dofs, (fdof - 1) * field_dim + d + offset)
+    for facet in boundaryfunc(interpolation)
+        for fdof in facet
+            kinds[fdof] === kind || continue
+            for d in 1:field_dim
+                if d in components
+                    push!(local_facet_dofs, (fdof - 1) * field_dim + d + offset)
+                end
             end
         end
         push!(local_facet_dofs_offset, length(local_facet_dofs) + 1)
@@ -956,6 +974,9 @@ function add!(ch::ConstraintHandler, dbc::Dirichlet)
             interpolation = interpolation.ip
         end
         getorder(interpolation) == 0 && error("No dof prescribed for order 0 interpolations")
+        if dbc.kind ∉ dof_kinds(interpolation)
+            error("interpolation $(interpolation) for field :$(dbc.field_name) has no dofs of kind :$(dbc.kind) (existing kinds: $(join(unique(dof_kinds(interpolation)), ", ")))")
+        end
         # Set up components to prescribe (empty input means prescribe all components)
         components = isempty(dbc.components) ? collect(Int, 1:n_comp) : dbc.components
         if !all(c -> 0 < c <= n_comp, components)
@@ -974,9 +995,9 @@ function add!(ch::ConstraintHandler, dbc::Dirichlet)
             EntityType = FacetIndex
         end
         CT = getcelltype(sdh) # Same celltype enforced in SubDofHandler constructor
-        bcvalues = BCValues(interpolation, geometric_interpolation(CT), EntityType)
+        bcvalues = BCValues(interpolation, geometric_interpolation(CT), EntityType, dbc.kind)
         # Recreate the Dirichlet(...) struct with the filtered set and call internal add!
-        filtered_dbc = Dirichlet(dbc.field_name, filtered_set, dbc.f, components)
+        filtered_dbc = Dirichlet(dbc.field_name, filtered_set, dbc.f, components; kind = dbc.kind)
         _add!(
             ch, filtered_dbc, filtered_dbc.facets, interpolation, n_comp,
             field_offset(sdh, field_idx), bcvalues, sdh.cellset,

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -964,9 +964,10 @@ function add!(ch::ConstraintHandler, dbc::Dirichlet)
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
         if EntityType <: Integer
-            if !(mapping_type(interpolation) isa IdentityMapping)
+            if !physical_basis_is_reference_basis(interpolation)
                 # The node idx -> local dof idx assumption in _add! below does not hold
-                # when dofs are not nodal values (e.g. for H(div)/H(curl) interpolations)
+                # when dofs are not nodal values (e.g. for H(div)/H(curl) interpolations,
+                # or for Hermite with its derivative dofs)
                 throw(ArgumentError("Dirichlet conditions on a nodeset are not supported for $(interpolation), use a facetset or vertexset instead."))
             end
             # BCValues are just dummy for nodesets so set to FacetIndex
@@ -1077,7 +1078,7 @@ function add!(ch::ConstraintHandler, pdbc::PeriodicDirichlet)
     if interpolation isa VectorizedInterpolation
         interpolation = interpolation.ip
     end
-    if !(mapping_type(interpolation) isa IdentityMapping)
+    if !physical_basis_is_reference_basis(interpolation)
         # Would pair only the dofs from dirichlet_facetdof_indices (which may not be all
         # dofs on the facet) and lacks mirror_local_dofs methods
         throw(ArgumentError("PeriodicDirichlet is not supported for $(interpolation)."))

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -1022,9 +1022,9 @@ function _evaluate_at_grid_nodes!(
         u::AbstractVector{T}, cv::CellValues, drange::UnitRange
     ) where {T}
     ue = zeros(T, length(drange))
-    # For identity mappings the physical shape values alias the reference values, but other
-    # mappings require reinit! to compute them
-    needs_reinit = !isa(mapping_type(function_interpolation(cv)), IdentityMapping)
+    # When the physical shape values equal the reference values they are precomputed and
+    # alias each other, otherwise reinit! is required to compute them
+    needs_reinit = !physical_basis_is_reference_basis(function_interpolation(cv))
     for cell in CellIterator(sdh)
         needs_reinit && reinit!(cv, cell)
         @assert getnquadpoints(cv) == length(cell.nodes)

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -38,10 +38,11 @@ function apply_analytical!(
     for sdh in dh.subdofhandlers
         isnothing(_find_field(sdh, fieldname)) && continue
         ip_fun = getfieldinterpolation(sdh, find_field(sdh, fieldname))
-        if !(mapping_type(ip_fun) isa IdentityMapping)
+        if !physical_basis_is_reference_basis(ip_fun)
             error(
                 "apply_analytical! is only supported for interpolations where the dof values " *
-                    "are function values at the nodes (identity mapping), got $(ip_fun)."
+                    "are function values at the nodes (identity mapping and no dof " *
+                    "transformation), got $(ip_fun)."
             )
         end
     end

--- a/src/FEValues/CellValues.jl
+++ b/src/FEValues/CellValues.jl
@@ -123,7 +123,7 @@ function reinit!(cv::AbstractCellValues, cell::Union{AbstractCell, Nothing}, x::
 
     check_reinit_sdim_consistency(cv, x)
     if cell === nothing && reinit_needs_cell(cv)
-        throw(ArgumentError("The cell::AbstractCell input is required to reinit! non-identity function mappings"))
+        throw(ArgumentError("The cell::AbstractCell input is required to reinit! this function mapping"))
     end
     if !checkbounds(Bool, x, 1:n_geom_basefuncs) || length(x) != n_geom_basefuncs
         throw_incompatible_coord_length(length(x), n_geom_basefuncs)
@@ -132,6 +132,7 @@ function reinit!(cv::AbstractCellValues, cell::Union{AbstractCell, Nothing}, x::
         mapping = calculate_mapping(geo_mapping, q_point, x)
         _update_detJdV!(getdetJdVs(cv), q_point, w, mapping)
         apply_mapping!(fun_values, q_point, mapping, cell)
+        apply_dof_transformation!(fun_values, q_point, mapping, cell)
     end
     return nothing
 end
@@ -274,7 +275,12 @@ get_quadrature_rule(cv::MultiFieldCellValues) = getfield(cv, :qr)
 end
 
 @inline function reinit_needs_cell(cv::MultiFieldCellValues)
-    return any(map(fv -> !isa(mapping_type(fv), IdentityMapping), get_fun_values(cv)))
+    return any(
+        map(
+            fv -> mapping_needs_cell(mapping_type(fv)) || dof_transformation_needs_cell(dof_transformation(fv)),
+            get_fun_values(cv)
+        )
+    )
 end
 
 function check_reinit_sdim_consistency(cmv::MultiFieldCellValues, ::AbstractVector{VT}) where {VT}
@@ -287,6 +293,17 @@ end
     expr = Expr(:block)
     for i in 1:N
         push!(expr.args, :(apply_mapping!(fun_values[$i], q_point, mapping, cell)))
+    end
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds return $expr
+    end
+end
+
+@generated function apply_dof_transformation!(fun_values::Tuple{Vararg{FunctionValues, N}}, q_point, mapping, cell) where {N}
+    expr = Expr(:block)
+    for i in 1:N
+        push!(expr.args, :(apply_dof_transformation!(fun_values[$i], q_point, mapping, cell)))
     end
     return quote
         $(Expr(:meta, :inline))

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -175,10 +175,10 @@ function Base.show(io::IO, d::MIME"text/plain", fv::FacetValues)
 end
 
 """
-    BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Union{Type{<:BoundaryIndex}})
+    BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Union{Type{<:BoundaryIndex}}, kind::Symbol = :value)
 
 `BCValues` stores the shape values at all facet/faces/edges/vertices (depending on `boundary_type`) for the geometric interpolation (`geom_interpol`),
-for each dof-position determined by the `func_interpol`. Used mainly by the `ConstraintHandler`.
+for each dof-position of kind `kind` (cf. [`Ferrite.dof_kinds`](@ref)) determined by the `func_interpol`. Used mainly by the `ConstraintHandler`.
 """
 mutable struct BCValues{T}
     const M::Array{T, 3}
@@ -186,18 +186,21 @@ mutable struct BCValues{T}
     current_entity::Int
 end
 
-BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex}) =
-    BCValues(Float64, func_interpol, geom_interpol, boundary_type)
+BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex}, kind::Symbol = :value) =
+    BCValues(Float64, func_interpol, geom_interpol, boundary_type, kind)
 
-function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}) where {T, dim, refshape <: AbstractRefShape{dim}}
+function BCValues(::Type{T}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}, kind::Symbol = :value) where {T, dim, refshape <: AbstractRefShape{dim}}
     # set up quadrature rules for each boundary entity with dof-positions
-    # (determined by func_interpol) as the quadrature points
+    # (determined by func_interpol, filtered to dofs of the requested kind) as the
+    # quadrature points
     interpolation_coords = reference_coordinates(func_interpol)
+    kinds = dof_kinds(func_interpol)
 
     qrs = QuadratureRule{refshape, Vector{T}, Vector{Vec{dim, T}}}[]
     for boundarydofs in dirichlet_boundarydof_indices(boundary_type)(func_interpol)
         dofcoords = Vec{dim, T}[]
         for boundarydof in boundarydofs
+            kinds[boundarydof] === kind || continue
             push!(dofcoords, interpolation_coords[boundarydof])
         end
         qrf = QuadratureRule{refshape}(fill(T(NaN), length(dofcoords)), dofcoords) # weights will not be used

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -135,7 +135,7 @@ function reinit!(fv::FacetValues, cell::Union{AbstractCell, Nothing}, x::Abstrac
     fun_values = get_fun_values(fv)
 
     if cell === nothing && reinit_needs_cell(fv)
-        throw(ArgumentError("The cell::AbstractCell input is required to reinit! non-identity function mappings"))
+        throw(ArgumentError("The cell::AbstractCell input is required to reinit! this function mapping"))
     end
 
     @inbounds for (q_point, w) in pairs(getweights(fv.fqr, facet_nr))
@@ -148,6 +148,7 @@ function reinit!(fv::FacetValues, cell::Union{AbstractCell, Nothing}, x::Abstrac
         @inbounds fv.detJdV[q_point] = detJ * w
         @inbounds fv.normals[q_point] = weight_norm / norm(weight_norm)
         apply_mapping!(fun_values, q_point, mapping, cell)
+        apply_dof_transformation!(fun_values, q_point, mapping, cell)
     end
     return
 end

--- a/src/FEValues/FunctionValues.jl
+++ b/src/FEValues/FunctionValues.jl
@@ -58,11 +58,14 @@ struct FunctionValues{DiffOrder, IP, N_t, dNdx_t, dNdξ_t, d2Ndx2_t, d2Ndξ2_t} 
 end
 function FunctionValues{DiffOrder}(::Type{T}, ip::Interpolation, qr::QuadratureRule, ip_geo::VectorizedInterpolation) where {DiffOrder, T}
     assert_same_refshapes(qr, ip, ip_geo)
+    check_geometry_compatibility(ip, ip_geo)
     n_shape = getnbasefunctions(ip)
     n_qpoints = getnquadpoints(qr)
 
     Nξ = zeros(typeof_N(T, ip, ip_geo), n_shape, n_qpoints)
-    Nx = isa(mapping_type(ip), IdentityMapping) ? Nξ : similar(Nξ)
+    # The physical values can alias the reference values only when they are guaranteed
+    # equal, i.e. for the identity mapping without a dof transformation.
+    Nx = physical_basis_is_reference_basis(ip) ? Nξ : similar(Nξ)
     dNdξ = dNdx = d2Ndξ2 = d2Ndx2 = nothing
 
     if DiffOrder >= 1
@@ -145,6 +148,43 @@ struct ContravariantPiolaMapping end
 
 mapping_type(fv::FunctionValues) = mapping_type(fv.ip)
 
+# Dof transformation types
+# In the factorization ψᵢ = Σⱼ Mᵢⱼ (F φ̂ⱼ) of the physical basis functions ψᵢ, the reference
+# basis functions φ̂ⱼ are first pushed forward by the mapping F (`apply_mapping!`, determined
+# by the function space), and then recombined with the cell-constant matrix M (determined by
+# the element's dof functionals) to restore duality between the basis functions and the
+# physical dofs shared between cells. Most elements have M = I (`NoDofTransformation`).
+# `DiagonalDofTransformation` covers elements whose M is diagonal, i.e. a pure per-basis-
+# function scaling (see `get_dof_scaling`), such as `Hermite` where the basis functions of
+# derivative dofs are scaled by the cell Jacobian.
+# Note that the separation is not yet complete: the orientation signs of the Piola-mapped
+# elements (`get_direction`), conceptually the signed-permutation part of M, are still
+# folded into their `apply_mapping!` methods. Migrating them here is a possible future
+# consolidation.
+struct NoDofTransformation end
+struct DiagonalDofTransformation end
+
+dof_transformation(fv::FunctionValues) = dof_transformation(fv.ip)
+
+"""
+    check_geometry_compatibility(ip_fun::Interpolation, ip_geo::VectorizedInterpolation)
+
+Check that the geometric interpolation is supported for the function interpolation, and
+throw an `ArgumentError` if not. Defaults to no restriction.
+"""
+check_geometry_compatibility(::Interpolation, ::VectorizedInterpolation) = nothing
+function check_geometry_compatibility(ip::Hermite, ip_geo::VectorizedInterpolation{sdim}) where {sdim}
+    if !(sdim == 1 && ip_geo.ip isa Lagrange{RefLine, 1})
+        throw(
+            ArgumentError(
+                "$(ip) requires an affine geometry in 1D (ip_geo = Lagrange{RefLine, 1}()^1), got $(ip_geo). " *
+                    "Embedded (sdim > 1) or curved line elements are not supported."
+            )
+        )
+    end
+    return nothing
+end
+
 """
     required_geo_diff_order(fun_mapping, fun_diff_order::Int)
 
@@ -155,6 +195,11 @@ to the physical cell geometry.
 required_geo_diff_order(::IdentityMapping, fun_diff_order::Int) = fun_diff_order
 required_geo_diff_order(::ContravariantPiolaMapping, fun_diff_order::Int) = 1 + fun_diff_order
 required_geo_diff_order(::CovariantPiolaMapping, fun_diff_order::Int) = 1 + fun_diff_order
+
+# Dof transformations may require geometric derivatives independently of the function
+# derivative order, e.g. the Jacobian for the scaling of the Hermite basis functions.
+required_geo_diff_order(::NoDofTransformation) = 0
+required_geo_diff_order(::DiagonalDofTransformation) = 1 # J needed for the scaling
 
 # Support for embedded elements
 @inline calculate_Jinv(J::Tensor{2}) = inv(J)
@@ -176,11 +221,28 @@ end
 end
 
 # Identity mapping
-@inline function apply_mapping!(::FunctionValues{0}, ::IdentityMapping, ::Int, mapping_values, args...)
+# The physical values Nx normally alias the reference values Nξ, but when a dof
+# transformation is present they are separate arrays and the values must be copied over
+# before the transformation is applied. Dispatch on the dof transformation (a compile-time
+# constant of the interpolation type) keeps this a static no-op in the aliased case.
+@inline function copy_identity_mapped_values!(funvals::FunctionValues, q_point::Int)
+    return copy_identity_mapped_values!(funvals, dof_transformation(funvals.ip), q_point)
+end
+@inline copy_identity_mapped_values!(::FunctionValues, ::NoDofTransformation, ::Int) = nothing
+@inline function copy_identity_mapped_values!(funvals::FunctionValues, ::Any, q_point::Int)
+    @inbounds for j in 1:getnbasefunctions(funvals)
+        funvals.Nx[j, q_point] = funvals.Nξ[j, q_point]
+    end
+    return nothing
+end
+
+@inline function apply_mapping!(funvals::FunctionValues{0}, ::IdentityMapping, q_point::Int, mapping_values, args...)
+    copy_identity_mapped_values!(funvals, q_point)
     return nothing
 end
 
 @inline function apply_mapping!(funvals::FunctionValues{1}, ::IdentityMapping, q_point::Int, mapping_values, args...)
+    copy_identity_mapped_values!(funvals, q_point)
     Jinv = calculate_Jinv(getjacobian(mapping_values))
     @inbounds for j in 1:getnbasefunctions(funvals)
         funvals.dNdx[j, q_point] = funvals.dNdξ[j, q_point] ⋅ Jinv
@@ -189,6 +251,7 @@ end
 end
 
 @inline function apply_mapping!(funvals::FunctionValues{2}, ::IdentityMapping, q_point::Int, mapping_values, args...)
+    copy_identity_mapped_values!(funvals, q_point)
     Jinv = calculate_Jinv(getjacobian(mapping_values))
 
     sdim, rdim = size(Jinv)
@@ -262,6 +325,51 @@ end
         Nξ = funvals.Nξ[j, q_point]
         funvals.Nx[j, q_point] = d * (J ⋅ Nξ) / detJ
         funvals.dNdx[j, q_point] = d * (J ⋅ dNdξ ⋅ Jinv / detJ + A1 ⋅ Nξ - (J ⋅ Nξ) ⊗ A2)
+    end
+    return nothing
+end
+
+# ========================
+# Apply dof transformation
+# ========================
+# Applied in `reinit!` after `apply_mapping!`, recombining the mapped basis functions with
+# the cell-constant matrix M (see the note on dof transformation types above). Since M is
+# constant on the cell it applies uniformly to values, gradients, and hessians.
+@inline function apply_dof_transformation!(funvals::FunctionValues, q_point::Int, args...)
+    return apply_dof_transformation!(funvals, dof_transformation(funvals.ip), q_point, args...)
+end
+
+@inline function apply_dof_transformation!(::FunctionValues, ::NoDofTransformation, ::Int, mapping_values, args...)
+    return nothing
+end
+
+# Diagonal M: each basis function is scaled independently, no mixing.
+@inline function apply_dof_transformation!(funvals::FunctionValues{0}, ::DiagonalDofTransformation, q_point::Int, mapping_values, args...)
+    J = getjacobian(mapping_values)
+    @inbounds for j in 1:getnbasefunctions(funvals)
+        s = get_dof_scaling(funvals.ip, j, J)
+        funvals.Nx[j, q_point] = s * funvals.Nx[j, q_point]
+    end
+    return nothing
+end
+
+@inline function apply_dof_transformation!(funvals::FunctionValues{1}, ::DiagonalDofTransformation, q_point::Int, mapping_values, args...)
+    J = getjacobian(mapping_values)
+    @inbounds for j in 1:getnbasefunctions(funvals)
+        s = get_dof_scaling(funvals.ip, j, J)
+        funvals.Nx[j, q_point] = s * funvals.Nx[j, q_point]
+        funvals.dNdx[j, q_point] = s * funvals.dNdx[j, q_point]
+    end
+    return nothing
+end
+
+@inline function apply_dof_transformation!(funvals::FunctionValues{2}, ::DiagonalDofTransformation, q_point::Int, mapping_values, args...)
+    J = getjacobian(mapping_values)
+    @inbounds for j in 1:getnbasefunctions(funvals)
+        s = get_dof_scaling(funvals.ip, j, J)
+        funvals.Nx[j, q_point] = s * funvals.Nx[j, q_point]
+        funvals.dNdx[j, q_point] = s * funvals.dNdx[j, q_point]
+        funvals.d2Ndx2[j, q_point] = s * funvals.d2Ndx2[j, q_point]
     end
     return nothing
 end

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -9,11 +9,19 @@ function checkquadpoint(fe_v::AbstractValues, qp::Int)
     return nothing
 end
 
+# Whether apply_mapping! for the given mapping requires the cell as input, e.g. to look up
+# the orientation of entities. Defaults to true as the safe option for new mappings.
+mapping_needs_cell(::Any) = true
+mapping_needs_cell(::IdentityMapping) = false
+
+# Same as mapping_needs_cell, but for apply_dof_transformation!.
+dof_transformation_needs_cell(::Any) = true
+dof_transformation_needs_cell(::NoDofTransformation) = false
+dof_transformation_needs_cell(::DiagonalDofTransformation) = false # J suffices (its sign handles the orientation)
+
 @inline function reinit_needs_cell(fe_values::AbstractValues)
-    # TODO: Might need better logic for this, but for current implementations this
-    # is ok. If someone implements a non-identity mapping that doesn't require the cell
-    # as input, this is only a slight performance issue in some cases.
-    return !isa(mapping_type(get_fun_values(fe_values)), IdentityMapping)
+    fv = get_fun_values(fe_values)
+    return mapping_needs_cell(mapping_type(fv)) || dof_transformation_needs_cell(dof_transformation(fv))
 end
 
 @noinline function throw_incompatible_dof_length(length_ue, n_base_funcs)
@@ -48,14 +56,21 @@ function ValuesUpdateFlags(
         ip_fun::Interpolation, ::Val{update_gradients}, ::Val{update_hessians}, ::Val{update_detJdV}
     ) where {update_gradients, update_hessians, update_detJdV}
     FunDiffOrder = update_hessians ? 2 : (update_gradients ? 1 : 0)
-    GeoDiffOrder = max(required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder), update_detJdV)
+    GeoDiffOrder = max(
+        required_geo_diff_order(mapping_type(ip_fun), FunDiffOrder),
+        required_geo_diff_order(dof_transformation(ip_fun)),
+        update_detJdV,
+    )
     return ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, update_detJdV}()
 end
 function ValuesUpdateFlags( # For MultiFieldCellValues
         ip_fun::NamedTuple, ::Val{update_gradients}, ::Val{update_hessians}, ::Val{update_detJdV}
     ) where {update_gradients, update_hessians, update_detJdV}
     FunDiffOrder = update_hessians ? 2 : (update_gradients ? 1 : 0)
-    GeoDiffOrder = max(maximum(ip -> required_geo_diff_order(mapping_type(ip), FunDiffOrder), ip_fun), update_detJdV)
+    GeoDiffOrder = max(
+        maximum(ip -> max(required_geo_diff_order(mapping_type(ip), FunDiffOrder), required_geo_diff_order(dof_transformation(ip))), ip_fun),
+        update_detJdV,
+    )
     return ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder, update_detJdV}()
 end
 
@@ -68,7 +83,8 @@ end
 Update the `CellValues`, `MultiFieldCellValues`, or `FacetValues` object for a cell or
 facet with cell coordinates `x`.
 The derivatives of the shape functions, and the new integration weights are computed.
-For interpolations with non-identity mappings, the current `cell` is also required.
+For interpolations whose mapping requires it (e.g. the Piola mappings), the current `cell`
+is also required.
 """
 reinit!
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -14,6 +14,7 @@ export
     BubbleEnrichedLagrange,
     CrouzeixRaviart,
     RannacherTurek,
+    Hermite,
     Lagrange,
     DiscontinuousLagrange,
     Serendipity,

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -24,6 +24,7 @@ The following interpolations are implemented:
 * `CrouzeixRaviart{RefTetrahedron, 1}`
 * `RannacherTurek{RefQuadrilateral, 1}`
 * `RannacherTurek{RefHexahedron, 1}`
+* `Hermite{RefLine, 3}`
 * `Lagrange{RefHexahedron, 1}`
 * `Lagrange{RefHexahedron, 2}`
 * `Lagrange{RefTetrahedron, 1}`
@@ -292,7 +293,8 @@ end
 
 Returns a vector of coordinates with length [`getnbasefunctions(::Interpolation)`](@ref)
 and indices corresponding to the indices of a dof in [`vertices`](@ref), [`faces`](@ref) and
-[`edges`](@ref). Only applicable to nodal interpolations.
+[`edges`](@ref). Mainly applicable to nodal interpolations; for interpolations with
+multiple dofs per entity (e.g. [`Hermite`](@ref)) the same coordinate is repeated.
 """
 reference_coordinates(::Interpolation)
 
@@ -318,8 +320,9 @@ match the vertex enumeration of the corresponding geometrical cell.
 Used internally in [`ConstraintHandler`](@ref) and defaults to [`vertexdof_indices(ip::Interpolation)`](@ref) for continuous interpolation.
 
 !!! note
-    The dofs appearing in the tuple must be continuous and increasing! The first dof must be
-    the 1, as vertex dofs are enumerated first.
+    The dofs appearing in the tuple must be a subset of the interpolation's dofs for the
+    corresponding vertex, but may leave out dofs that should not be constrained by
+    `Dirichlet` (e.g. derivative dofs, see [`Hermite`](@ref)).
 """
 dirichlet_vertexdof_indices(ip::Interpolation) = vertexdof_indices(ip)
 
@@ -1570,12 +1573,76 @@ function reference_shape_value(ip::RannacherTurek{RefHexahedron, 1}, ξ::Vec{3, 
     throw(ArgumentError("no shape function $i for interpolation $ip"))
 end
 
+##########################################
+# Cubic Hermite on the line (C1 element) #
+##########################################
+"""
+    Hermite{RefLine, 3} <: ScalarInterpolation
+
+Cubic Hermite interpolation with two dofs per vertex: the function value and its
+derivative. Since both are shared between neighboring cells the interpolation is
+C¹-continuous, as required for fourth-order problems such as the Euler-Bernoulli beam.
+
+The local dof order is `(u₁, u₁', u₂, u₂')` where the derivative dofs are *physical*
+derivatives `du/dx` (the corresponding basis functions are scaled by the geometric
+Jacobian). Only affine 1D geometries are supported, i.e. `Line` cells with the default
+`Lagrange{RefLine, 1}` geometric interpolation; embedded or curved elements are not.
+
+[`Dirichlet`](@ref) conditions on facet- or vertex-sets constrain only the value dofs.
+To also clamp the derivative at a boundary vertex, prescribe the corresponding global dof
+directly with a master-less [`AffineConstraint`](@ref), e.g. for vertex 1 of cell 1:
+```julia
+add!(ch, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 0.0))
+```
+`Dirichlet` conditions on node-sets and `PeriodicDirichlet` are not supported.
+"""
+struct Hermite{shape, order} <: ScalarInterpolation{shape, order} end
+
+conformity(::Hermite) = H1Conformity() # C¹ ⊂ C⁰; finer classification is not needed
+mapping_type(::Hermite) = IdentityMapping()
+dof_transformation(::Hermite) = DiagonalDofTransformation()
+adjust_dofs_during_distribution(::Hermite) = false
+
+getnbasefunctions(::Hermite{RefLine, 3}) = 4
+vertexdof_indices(::Hermite{RefLine, 3}) = ((1, 2), (3, 4))
+# Only the value dofs (not the derivative dofs) are constrained by Dirichlet conditions
+dirichlet_vertexdof_indices(::Hermite{RefLine, 3}) = ((1,), (3,))
+
+function reference_coordinates(::Hermite{RefLine, 3})
+    return [
+        Vec{1, Float64}((-1.0,)),
+        Vec{1, Float64}((-1.0,)),
+        Vec{1, Float64}((1.0,)),
+        Vec{1, Float64}((1.0,)),
+    ]
+end
+
+function reference_shape_value(ip::Hermite{RefLine, 3}, ξ::Vec{1, T}, i::Int) where {T}
+    x = ξ[1]
+    i == 1 && return (1 - x)^2 * (2 + x) / 4
+    i == 2 && return (1 - x)^2 * (1 + x) / 4
+    i == 3 && return (1 + x)^2 * (2 - x) / 4
+    i == 4 && return -(1 + x)^2 * (1 - x) / 4
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+# Basis functions for derivative dofs are scaled by the Jacobian such that the dof value is
+# the physical derivative du/dx (consistent between cells of different length). The sign of
+# J accounts for reversed cell orientation.
+@inline function get_dof_scaling(::Hermite{RefLine, 3}, shape_nr::Int, J::Tensor{2, 1})
+    return (shape_nr == 2 || shape_nr == 4) ? J[1, 1] : one(J[1, 1])
+end
+
 ##################################################
 # VectorizedInterpolation{<:ScalarInterpolation} #
 ##################################################
 struct VectorizedInterpolation{vdim, refshape, order, SI <: ScalarInterpolation{refshape, order}} <: VectorInterpolation{vdim, refshape, order}
     ip::SI
     function VectorizedInterpolation{vdim}(ip::SI) where {vdim, refshape, order, SI <: ScalarInterpolation{refshape, order}}
+        # The vectorized interpolation uses the identity mapping without dof transformation,
+        # so interpolations with a non-trivial mapping or a dof transformation (e.g.
+        # Hermite) cannot be vectorized.
+        physical_basis_is_reference_basis(ip) || throw(ArgumentError("$(ip) cannot be vectorized since it has a non-identity mapping or a dof transformation"))
         return new{vdim, refshape, order, SI}(ip)
     end
 end
@@ -1644,6 +1711,54 @@ function mapping_type end
 
 mapping_type(::ScalarInterpolation) = IdentityMapping()
 mapping_type(::VectorizedInterpolation) = IdentityMapping()
+
+"""
+    dof_transformation(ip::Interpolation)
+
+Get the dof transformation applied to the mapped basis functions of `ip`. In the
+factorization ``ψᵢ = ∑ⱼ Mᵢⱼ (F φ̂ⱼ)`` of the physical basis functions ``ψᵢ``, the mapping
+``F`` (see [`Ferrite.mapping_type`](@ref)) is determined by the function space, while the
+cell-constant matrix ``M`` is determined by the element's dof functionals and restores
+duality between the basis functions and the physical dofs shared between cells.
+
+Defaults to `NoDofTransformation()` (``M = I``). Interpolations whose ``M`` is diagonal
+(e.g. [`Hermite`](@ref)) return `DiagonalDofTransformation()` and implement
+[`Ferrite.get_dof_scaling`](@ref).
+
+!!! note
+    The separation is not yet complete: the orientation signs of the Piola-mapped
+    elements ([`Ferrite.get_direction`](@ref)), conceptually the signed-permutation part
+    of ``M``, are currently still applied as part of the mapping.
+"""
+dof_transformation(::Interpolation) = NoDofTransformation()
+
+"""
+    get_dof_scaling(ip::Interpolation, shape_nr::Int, J::Tensor{2})
+
+For interpolations with a `DiagonalDofTransformation` (see
+[`Ferrite.dof_transformation`](@ref)), return the diagonal entry ``M_{jj}``,
+`j = shape_nr`, of the dof transformation matrix given the cell Jacobian `J`, i.e. the
+scaling applied to the mapped basis function `shape_nr`.
+"""
+function get_dof_scaling end
+
+"""
+    physical_basis_is_reference_basis(ip::Interpolation)
+
+Return `true` if the physical basis functions of `ip` coincide with the reference basis
+functions on any cell, i.e. if `ip` has the identity mapping (see
+[`Ferrite.mapping_type`](@ref)) and no dof transformation (see
+[`Ferrite.dof_transformation`](@ref)). `reinit!` does not affect the shape values of such
+interpolations, and the physical dof functionals coincide with the reference dof
+functionals. For all such interpolations currently implemented in Ferrite the dofs are
+point evaluations at the reference coordinates ("nodal" values), which e.g.
+[`apply_analytical!`](@ref) and `Dirichlet` conditions on nodesets rely on; an
+interpolation with non-point-evaluation dofs and untransformed basis functions (e.g. a
+modal basis with moment dofs) would need a finer distinction at those call sites.
+"""
+function physical_basis_is_reference_basis(ip::Interpolation)
+    return mapping_type(ip) isa IdentityMapping && dof_transformation(ip) isa NoDofTransformation
+end
 
 """
     get_direction(interpolation::Interpolation, shape_nr::Int, cell::AbstractCell)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -320,9 +320,8 @@ match the vertex enumeration of the corresponding geometrical cell.
 Used internally in [`ConstraintHandler`](@ref) and defaults to [`vertexdof_indices(ip::Interpolation)`](@ref) for continuous interpolation.
 
 !!! note
-    The dofs appearing in the tuple must be a subset of the interpolation's dofs for the
-    corresponding vertex, but may leave out dofs that should not be constrained by
-    `Dirichlet` (e.g. derivative dofs, see [`Hermite`](@ref)).
+    The dofs appearing in the tuple must be continuous and increasing! The first dof must be
+    the 1, as vertex dofs are enumerated first.
 """
 dirichlet_vertexdof_indices(ip::Interpolation) = vertexdof_indices(ip)
 
@@ -485,6 +484,17 @@ dirichlet_boundarydof_indices(::Type{FaceIndex}) = dirichlet_facedof_indices
 dirichlet_boundarydof_indices(::Type{EdgeIndex}) = dirichlet_edgedof_indices
 dirichlet_boundarydof_indices(::Type{VertexIndex}) = dirichlet_vertexdof_indices
 dirichlet_boundarydof_indices(::Type{FacetIndex}) = dirichlet_facetdof_indices
+
+"""
+    dof_kinds(ip::Interpolation)
+
+A tuple of length [`getnbasefunctions(::Interpolation)`](@ref) with a `Symbol` classifying
+the kind of each local dof. By default all dofs are `:value` dofs, i.e. the dof value is
+the value of the approximated function at the dof location. Interpolations with other kinds
+of dofs overload this function, e.g. [`Hermite`](@ref) which also has `:derivative` dofs.
+The kind is used by [`Dirichlet`](@ref) to select which dofs a condition constrains.
+"""
+dof_kinds(ip::Interpolation) = ntuple(_ -> :value, getnbasefunctions(ip))
 
 
 get_edge_direction(cell, edgenr) = get_edge_direction(edges(cell)[edgenr])
@@ -1588,11 +1598,12 @@ derivatives `du/dx` (the corresponding basis functions are scaled by the geometr
 Jacobian). Only affine 1D geometries are supported, i.e. `Line` cells with the default
 `Lagrange{RefLine, 1}` geometric interpolation; embedded or curved elements are not.
 
-[`Dirichlet`](@ref) conditions on facet- or vertex-sets constrain only the value dofs.
-To also clamp the derivative at a boundary vertex, prescribe the corresponding global dof
-directly with a master-less [`AffineConstraint`](@ref), e.g. for vertex 1 of cell 1:
+[`Dirichlet`](@ref) conditions on facet- or vertex-sets constrain the value dofs by
+default. To also clamp the derivative at a boundary, add a second `Dirichlet` with
+`kind = :derivative`:
 ```julia
-add!(ch, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 0.0))
+add!(ch, Dirichlet(:w, ∂Ω, Returns(0.0)))                     # w = 0
+add!(ch, Dirichlet(:w, ∂Ω, Returns(0.0); kind = :derivative)) # dw/dx = 0
 ```
 `Dirichlet` conditions on node-sets and `PeriodicDirichlet` are not supported.
 """
@@ -1605,8 +1616,7 @@ adjust_dofs_during_distribution(::Hermite) = false
 
 getnbasefunctions(::Hermite{RefLine, 3}) = 4
 vertexdof_indices(::Hermite{RefLine, 3}) = ((1, 2), (3, 4))
-# Only the value dofs (not the derivative dofs) are constrained by Dirichlet conditions
-dirichlet_vertexdof_indices(::Hermite{RefLine, 3}) = ((1,), (3,))
+dof_kinds(::Hermite{RefLine, 3}) = (:value, :derivative, :value, :derivative)
 
 function reference_coordinates(::Hermite{RefLine, 3})
     return [

--- a/test/test_interpolations_hermite.jl
+++ b/test/test_interpolations_hermite.jl
@@ -145,9 +145,10 @@ using Ferrite: reference_shape_value, reference_shape_gradient, OrderedSet
         end
     end
 
-    @testset "Dirichlet constrains only value dofs" begin
+    @testset "Dirichlet on value and derivative dofs" begin
         grid = generate_grid(Line, (2,), Vec((0.0,)), Vec((1.0,)))
         dh = DofHandler(grid); add!(dh, :w, ip); close!(dh)
+        # default kind = :value constrains only the value dofs
         ch = ConstraintHandler(dh)
         add!(ch, Dirichlet(:w, union(getfacetset(grid, "left"), getfacetset(grid, "right")), x -> x[1] + 42.0))
         close!(ch); update!(ch, 0.0)
@@ -156,14 +157,26 @@ using Ferrite: reference_shape_value, reference_shape_gradient, OrderedSet
         @test sort(ch.prescribed_dofs) == sort([left_dof, right_dof])
         @test ch.inhomogeneities[findfirst(==(left_dof), ch.prescribed_dofs)] ≈ 42.0
         @test ch.inhomogeneities[findfirst(==(right_dof), ch.prescribed_dofs)] ≈ 43.0
-        # derivative dof pinning via a master-less AffineConstraint
+        # kind = :derivative constrains only the derivative dofs, and f prescribes du/dx
         ch2 = ConstraintHandler(dh)
         add!(ch2, Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0)))
-        add!(ch2, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 1.5))
+        add!(ch2, Dirichlet(:w, union(getfacetset(grid, "left"), getfacetset(grid, "right")), (x, t) -> x[1] + t; kind = :derivative))
         close!(ch2); update!(ch2, 0.0)
-        @test celldofs(dh, 1)[2] in ch2.prescribed_dofs
+        left_deriv = celldofs(dh, 1)[2]
+        right_deriv = celldofs(dh, 2)[4]
+        @test sort(ch2.prescribed_dofs) == sort([left_dof, left_deriv, right_deriv])
         a = zeros(ndofs(dh)); apply!(a, ch2)
-        @test a[celldofs(dh, 1)[2]] ≈ 1.5
+        @test a[left_dof] ≈ 0.0
+        @test a[left_deriv] ≈ 0.0
+        @test a[right_deriv] ≈ 1.0
+        update!(ch2, 2.0) # derivative BCs are update!-able in time
+        apply!(a, ch2)
+        @test a[left_deriv] ≈ 2.0
+        @test a[right_deriv] ≈ 3.0
+        # requesting a dof kind the interpolation does not have errors
+        @test_throws ErrorException add!(ConstraintHandler(dh), Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); kind = :nope))
+        dh_lag = DofHandler(grid); add!(dh_lag, :u, Lagrange{RefLine, 1}()); close!(dh_lag)
+        @test_throws ErrorException add!(ConstraintHandler(dh_lag), Dirichlet(:u, getfacetset(grid, "left"), Returns(0.0); kind = :derivative))
     end
 
     @testset "unsupported usage errors" begin
@@ -190,7 +203,7 @@ using Ferrite: reference_shape_value, reference_shape_gradient, OrderedSet
             dh = DofHandler(grid); add!(dh, :w, ip); close!(dh)
             ch = ConstraintHandler(dh)
             add!(ch, Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0)))
-            add!(ch, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 0.0))
+            add!(ch, Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); kind = :derivative))
             close!(ch)
             cv = CellValues(QuadratureRule{RefLine}(2), ip; update_hessians = true)
             K = allocate_matrix(dh)

--- a/test/test_interpolations_hermite.jl
+++ b/test/test_interpolations_hermite.jl
@@ -1,0 +1,233 @@
+# Imports for parallel (isolated) test execution:
+using Test, LinearAlgebra
+include(joinpath(@__DIR__, "test_utils.jl"))
+include(joinpath(@__DIR__, "interpolation_test_utils.jl"))
+
+using Ferrite: reference_shape_value, reference_shape_gradient, OrderedSet
+
+@testset "Hermite{RefLine, 3}" begin
+    ip = Hermite{RefLine, 3}()
+
+    test_interpolation_properties(ip)
+
+    ξL, ξR = Vec((-1.0,)), Vec((1.0,))
+    N(j, ξ) = reference_shape_value(ip, ξ, j)
+    dN(j, ξ) = reference_shape_gradient(ip, ξ, j)[1]
+
+    # The dof functionals are (N(-1), N'(-1), N(1), N'(1)) instead of point evaluations,
+    # so the nodal interpolation tests in test_interpolations.jl do not apply.
+    @testset "generalized Kronecker property" begin
+        for j in 1:4
+            @test N(j, ξL) ≈ (j == 1 ? 1.0 : 0.0) atol = 1.0e-14
+            @test dN(j, ξL) ≈ (j == 2 ? 1.0 : 0.0) atol = 1.0e-14
+            @test N(j, ξR) ≈ (j == 3 ? 1.0 : 0.0) atol = 1.0e-14
+            @test dN(j, ξR) ≈ (j == 4 ? 1.0 : 0.0) atol = 1.0e-14
+        end
+    end
+
+    @testset "cubic reproduction in reference coordinates" begin
+        for (f, df) in ((x -> 1.0, x -> 0.0), (x -> x, x -> 1.0), (x -> x^2, x -> 2x), (x -> x^3, x -> 3x^2))
+            for ξv in (-0.7, 0.13, 0.9)
+                ξ = Vec((ξv,))
+                interp = f(-1.0) * N(1, ξ) + df(-1.0) * N(2, ξ) + f(1.0) * N(3, ξ) + df(1.0) * N(4, ξ)
+                @test interp ≈ f(ξv) atol = 1.0e-13
+            end
+        end
+    end
+
+    # Nonuniform 2-cell grid: nodes at x = 0, 1, 3 (element lengths 1 and 2). Two different
+    # element lengths make the tests below sensitive to the Jacobian scaling of the
+    # derivative basis functions in the dof transformation.
+    grid2 = Grid([Line((1, 2)), Line((2, 3))], [Node(Vec((0.0,))), Node(Vec((1.0,))), Node(Vec((3.0,)))])
+    dh2 = DofHandler(grid2)
+    add!(dh2, :w, ip)
+    close!(dh2)
+
+    @testset "dof distribution" begin
+        @test ndofs(dh2) == 6
+        cd1, cd2 = celldofs(dh2, 1), celldofs(dh2, 2)
+        @test cd1[3:4] == cd2[1:2] # shared (value, derivative) pair at the middle vertex
+        @test length(unique(vcat(cd1, cd2))) == 6
+    end
+
+    # Exact interpolant of w(x) = x^3: value dofs x³, derivative dofs 3x² (physical derivative)
+    w_ex(x) = x^3
+    dw_ex(x) = 3x^2
+    u2 = zeros(ndofs(dh2))
+    for cellid in 1:2
+        cd = celldofs(dh2, cellid)
+        xs = [x[1] for x in getcoordinates(grid2, cellid)]
+        u2[cd[1]] = w_ex(xs[1]); u2[cd[2]] = dw_ex(xs[1])
+        u2[cd[3]] = w_ex(xs[2]); u2[cd[4]] = dw_ex(xs[2])
+    end
+
+    @testset "mapping exactness on nonuniform mesh" begin
+        cv = CellValues(QuadratureRule{RefLine}(3), ip; update_hessians = true)
+        for cellid in 1:2
+            coords = getcoordinates(grid2, cellid)
+            reinit!(cv, coords) # cell-less reinit must work (mapping_needs_cell = false)
+            ue = u2[celldofs(dh2, cellid)]
+            for qp in 1:getnquadpoints(cv)
+                x = spatial_coordinate(cv, qp, coords)[1]
+                @test function_value(cv, qp, ue) ≈ w_ex(x) atol = 1.0e-12
+                @test function_gradient(cv, qp, ue)[1] ≈ dw_ex(x) atol = 1.0e-12
+                @test function_hessian(cv, qp, ue)[1, 1] ≈ 6x atol = 1.0e-11
+            end
+        end
+    end
+
+    @testset "per-DiffOrder mapping consistency" begin
+        qr = QuadratureRule{RefLine}(2)
+        coords = getcoordinates(grid2, 2)
+        cv0 = CellValues(qr, ip; update_gradients = false, update_detJdV = false)
+        cv1 = CellValues(qr, ip)
+        cv2 = CellValues(qr, ip; update_hessians = true)
+        reinit!(cv0, coords); reinit!(cv1, coords); reinit!(cv2, coords)
+        for qp in 1:2, j in 1:4
+            @test shape_value(cv0, qp, j) ≈ shape_value(cv2, qp, j)
+            @test shape_value(cv1, qp, j) ≈ shape_value(cv2, qp, j)
+            @test shape_gradient(cv1, qp, j) ≈ shape_gradient(cv2, qp, j)
+        end
+    end
+
+    @testset "C1 continuity at shared vertex" begin
+        urand = rand(ndofs(dh2))
+        cv_r = CellValues(QuadratureRule{RefLine}([1.0], [Vec((1.0,))]), ip)
+        cv_l = CellValues(QuadratureRule{RefLine}([1.0], [Vec((-1.0,))]), ip)
+        reinit!(cv_r, getcoordinates(grid2, 1))
+        reinit!(cv_l, getcoordinates(grid2, 2))
+        @test function_value(cv_r, 1, urand[celldofs(dh2, 1)]) ≈ function_value(cv_l, 1, urand[celldofs(dh2, 2)])
+        @test function_gradient(cv_r, 1, urand[celldofs(dh2, 1)]) ≈ function_gradient(cv_l, 1, urand[celldofs(dh2, 2)])
+    end
+
+    @testset "Float32 and inference" begin
+        cvf = CellValues(Float32, QuadratureRule{RefLine}(2), ip; update_hessians = true)
+        reinit!(cvf, [Vec((0.0f0,)), Vec((2.0f0,))])
+        uef = rand(Float32, 4)
+        @test (@inferred function_value(cvf, 1, uef)) isa Float32
+        @test (@inferred function_gradient(cvf, 1, uef)) isa Vec{1, Float32}
+        @test (@inferred function_hessian(cvf, 1, uef)) isa Tensor{2, 1, Float32}
+    end
+
+    @testset "FacetValues" begin
+        fv = FacetValues(FacetQuadratureRule{RefLine}(1), ip)
+        reinit!(fv, getcoordinates(grid2, 1), 2) # right vertex of cell 1
+        @test shape_value(fv, 1, 3) ≈ 1.0
+        @test shape_value(fv, 1, 1) ≈ 0.0 atol = 1.0e-14
+    end
+
+    @testset "MultiFieldCellValues" begin
+        qr = QuadratureRule{RefLine}(2)
+        coords = getcoordinates(grid2, 2)
+        cmv = MultiFieldCellValues(qr, (w = ip, u = Lagrange{RefLine, 1}()))
+        reinit!(cmv, coords)
+        cv = CellValues(qr, ip)
+        reinit!(cv, coords)
+        for qp in 1:2, j in 1:4
+            @test shape_value(cmv.w, qp, j) ≈ shape_value(cv, qp, j)
+            @test shape_gradient(cmv.w, qp, j) ≈ shape_gradient(cv, qp, j)
+        end
+    end
+
+    @testset "evaluate_at_grid_nodes and PointEvalHandler" begin
+        @test evaluate_at_grid_nodes(dh2, u2, :w) ≈ [0.0, 1.0, 27.0]
+        ph = PointEvalHandler(grid2, [Vec((0.3,)), Vec((1.77,))])
+        @test evaluate_at_points(ph, dh2, u2, :w) ≈ [0.3^3, 1.77^3]
+    end
+
+    @testset "VTK export" begin
+        mktempdir() do dir
+            fname = joinpath(dir, "hermite")
+            VTKGridFile(fname, dh2) do vtk
+                write_solution(vtk, dh2, u2, "")
+            end
+            @test isfile(fname * ".vtu")
+        end
+    end
+
+    @testset "Dirichlet constrains only value dofs" begin
+        grid = generate_grid(Line, (2,), Vec((0.0,)), Vec((1.0,)))
+        dh = DofHandler(grid); add!(dh, :w, ip); close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, Dirichlet(:w, union(getfacetset(grid, "left"), getfacetset(grid, "right")), x -> x[1] + 42.0))
+        close!(ch); update!(ch, 0.0)
+        left_dof = celldofs(dh, 1)[1]
+        right_dof = celldofs(dh, 2)[3]
+        @test sort(ch.prescribed_dofs) == sort([left_dof, right_dof])
+        @test ch.inhomogeneities[findfirst(==(left_dof), ch.prescribed_dofs)] ≈ 42.0
+        @test ch.inhomogeneities[findfirst(==(right_dof), ch.prescribed_dofs)] ≈ 43.0
+        # derivative dof pinning via a master-less AffineConstraint
+        ch2 = ConstraintHandler(dh)
+        add!(ch2, Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0)))
+        add!(ch2, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 1.5))
+        close!(ch2); update!(ch2, 0.0)
+        @test celldofs(dh, 1)[2] in ch2.prescribed_dofs
+        a = zeros(ndofs(dh)); apply!(a, ch2)
+        @test a[celldofs(dh, 1)[2]] ≈ 1.5
+    end
+
+    @testset "unsupported usage errors" begin
+        @test_throws ArgumentError Hermite{RefLine, 3}()^2
+        @test_throws ArgumentError CellValues(QuadratureRule{RefLine}(2), ip, Lagrange{RefLine, 2}()^1) # curved
+        @test_throws ArgumentError CellValues(QuadratureRule{RefLine}(2), ip, Lagrange{RefLine, 1}()^2) # embedded
+        @test_throws ErrorException apply_analytical!(zeros(ndofs(dh2)), dh2, :w, x -> 0.0)
+        ch = ConstraintHandler(dh2)
+        @test_throws ArgumentError add!(ch, Dirichlet(:w, Set([1]), Returns(0.0))) # nodeset
+        @test_throws ArgumentError add!(ch, PeriodicDirichlet(:w, Ferrite.PeriodicFacetPair[]))
+    end
+
+    @testset "cantilever beam vs analytic solution" begin
+        function solve_cantilever(n; L, EI, q = 0.0, P = 0.0, M = 0.0, nonuniform = false)
+            grid = if nonuniform
+                xs = L .* range(0.0, 1.0; length = n + 1) .^ 2
+                Grid(
+                    [Line((i, i + 1)) for i in 1:n], [Node(Vec((x,))) for x in xs];
+                    facetsets = Dict("left" => OrderedSet([FacetIndex(1, 1)]))
+                )
+            else
+                generate_grid(Line, (n,), Vec((0.0,)), Vec((L,)))
+            end
+            dh = DofHandler(grid); add!(dh, :w, ip); close!(dh)
+            ch = ConstraintHandler(dh)
+            add!(ch, Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0)))
+            add!(ch, AffineConstraint(celldofs(dh, 1)[2], Pair{Int, Float64}[], 0.0))
+            close!(ch)
+            cv = CellValues(QuadratureRule{RefLine}(2), ip; update_hessians = true)
+            K = allocate_matrix(dh)
+            f = zeros(ndofs(dh))
+            assembler = start_assemble(K, f)
+            Ke = zeros(4, 4); fe = zeros(4)
+            for cell in CellIterator(dh)
+                reinit!(cv, cell)
+                fill!(Ke, 0.0); fill!(fe, 0.0)
+                for qp in 1:getnquadpoints(cv)
+                    dΩ = getdetJdV(cv, qp)
+                    for i in 1:4
+                        fe[i] += q * shape_value(cv, qp, i) * dΩ
+                        κi = shape_hessian(cv, qp, i)
+                        for j in 1:4
+                            Ke[i, j] += EI * (κi ⊡ shape_hessian(cv, qp, j)) * dΩ
+                        end
+                    end
+                end
+                assemble!(assembler, celldofs(cell), Ke, fe)
+            end
+            tip = celldofs(dh, getncells(grid))
+            f[tip[3]] += P # point load -> value dof
+            f[tip[4]] += M # point moment -> derivative dof
+            apply!(K, f, ch)
+            u = K \ f
+            return u[tip[3]], u[tip[4]]
+        end
+        L, EI = 2.0, 3.0
+        for n in (1, 5), nonuniform in (false, true)
+            n == 1 && nonuniform && continue
+            for (q, P, M) in ((0.0, 0.0, 1.0), (0.0, 1.0, 0.0), (1.0, 0.0, 0.0), (2.0, 3.0, 0.5))
+                wt, θt = solve_cantilever(n; L, EI, q, P, M, nonuniform)
+                # The cubic Hermite solution is nodally exact for Euler-Bernoulli beams
+                @test wt ≈ q * L^4 / (8EI) + P * L^3 / (3EI) + M * L^2 / (2EI)
+                @test θt ≈ q * L^3 / (6EI) + P * L^2 / (2EI) + M * L / EI
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds a cubic Hermite interpolation on `RefLine` with two dofs per vertex (value + derivative), making fourth-order problems (Euler-Bernoulli beams) solvable. A follow-up PR (#1392) adds a beam tutorial using it.

**Stacked on #1405**, which contains the library fixes that were originally part of this PR (`evaluate_at_grid_nodes` reinit fix, `apply_analytical!`/nodeset-`Dirichlet`/`PeriodicDirichlet` guards, `function_hessian` export + hessian docs). This PR retargets to `master` automatically when #1405 is merged.

## Design
- The derivative dofs are **physical** derivatives `du/dx`: a new `HermiteMapping` scales the corresponding basis functions by the geometric Jacobian, so the shared vertex dofs are consistent between neighboring cells of different length (the sign of J handles orientation). Restricted to affine 1D geometry, enforced at `FunctionValues` construction.
- `Dirichlet` gets a `kind::Symbol = :value` keyword, backed by a new `dof_kinds(::Interpolation)` trait (all `:value` by default; Hermite tags its derivative dofs `:derivative`). The default constrains only the value dofs; `kind = :derivative` prescribes the derivative dofs, with `f` returning the prescribed `dw/dx` (well-defined since the dofs are physical derivatives). A clamped end is thus two `Dirichlet`s on the same set, and derivative BCs are `update!`-able in time like any other. This replaces the earlier master-less-`AffineConstraint` workaround discussed in the review.
- Unsupported paths error explicitly instead of silently corrupting: vectorization (`Hermite^n`), nodeset `Dirichlet`, `PeriodicDirichlet`, `apply_analytical!` (the guards for the latter three live in #1405 and apply to all non-identity mappings).
- `reinit_needs_cell` is now a `mapping_needs_cell` trait (resolves the TODO in common_values.jl); Hermite does not need the cell, so cell-less `reinit!` and `PointValues` work.

## Tests
`test/test_interpolations_hermite.jl`: generalized Kronecker duality, cubic reproduction, mapping exactness on a nonuniform mesh (catches any missed J-scaling), C1 continuity, dof distribution/sharing, BC behavior, guard errors, Float32/inference, FacetValues/MultiFieldCellValues/PointEvalHandler/VTK integration, and a cantilever solved against the analytic solution (nodally exact) on uniform and nonuniform meshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
