### PR TITLE
Add Euler-Bernoulli beam tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    clamped beam ends. ([#1391])
 
 ### Documentation
+ - New tutorial: "Euler-Bernoulli beam", solving a fourth-order problem with the new
+   `Hermite{RefLine, 3}` interpolation, including point loads and point moments. ([#1392])
  - The figures for the documentation are now programmatically generated and made to have a consistent look.
  - New tutorial: Elastodynamics and modal analysis of a cantilever beam (mass matrix, generalized eigenvalue problem, Rayleigh damping, Newmark time integration).
 

--- a/docs/download_resources.jl
+++ b/docs/download_resources.jl
@@ -35,7 +35,7 @@ fetch_assets(
                 "heat_equation", "linear_elasticity", "incompressible_elasticity",
                 "hyperelasticity", "plasticity", "computational_homogenization",
                 "stokes-flow", "dg_heat_equation", "linear_shell",
-                "linear_elasticity_stress", "elastodynamics_modes",
+                "linear_elasticity_stress", "elastodynamics_modes", "euler_bernoulli_beam",
             ], ".png"
         ),
         variants(["transient_heat", "elastodynamics", "porous_media", "ns_vs_diffeq", "reactive_surface"], ".webp"),

--- a/docs/gallery_index_body.md
+++ b/docs/gallery_index_body.md
@@ -22,8 +22,8 @@ Neumann boundary conditions and the method of manufactured solutions.
 
 #### [Nearly incompressible hyperelasticity](quasi_incompressible_hyperelasticity.md)
 
-This program combines the ideas from [Tutorial 3: Incompressible
-elasticity](../tutorials/incompressible_elasticity.md) and [Tutorial 4:
+This program combines the ideas from [Tutorial 4: Incompressible
+elasticity](../tutorials/incompressible_elasticity.md) and [Tutorial 5:
 Hyperelasticity](../tutorials/hyperelasticity.md) to construct a mixed element
 solving three-dimensional displacement-pressure equations.
 

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -123,6 +123,7 @@ write_overview(
         ("heat_equation", "Heat equation", ["heat_equation-light.png", "heat_equation-dark.png"]),
         ("linear_elasticity", "Linear elasticity", ["linear_elasticity-light.png", "linear_elasticity-dark.png"]),
         ("elastodynamics", "Elastodynamics and modal analysis", ["elastodynamics-light.webp", "elastodynamics-dark.webp"]),
+        ("euler_bernoulli_beam", "Euler-Bernoulli beam", ["euler_bernoulli_beam-light.png", "euler_bernoulli_beam-dark.png"]),
         ("incompressible_elasticity", "Incompressible elasticity", ["incompressible_elasticity-light.png", "incompressible_elasticity-dark.png"]),
         ("hyperelasticity", "Hyperelasticity", ["hyperelasticity-light.png", "hyperelasticity-dark.png"]),
         ("plasticity", "von Mises plasticity", ["plasticity-light.png", "plasticity-dark.png"]),

--- a/docs/generate_screenshots.jl
+++ b/docs/generate_screenshots.jl
@@ -39,6 +39,7 @@ const EXAMPLES = Dict(
     "stokes-flow" => "literate-tutorials/stokes-flow.jl",
     "computational_homogenization" => "literate-tutorials/computational_homogenization.jl",
     "linear_shell" => "literate-tutorials/linear_shell.jl",
+    "euler_bernoulli_beam" => "literate-tutorials/euler_bernoulli_beam.jl",
     # Time-stepping examples rendered as animations (write a .pvd collection).
     "transient_heat" => "literate-tutorials/transient_heat_equation.jl",
     "elastodynamics" => "literate-tutorials/elastodynamics.jl",
@@ -52,11 +53,27 @@ const EXAMPLES = Dict(
     "topology_optimization" => "literate-gallery/topology_optimization.jl",
 )
 
+# Examples plotted with Plots.jl instead of ParaView: their POSTRUN hook writes
+# the -light/-dark variants itself and they are excluded from the pvbatch call.
+const JULIA_RENDERED = Set(["euler_bernoulli_beam"])
+
 # Extra code evaluated in the example's module after running it, e.g. to
 # re-run at a finer mesh resolution for a smoother figure than the (cheap)
 # default the example uses.
 const POSTRUN = Dict(
     "stokes-flow" => :(main(0.02)),
+    "euler_bernoulli_beam" => quote
+        for (variant, fg) in (("light", "#000000"), ("dark", "#e5e5e5"))
+            thumb = Plots.plot(
+                x_fe, w_fe; label = "FE solution", color = 1, linewidth = 2,
+                foreground_color = fg, background_color = :transparent, size = (800, 600),
+            )
+            Plots.plot!(thumb, w_ana; xlims = (0, L), label = "analytic", color = fg, linestyle = :dash)
+            Plots.scatter!(thumb, node_x, evaluate_at_grid_nodes(dh, u, :w); label = "nodal values", color = 1)
+            Plots.plot!(thumb; xlabel = "x", ylabel = "deflection w", legend = :topleft)
+            Plots.savefig(thumb, joinpath($(joinpath(@__DIR__, "screenshot-assets")), "euler_bernoulli_beam-$variant.png"))
+        end
+    end,
 )
 
 # Output file basenames (before the -light/-dark suffix) each scene renders;
@@ -111,6 +128,16 @@ render_only = "--render-only" in ARGS
 selected = filter(a -> !startswith(a, "--"), ARGS)
 isempty(selected) && (selected = collect(keys(EXAMPLES)))
 
+# Julia-rendered examples have no data files to re-render from: skip them with
+# --render-only (also excludes them from --upload, which would upload stale files).
+if render_only
+    skipped = filter(in(JULIA_RENDERED), selected)
+    if !isempty(skipped)
+        @warn "--render-only skips Julia-rendered examples: $(join(skipped, ", "))"
+        filter!(!in(JULIA_RENDERED), selected)
+    end
+end
+
 mkpath(DATADIR)
 mkpath(OUTDIR)
 
@@ -128,7 +155,10 @@ if !render_only
     end
 end
 
-run(`pvbatch $(joinpath(DOCS, "screenshots.py")) $DATADIR $OUTDIR $selected`)
+pv_selected = filter(!in(JULIA_RENDERED), selected)
+if !isempty(pv_selected)
+    run(`pvbatch $(joinpath(DOCS, "screenshots.py")) $DATADIR $OUTDIR $pv_selected`)
+end
 @info "screenshots written to $OUTDIR"
 
 if "--upload" in ARGS

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -61,6 +61,7 @@ bibtex_plugin = CitationBibliography(
             "tutorials/heat_equation.md",
             "tutorials/linear_elasticity.md",
             "tutorials/elastodynamics.md",
+            "tutorials/euler_bernoulli_beam.md",
             "tutorials/incompressible_elasticity.md",
             "tutorials/hyperelasticity.md",
             "tutorials/plasticity.md",

--- a/docs/src/literate-tutorials/euler_bernoulli_beam.jl
+++ b/docs/src/literate-tutorials/euler_bernoulli_beam.jl
@@ -1,0 +1,254 @@
+# # [Euler-Bernoulli beam](@id tutorial-euler-bernoulli-beam)
+#
+# ![](euler_bernoulli_beam-light.png)
+# ![](euler_bernoulli_beam-dark.png)
+#
+# *Figure 1*: Deflection of a cantilever beam, clamped at the left end and loaded by a
+# distributed load, a point load, and a moment at the tip.
+#
+#-
+#md # !!! tip
+#md #     This example is also available as a Jupyter notebook:
+#md #     [`euler_bernoulli_beam.ipynb`](@__NBVIEWER_ROOT_URL__/tutorials/euler_bernoulli_beam.ipynb).
+#-
+#
+# ## Introduction
+#
+# In this tutorial we solve the Euler-Bernoulli beam equation, our first *fourth-order*
+# problem. The strong form for a beam on the domain $\Omega = (0, L)$ reads
+#
+# ```math
+# EI \frac{\mathrm{d}^4 w}{\mathrm{d}x^4} = q,
+# ```
+#
+# where $w$ is the transverse deflection, $EI$ the bending stiffness, and $q$ a distributed
+# load. We consider a cantilever: the left end is clamped,
+#
+# ```math
+# w(0) = 0, \quad w'(0) = 0,
+# ```
+#
+# and at the right end we apply a point load $P$ and a moment $\bar{M}$.
+#
+# To derive the weak form we multiply the strong form with a test function $\delta w$ and
+# integrate by parts *twice*:
+#
+# ```math
+# \int_0^L q \, \delta w \, \mathrm{d}x
+# = \int_0^L EI \, w'''' \, \delta w \, \mathrm{d}x
+# = \int_0^L EI \, w'' \, \delta w'' \, \mathrm{d}x
+# + \left[ EI \, w''' \, \delta w - EI \, w'' \, \delta w' \right]_0^L.
+# ```
+#
+# In the boundary term we recognize the shear force $V = -EI \, w'''$ and the bending
+# moment $M = EI \, w''$. At the clamped end the test functions vanish,
+# $\delta w(0) = \delta w'(0) = 0$, and at the tip the natural boundary conditions
+# prescribe $V(L) = P$ and $M(L) = \bar{M}$. The weak form thus reads: find
+# $w \in \mathbb{U}$ such that
+#
+# ```math
+# \int_0^L EI \, w'' \, \delta w'' \, \mathrm{d}x =
+#     \int_0^L q \, \delta w \, \mathrm{d}x + P \, \delta w(L) + \bar{M} \, \delta w'(L)
+#     \quad \forall \, \delta w \in \mathbb{T}.
+# ```
+#
+# Two things are new compared to the second-order problems in the previous tutorials:
+#
+# * The weak form contains *second* derivatives of the trial and test functions, so
+#   $\mathbb{U}$ and $\mathbb{T}$ are subspaces of $H^2$. Piecewise polynomials belong to
+#   $H^2$ only if they are $C^1$-continuous, i.e. the derivative may not jump between
+#   elements. Standard Lagrange interpolations are only $C^0$ and can therefore not be
+#   used. Instead we use the cubic [`Hermite`](@ref) interpolation, which has two degrees
+#   of freedom per node -- the deflection $w$ and the slope $w'$ -- and sharing both
+#   between neighboring elements gives exactly $C^1$ continuity.
+# * The boundary terms load not only the deflection ($P \, \delta w(L)$) but also the
+#   *slope* ($\bar{M} \, \delta w'(L)$). Since the slope is a degree of freedom, applying a
+#   point moment is as simple as adding to its entry in the force vector.
+#
+# A useful property of this discretization is that the nodal deflections and slopes of
+# the finite element solution are *exact*, on any mesh, provided that the load term is
+# integrated exactly (which our quadrature rule does for the constant $q$ used here). To
+# make this visible we solve with only 4 elements and compare against the analytic
+# solution
+#
+# ```math
+# w(x) = \frac{q x^2 (x^2 - 4Lx + 6L^2)}{24 EI} + \frac{P x^2 (3L - x)}{6 EI}
+#      + \frac{\bar{M} x^2}{2 EI}.
+# ```
+#-
+# ## Commented program
+#
+# Now we solve the problem in Ferrite. What follows is a program spliced with comments.
+#md # The full program, without comments, can be found in the next
+#md # [section](@ref euler_bernoulli_beam-plain-program).
+#
+# First we load Ferrite and define the parameters (in normalized units).
+using Ferrite
+
+L = 1.0  # beam length
+EI = 1.0 # bending stiffness
+q = 1.0  # distributed load
+P = 1.0  # tip point load
+M̄ = 1.0; # tip moment
+
+# ### Mesh
+# We discretize the beam with 4 `Line` elements. This is our first 1D grid: the facets of
+# a `Line` cell are its two end vertices, and `generate_grid` sets up the facet sets
+# `"left"` and `"right"` for the two end points. We use `"left"` for the clamped end
+# below; the tip loads need no facet set since they are applied directly to dofs.
+grid = generate_grid(Line, (4,), Vec((0.0,)), Vec((L,)));
+
+# ### Trial and test functions
+# We use the cubic Hermite interpolation on the reference line. It has 4 basis functions,
+# associated with the dofs $(w_1, w_1', w_2, w_2')$ where subscripts denote the two
+# vertices: `Ferrite.vertexdof_indices(ip) == ((1, 2), (3, 4))`. The slope dofs carry the
+# *physical* derivative $w' = \mathrm{d}w/\mathrm{d}x$.
+ip = Hermite{RefLine, 3}();
+
+# The integrand of the stiffness contribution is a product of two second derivatives, each
+# linear in $\xi$, so two Gauss points integrate it exactly.
+qr = QuadratureRule{RefLine}(2);
+
+# Since the weak form needs second derivatives of the shape functions we construct the
+# `CellValues` with `update_hessians = true` (they are off by default for performance) and
+# access them with [`shape_hessian`](@ref).
+cellvalues = CellValues(qr, ip; update_hessians = true);
+
+# ### Degrees of freedom
+# The `DofHandler` distributes the dofs as usual; the two dofs per vertex are handled
+# automatically, giving $2 (n_{el} + 1) = 10$ dofs in total.
+dh = DofHandler(grid)
+add!(dh, :w, ip)
+close!(dh);
+
+# !!! warning "Numbering of degrees of freedom"
+#     Recall that the numbering of degrees of freedom does not follow the numbering of the
+#     nodes in the grid. With Hermite there is a second pitfall: `u[i]` may be either a
+#     deflection *or* a slope dof.
+
+# ### Boundary conditions
+# The clamped end requires both $w(0) = 0$ and $w'(0) = 0$. `Dirichlet` conditions on a
+# Hermite field constrain only the *deflection* dofs (prescribing a function value to a
+# slope dof would be wrong).
+ch = ConstraintHandler(dh)
+add!(ch, Dirichlet(:w, getfacetset(grid, "left"), (x, t) -> 0.0));
+
+# The slope dof is instead prescribed directly with a master-less `AffineConstraint`.
+# Local dof 2 is the slope at vertex 1 (cf. `vertexdof_indices` above), so the global dof
+# number at the clamped end of the first cell is `celldofs(dh, 1)[2]`.
+slope_dof = celldofs(dh, 1)[2]
+add!(ch, AffineConstraint(slope_dof, Pair{Int, Float64}[], 0.0))
+close!(ch);
+
+# ### Assembling the linear system
+# The element routine follows the same structure as in the
+# [heat equation tutorial](@ref tutorial-heat-equation), with the stiffness
+# $\int EI \, \delta w'' \, w'' \, \mathrm{d}x$ now built from `shape_hessian`. In 1D the
+# hessian is a 1×1 tensor, so the double contraction `⊡` is just a scalar product.
+function assemble_global!(K, f, cellvalues, dh, EI, q)
+    n_basefuncs = getnbasefunctions(cellvalues)
+    Ke = zeros(n_basefuncs, n_basefuncs)
+    fe = zeros(n_basefuncs)
+    assembler = start_assemble(K, f)
+    for cell in CellIterator(dh)
+        reinit!(cellvalues, cell)
+        fill!(Ke, 0)
+        fill!(fe, 0)
+        for q_point in 1:getnquadpoints(cellvalues)
+            dΩ = getdetJdV(cellvalues, q_point)
+            for i in 1:n_basefuncs
+                δw = shape_value(cellvalues, q_point, i)
+                δw′′ = shape_hessian(cellvalues, q_point, i)
+                fe[i] += q * δw * dΩ
+                for j in 1:n_basefuncs
+                    w′′ = shape_hessian(cellvalues, q_point, j)
+                    Ke[i, j] += EI * (δw′′ ⊡ w′′) * dΩ
+                end
+            end
+        end
+        assemble!(assembler, celldofs(cell), Ke, fe)
+    end
+    return K, f
+end
+
+K = allocate_matrix(dh)
+f = zeros(ndofs(dh))
+assemble_global!(K, f, cellvalues, dh, EI, q);
+
+# ### Point load and point moment
+# The boundary terms of the weak form become contributions to single entries of the force
+# vector: $P$ multiplies $\delta w(L)$, i.e. it loads the deflection dof at the tip, and
+# $\bar{M}$ multiplies $\delta w'(L)$, i.e. it loads the slope dof. With Lagrange elements
+# a point moment would require e.g. a force couple, but here it is one vector entry. The
+# tip dofs are local dofs 3 (deflection) and 4 (slope) of the last cell.
+tip_dofs = celldofs(dh, getncells(grid))
+f[tip_dofs[3]] += P
+f[tip_dofs[4]] += M̄;
+
+# ### Solution of the system
+apply!(K, f, ch)
+u = K \ f;
+
+# ### Postprocessing
+# Since the mesh is 1D we plot the solution directly instead of exporting to VTK. To
+# evaluate the FE solution *inside* the elements we construct a `CellValues` with the
+# plotting points as "quadrature" points (the weights are unused).
+ξs = [Vec((ξ,)) for ξ in range(-1.0, 1.0; length = 21)]
+qr_plot = QuadratureRule{RefLine}(zeros(length(ξs)), ξs)
+cv_plot = CellValues(qr_plot, ip; update_hessians = true, update_detJdV = false)
+
+x_fe = Float64[]; w_fe = Float64[]; M_fe = Float64[]
+for cell in CellIterator(dh)
+    reinit!(cv_plot, cell)
+    ue = u[celldofs(cell)]
+    for q_point in 1:getnquadpoints(cv_plot)
+        push!(x_fe, spatial_coordinate(cv_plot, q_point, getcoordinates(cell))[1])
+        push!(w_fe, function_value(cv_plot, q_point, ue))
+        push!(M_fe, EI * function_hessian(cv_plot, q_point, ue)[1, 1])
+    end
+end
+
+# For comparison we evaluate the analytic deflection and bending moment
+# $M(x) = EI \, w''(x)$:
+w_ana(x) = (q * x^2 * (x^2 - 4L * x + 6L^2) / 24 + P * x^2 * (3L - x) / 6 + M̄ * x^2 / 2) / EI
+M_ana(x) = q * (L - x)^2 / 2 + P * (L - x) + M̄;
+
+# We plot the FE deflection together with the analytic solution and mark the nodal values,
+# which coincide with the analytic curve even on this coarse mesh. In fact, for $q = 0$
+# the analytic solution is a cubic polynomial, and the FE solution would be exact
+# *everywhere*.
+import Plots
+
+node_x = range(0.0, L; length = getncells(grid) + 1)
+## Transparent background and gray foreground render well on both the light and the dark
+## documentation theme
+theme = (background_color = :transparent, foreground_color = :gray)
+plt_w = Plots.plot(x_fe, w_fe; label = "FE solution", color = 1, linewidth = 2, theme...)
+Plots.plot!(plt_w, w_ana; xlims = (0, L), label = "analytic", color = :gray, linestyle = :dash)
+Plots.scatter!(plt_w, node_x, evaluate_at_grid_nodes(dh, u, :w); label = "nodal values", color = 1)
+Plots.plot!(plt_w; xlabel = "x", ylabel = "deflection w", legend = :topleft)
+# *Figure 2*: FE deflection compared to the analytic solution. The nodal values are exact.
+
+# The bending moment is obtained from the second derivative of the solution via
+# `function_hessian`. The FE moment is piecewise linear and only approximates the
+# quadratic analytic moment: derivatives of the solution converge at a lower rate than the
+# solution itself.
+plt_M = Plots.plot(x_fe, M_fe; label = "FE solution", color = 1, linewidth = 2, theme...)
+Plots.plot!(plt_M, M_ana; xlims = (0, L), label = "analytic", color = :gray, linestyle = :dash)
+Plots.plot!(plt_M; xlabel = "x", ylabel = "bending moment M", legend = :topright)
+# *Figure 3*: Bending moment $M = EI \, w''$. The distributed load $q$ is the part of the
+# solution the cubic elements cannot represent exactly.
+
+using Test                                                       #hide
+@test u[tip_dofs[3]] ≈ (q * L^4 / 8 + P * L^3 / 3 + M̄ * L^2 / 2) / EI #hide
+@test u[tip_dofs[4]] ≈ (q * L^3 / 6 + P * L^2 / 2 + M̄ * L) / EI      #hide
+nothing                                                          #hide
+
+#md # ## [Plain program](@id euler_bernoulli_beam-plain-program)
+#md #
+#md # Here follows a version of the program without any comments.
+#md # The file is also available here: [`euler_bernoulli_beam.jl`](euler_bernoulli_beam.jl).
+#md #
+#md # ```julia
+#md # @__CODE__
+#md # ```

--- a/docs/src/literate-tutorials/euler_bernoulli_beam.jl
+++ b/docs/src/literate-tutorials/euler_bernoulli_beam.jl
@@ -127,17 +127,15 @@ close!(dh);
 #     deflection *or* a slope dof.
 
 # ### Boundary conditions
-# The clamped end requires both $w(0) = 0$ and $w'(0) = 0$. `Dirichlet` conditions on a
-# Hermite field constrain only the *deflection* dofs (prescribing a function value to a
-# slope dof would be wrong).
+# The clamped end requires both $w(0) = 0$ and $w'(0) = 0$. By default a `Dirichlet`
+# condition on a Hermite field constrains only the *deflection* dofs (prescribing a
+# function value to a slope dof would be wrong).
 ch = ConstraintHandler(dh)
 add!(ch, Dirichlet(:w, getfacetset(grid, "left"), (x, t) -> 0.0));
 
-# The slope dof is instead prescribed directly with a master-less `AffineConstraint`.
-# Local dof 2 is the slope at vertex 1 (cf. `vertexdof_indices` above), so the global dof
-# number at the clamped end of the first cell is `celldofs(dh, 1)[2]`.
-slope_dof = celldofs(dh, 1)[2]
-add!(ch, AffineConstraint(slope_dof, Pair{Int, Float64}[], 0.0))
+# The slope dofs are constrained with a second `Dirichlet` with `kind = :derivative`, where
+# the function now prescribes the derivative $w'$ instead of the value:
+add!(ch, Dirichlet(:w, getfacetset(grid, "left"), (x, t) -> 0.0; kind = :derivative))
 close!(ch);
 
 # ### Assembling the linear system

--- a/docs/src/topics/degrees_of_freedom.md
+++ b/docs/src/topics/degrees_of_freedom.md
@@ -89,7 +89,7 @@ i.e. the local indices for the `:u` field are `1:3` and for the `:v` field `4:9`
 matches directly with the number of dofs for each field: 3 for `:u` and 6 for `:v`. The
 ranges are used when assembling the blocks of the matrix, i.e. if `Ke` is the local matrix,
 then `Ke[u_range, u_range]` corresponds to the ``K_{uu}``, `Ke[u_range, v_range]` to
-``K_{uv}``, etc. See for example [Tutorial 8: Stokes flow](../tutorials/stokes-flow.md) for
+``K_{uv}``, etc. See for example [Tutorial 9: Stokes flow](../tutorials/stokes-flow.md) for
 how the ranges are used.
 
 

--- a/docs/tutorials_index_body.md
+++ b/docs/tutorials_index_body.md
@@ -20,7 +20,7 @@ The tutorials are listed in roughly increasing order of complexity. However, sin
 focus on different aspects, and solve different problems, it is suggested to have a look at
 the brief descriptions below to get an idea about what you will learn from each tutorial.
 
-If you are new to Ferrite then Tutorials 1 - 7 are the best place to start. These
+If you are new to Ferrite then Tutorials 1 - 8 are the best place to start. These
 tutorials introduce and teach most of the basic finite element techniques (e.g. linear
 and non-linear problems, scalar- and vector-valued problems, Dirichlet and Neumann boundary
 conditions, mixed finite elements, time integration, direct and iterative linear solvers,
@@ -63,7 +63,20 @@ frequencies, modal analysis, Rayleigh damping, Newmark time integration.
 
 ---
 
-#### [Tutorial 4: Incompressible elasticity](incompressible_elasticity.md)
+#### [Tutorial 4: Euler-Bernoulli beam](euler_bernoulli_beam.md)
+
+This tutorial solves a fourth-order problem, the Euler-Bernoulli beam equation, using a
+C1-continuous cubic Hermite interpolation with both deflection and slope degrees of
+freedom. It introduces second derivatives of shape functions (hessians) in the assembly,
+and shows how point loads and point moments are applied directly to individual degrees of
+freedom.
+
+**Keywords**: C1-continuous interpolation, Hermite shape functions, second derivatives,
+point loads and point moments.
+
+---
+
+#### [Tutorial 5: Incompressible elasticity](incompressible_elasticity.md)
 
 This tutorial focuses on a mixed formulation of linear elasticity, with (vector)
 displacement and (scalar) pressure as the two unknowns, suitable for incompressibility.
@@ -75,7 +88,7 @@ incompressible limit.
 
 ---
 
-#### [Tutorial 5: Hyperelasticity](hyperelasticity.md)
+#### [Tutorial 6: Hyperelasticity](hyperelasticity.md)
 
 In this tutorial you will learn how to solve a non-linear finite element problem. In
 particular, a hyperelastic material model, in a finite strain setting, is used to solve the
@@ -88,7 +101,7 @@ Newton's method, conjugate gradient (CG).
 
 ---
 
-#### [Tutorial 6: von Mises Plasticity](plasticity.md)
+#### [Tutorial 7: von Mises Plasticity](plasticity.md)
 
 This tutorial revisits the cantilever beam problem from [Tutorial 2: Linear
 elasticity](linear_elasticity.md), but instead of linear elasticity a plasticity model is
@@ -102,7 +115,7 @@ Newton’s method.
 
 ---
 
-#### [Tutorial 7: Transient heat equation](@ref tutorial-transient-heat-equation)
+#### [Tutorial 8: Transient heat equation](@ref tutorial-transient-heat-equation)
 
 In this tutorial the transient heat equation is solved on the unit square. The problem to be
 solved is thus similar to the one solved in the first tutorial, [Heat
@@ -114,7 +127,7 @@ integration.
 
 ---
 
-#### [Tutorial 8: Computational homogenization](computational_homogenization.md)
+#### [Tutorial 9: Computational homogenization](computational_homogenization.md)
 
 This tutorial guides you through computational homogenization of a representative volume
 element (RVE) consisting of a soft matrix material with stiff inclusions. The computational
@@ -125,7 +138,7 @@ conditions are used.
 
 ---
 
-#### [Tutorial 9: Stokes flow](stokes-flow.md)
+#### [Tutorial 10: Stokes flow](stokes-flow.md)
 
 In this tutorial Stokes flow with (vector) velocity and (scalar) pressure is solved on a
 quarter circle. Rotationally periodic boundary conditions is used for the inlet/outlet
@@ -137,7 +150,7 @@ Gmsh.
 
 ---
 
-#### [Tutorial 10: Porous media (SubDofHandler)](porous_media.md)
+#### [Tutorial 11: Porous media (SubDofHandler)](porous_media.md)
 
 This tutorial introduces how to solve a complex linear problem, where there are different
 fields on different subdomains, and different cell types in the grid. This requires using
@@ -147,7 +160,7 @@ the `SubDofHandler` interface.
 
 ---
 
-#### [Tutorial 11: Incompressible Navier-Stokes equations](ns_vs_diffeq.md)
+#### [Tutorial 12: Incompressible Navier-Stokes equations](ns_vs_diffeq.md)
 
 In this tutorial the incompressible Navier-Stokes equations are solved. The domain is
 discretized in space with Ferrite as usual, and then formulated in a way to be compatible
@@ -158,7 +171,7 @@ for the time-integration.
 
 ---
 
-#### [Tutorial 12: Reactive surface](@ref tutorial-reactive-surface)
+#### [Tutorial 13: Reactive surface](@ref tutorial-reactive-surface)
 
 In this tutorial a reaction diffusion system on a sphere surface embedded in 3D is solved.
 Ferrite is used to assemble the diffusion operators and the mass matrices. The problem is
@@ -168,7 +181,7 @@ solved by using the usual first order reaction diffusion operator splitting.
 
 ---
 
-#### [Tutorial 13: Linear shell](@ref tutorial-linear-shell)
+#### [Tutorial 14: Linear shell](@ref tutorial-linear-shell)
 
 In this tutorial a linear shell element formulation is set up as a two-dimensional domain
 embedded in three-dimensional space. This will teach, and perhaps inspire, you on how
@@ -179,7 +192,7 @@ Ferrite.
 
 ---
 
-#### [Tutorial 14: Discontinuous Galerkin heat equation](@ref tutorial-dg-heat-equation)
+#### [Tutorial 15: Discontinuous Galerkin heat equation](@ref tutorial-dg-heat-equation)
 
 This tutorial guides you through the process of solving the linear stationary heat equation
 (i.e. Poisson's equation) on a unit square with inhomogeneous Dirichlet and Neumann boundary


### PR DESCRIPTION
Adds "Tutorial 3: Euler-Bernoulli beam" using the `Hermite{RefLine, 3}` interpolation from #1391 (stacked on that PR).

- First tutorial with a 1D grid, `update_hessians = true` assembly (`shape_hessian`), and a fourth-order problem; shows applying a point load and a point **moment** directly to dofs.
- Cantilever with distributed load + tip load + tip moment, compared against the analytic solution on a 4-element mesh to showcase nodal exactness; second figure shows the bending moment via `function_hessian`.
- Figures rendered inline with Plots.jl; thumbnails generated via a new Julia-rendered path in `generate_screenshots.jl` (no ParaView needed for this example).
- Inserted as Tutorial 3 (after linear elasticity); later tutorials renumbered, including cross-references in topics/gallery pages.

Full local docs build passes. Note: the thumbnail assets must be on `gh-pages` for docs CI to pass (uploaded via `docs/generate_screenshots.jl euler_bernoulli_beam --upload`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)