### PR TITLE
Fix ProjectedDirichlet dof lookup for non-first fields and make its projection kernel allocation-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
  - `FacetIterator` now works with `AbstractVector{FacetIndex}` and `AbstractSet{FacetIndex}` inputs as documented, instead of requiring an `OrderedSet` ([#1384])
+ - `ProjectedDirichlet` now updates the correct dofs when the constrained field is not the first
+   field in the `DofHandler`; previously the dof lookup ignored the field offset in the cell dof
+   vector (typically causing a `KeyError` during `update!`) ([#1393])
 
 ## [v1.5.0] - 2026-07-13
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1964,8 +1964,11 @@ function _update_projected_dbc!(
         reinit!(fv, fc)
         shape_nrs = dirichlet_facetdof_indices(ip)[getcurrentfacet(fv)]
         solve_projected_dbc!(aᶠ, Kᶠ, fᶠ, f, fv, shape_nrs, getcoordinates(fc), time)
-        for (idof, shape_nr) in enumerate(shape_nrs)
-            globaldof = celldofs(fc)[shape_nr]
+        # facet_dofs (unlike shape_nrs) includes the field offset in the cell dof vector,
+        # which matters when the constrained field is not the first field in the SubDofHandler.
+        local_dofs = facet_dofs[getcurrentfacet(fv)]
+        for idof in eachindex(shape_nrs)
+            globaldof = celldofs(fc)[local_dofs[idof]]
             dbc_index = dofmapping[globaldof]
             # Only DBC dofs are currently update!-able so don't modify inhomogeneities
             # for affine constraints

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1952,9 +1952,9 @@ end
 
 
 function _update_projected_dbc!(
-        inhomogeneities::Vector{T}, f::Function, facets::AbstractVecOrSet{FacetIndex}, fv::FacetValues, facet_dofs::ArrayOfVectorViews,
+        inhomogeneities::Vector{T}, f::F, facets::AbstractVecOrSet{FacetIndex}, fv::FacetValues, facet_dofs::ArrayOfVectorViews,
         dh::AbstractDofHandler, dofmapping::Dict{Int, Int}, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T}}}, time::Real
-    ) where {T}
+    ) where {T, F <: Function}
     ip = get_base_interpolation(function_interpolation(fv)) # Ensures getting error message from `integrate_projected_dbc!`
     max_dofs_per_facet = maximum(length, dirichlet_facetdof_indices(ip))
     Kᶠ = zeros(max_dofs_per_facet, max_dofs_per_facet)
@@ -1980,7 +1980,33 @@ function _update_projected_dbc!(
     return nothing
 end
 
-function solve_projected_dbc!(aᶠ, Kᶠ, fᶠ, bc_fun, fv, shape_nrs, cell_coords, time)
+# Solve x = K \ b for a small symmetric positive definite K (a Gram matrix from
+# an L2 projection): closed form for the common 1x1 and 2x2 cases, otherwise
+# in-place Cholesky, to avoid allocations.
+function solve_small_spd!(x::AbstractVector, K::AbstractMatrix, b::AbstractVector)
+    n = length(x)
+    if n == 1
+        x[1] = b[1] / K[1, 1]
+    elseif n == 2
+        # Unrolled Cholesky (K = LLᵀ) with forward/backward substitution. Unlike
+        # Cramer's rule this does not form products of matrix entries, so it does
+        # not overflow/underflow for extreme (but representable) entry magnitudes.
+        L11 = sqrt(K[1, 1])
+        L21 = K[2, 1] / L11
+        L22 = sqrt(K[2, 2] - L21^2)
+        y1 = b[1] / L11
+        y2 = (b[2] - L21 * y1) / L22
+        x[2] = y2 / L22
+        x[1] = (y1 - L21 * x[2]) / L11
+    else
+        ldiv!(x, cholesky!(Symmetric(K)), b)
+    end
+    return x
+end
+
+# Note: the `bc_fun::F` type parameters force specialization on the function argument in
+# the methods that only pass it through (otherwise the inner call is a dynamic dispatch).
+function solve_projected_dbc!(aᶠ, Kᶠ, fᶠ, bc_fun::F, fv, shape_nrs, cell_coords, time) where {F}
     fill!(Kᶠ, 0)
     fill!(fᶠ, 0)
     # Supporting varying number of facetdofs (for ref shapes with different facet types) requires
@@ -1989,11 +2015,11 @@ function solve_projected_dbc!(aᶠ, Kᶠ, fᶠ, bc_fun, fv, shape_nrs, cell_coor
     # end
     @assert length(shape_nrs) == size(Kᶠ, 1)
     integrate_projected_dbc!(Kᶠ, fᶠ, bc_fun, fv, shape_nrs, cell_coords, time)
-    aᶠ .= Kᶠ \ fᶠ # Could be done non-allocating if required, using e.g. SMatrix
+    solve_small_spd!(aᶠ, Kᶠ, fᶠ)
     return aᶠ
 end
 
-function integrate_projected_dbc!(Kᶠ, fᶠ, bc_fun, fv, shape_nrs, cell_coords, time)
+function integrate_projected_dbc!(Kᶠ, fᶠ, bc_fun::F, fv, shape_nrs, cell_coords, time) where {F}
     return integrate_projected_dbc!(conformity(fv), Kᶠ, fᶠ, bc_fun, fv, shape_nrs, cell_coords, time)
 end
 

--- a/src/Ferrite.jl
+++ b/src/Ferrite.jl
@@ -8,7 +8,7 @@ using Base:
 using EnumX:
     EnumX, @enumx
 using LinearAlgebra:
-    LinearAlgebra, Symmetric, cholesky, det, norm, tr, mul!, normalize
+    LinearAlgebra, Symmetric, cholesky, cholesky!, det, ldiv!, norm, tr, mul!, normalize
 using NearestNeighbors:
     NearestNeighbors, KDTree, knn
 using OrderedCollections:

--- a/test/test_interpolations_hcurl_hdiv.jl
+++ b/test/test_interpolations_hcurl_hdiv.jl
@@ -409,6 +409,39 @@ using Ferrite: reference_shape_value
         end
     end
 
+    @testset "ProjectedDirichlet in mixed DofHandler" begin
+        # Regression test: the constrained field is not the first field in the
+        # DofHandler, so its facet dofs are offset in the cell dof vector.
+        for ip in (RaviartThomas{RefTriangle, 2}(), Nedelec{RefTriangle, 2}())
+            grid = generate_grid(Triangle, (2, 2))
+            transform_coordinates!(grid, x -> x + 0.1 * Vec(abs(x[2])^2, abs(x[1])^2))
+            facetset = getfacetset(grid, "right")
+            f_bc = if Ferrite.conformity(ip) isa Ferrite.HdivConformity
+                (x, t, n) -> x[1] + 2 * x[2]
+            else
+                (x, t, n) -> Vec(0.0, 0.0, x[1] + 2 * x[2])
+            end
+            function solve_with_fields(fields...)
+                dh = DofHandler(grid)
+                for (name, field_ip) in fields
+                    add!(dh, name, field_ip)
+                end
+                close!(dh)
+                ch = close!(add!(ConstraintHandler(dh), ProjectedDirichlet(:u, facetset, f_bc)))
+                a = zeros(ndofs(dh))
+                apply!(a, ch)
+                return dh, a
+            end
+            dh_single, a_single = solve_with_fields((:u, ip))
+            dh_mixed, a_mixed = solve_with_fields((:p, Lagrange{RefTriangle, 1}()), (:u, ip))
+            for (cellidx, _) in facetset
+                dofs_single = celldofs(dh_single, cellidx)[dof_range(dh_single.subdofhandlers[1], :u)]
+                dofs_mixed = celldofs(dh_mixed, cellidx)[dof_range(dh_mixed.subdofhandlers[1], :u)]
+                @test a_mixed[dofs_mixed] ≈ a_single[dofs_single]
+            end
+        end
+    end
+
     @testset "ProjectedDirichlet error path" begin
         dh_H1, _ = _setup_dh_fv_for_bc_test(Lagrange{RefTriangle, 1}()^2; nel = 1, qr_order = 1)
         dh_L2, _ = _setup_dh_fv_for_bc_test(DiscontinuousLagrange{RefTriangle, 1}()^2; nel = 1, qr_order = 1)

--- a/test/test_interpolations_hcurl_hdiv.jl
+++ b/test/test_interpolations_hcurl_hdiv.jl
@@ -409,6 +409,31 @@ using Ferrite: reference_shape_value
         end
     end
 
+    @testset "solve_small_spd!" begin
+        # The 1x1/2x2 fast paths must be scale-safe: forming products of the
+        # matrix entries (e.g. Cramer's rule) would overflow for these scales.
+        for T in (Float32, Float64)
+            overflow_scale = T == Float32 ? T(1.0e20) : 1.0e160
+            for scale in (T(1) / overflow_scale, T(1), overflow_scale)
+                K2 = T[2 1 / 2; 1 / 2 1] .* scale
+                x_exact = T[1, -2]
+                b = K2 * x_exact
+                x = zeros(T, 2)
+                Ferrite.solve_small_spd!(x, copy(K2), b)
+                @test x ≈ x_exact rtol = sqrt(eps(T))
+                K1 = fill(scale, 1, 1)
+                Ferrite.solve_small_spd!(view(x, 1:1), K1, T[3scale])
+                @test x[1] ≈ 3 rtol = sqrt(eps(T))
+            end
+        end
+        # Generic (Cholesky) path against `\`
+        M = [2.0 0.5 0.1; 0.5 1.0 0.2; 0.1 0.2 3.0]
+        b3 = [1.0, -2.0, 0.5]
+        x3 = zeros(3)
+        Ferrite.solve_small_spd!(x3, copy(M), copy(b3))
+        @test x3 ≈ M \ b3
+    end
+
     @testset "ProjectedDirichlet in mixed DofHandler" begin
         # Regression test: the constrained field is not the first field in the
         # DofHandler, so its facet dofs are offset in the cell dof vector.


### PR DESCRIPTION
Two changes to `ProjectedDirichlet`, split into separate commits:

## Bug fix

`_update_projected_dbc!` looked up global dofs as `celldofs(fc)[shape_nr]`, where `shape_nr` indexes the constrained field's interpolation *without* the field offset in the cell dof vector. For a `DofHandler` where the projected field is not the first field, `update!` therefore resolved dofs belonging to other fields (typically erroring with a `KeyError` in the `dofmapping` lookup). The fix uses the `facet_dofs` views — which are built with `field_offset` at `add!` time and were already passed in, but unused — for the global dof lookup. Includes a regression test with the projected field as the second field, for both H(div) and H(curl).

## Performance

The per-facet projection solve is now allocation-free:

- The small SPD facet systems are solved in closed form for the common 1x1 and 2x2 cases (2x2 via unrolled Cholesky, which unlike Cramer's rule does not form products of matrix entries and is therefore scale-safe; covered by unit tests at entry scales where such products would overflow/underflow), and with in-place Cholesky otherwise, instead of allocating an LU factorization per facet.
- The methods that only pass the boundary-condition function through now force specialization on it (`bc_fun::F ... where F`). Julia does not specialize on `Function`-typed arguments that are never called in the method body, which made the inner kernel call a dynamic dispatch per facet, boxing the isbits `shape_nrs` tuple argument.

Note on failure modes: for degenerate input (near-singular or indefinite `K` from e.g. degenerate geometry), the Cholesky-based solves raise `PosDefException`/`DomainError` where pivoted LU might previously have returned a (garbage) result quietly. Valid SPD Gram matrices are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)