### PR TITLE
Add a manually dispatched runner-noise experiment for the benchmark CI

### DIFF
--- a/.github/workflows/RunnerNoise.yml
+++ b/.github/workflows/RunnerNoise.yml
@@ -1,0 +1,127 @@
+# One-off experiment (manual dispatch only): measure how noisy each GitHub-hosted runner
+# type is for the benchmark suite, to pick the runner for Benchmarks.yml empirically.
+#
+# Each matrix job runs the suite `passes` times at the SAME commit via Tachometer's
+# per-revision runner (fresh worktree + subprocess + tuning per pass, exactly like a
+# production pass). Since the code is identical, any change Tachometer's policy would
+# flag is a false positive. The analyze job aggregates everything into a per-runner
+# noise profile in the workflow step summary; benchmark/runner-noise/analyze.jl can
+# also be rerun locally on the downloaded artifacts to try other tolerance policies.
+#
+# NOTE: workflow_dispatch only lists workflows that exist on the default branch, so
+# this file must land on master before it can be dispatched.
+name: RunnerNoise
+
+on:
+  workflow_dispatch:
+    inputs:
+      runners:
+        description: "JSON array of runner labels to profile"
+        default: '["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]'
+      reps:
+        description: "Independent jobs per runner label (job-to-job variation)"
+        default: '5'
+      passes:
+        description: "Suite runs per job; each disjoint block of 4 simulates one nruns=2 comparison"
+        default: '8'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-noise
+  cancel-in-progress: false
+
+jobs:
+  # workflow_dispatch inputs cannot parameterize a matrix directly for the rep count,
+  # so a tiny setup job turns `reps` into a JSON list for fromJSON below.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      reps: ${{ steps.mk.outputs.reps }}
+    steps:
+      - id: mk
+        env:
+          REPS: ${{ inputs.reps }}
+        run: echo "reps=$(seq -s, 1 "$REPS" | sed 's/.*/[&]/')" >> "$GITHUB_OUTPUT"
+
+  measure:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(inputs.runners) }}
+        rep: ${{ fromJSON(needs.plan.outputs.reps) }}
+    name: measure (${{ matrix.runner }} #${{ matrix.rep }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same source as Benchmarks.yml uses for the action; run_revision is called
+      # directly here (via collect.jl) instead of the compare entrypoint.
+      - uses: actions/checkout@v7
+        with:
+          repository: KristofferC/Tachometer.jl
+          ref: main
+          path: .tachometer-src
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+
+      - name: Run the suite ${{ inputs.passes }} times at ${{ github.sha }}
+        env:
+          RUNNER_LABEL: ${{ matrix.runner }}
+          RUNNER_REP: ${{ matrix.rep }}
+          NOISE_PASSES: ${{ inputs.passes }}
+          NOISE_OUT: runner-noise-${{ matrix.runner }}-${{ matrix.rep }}.json
+        run: |
+          julia --color=yes -e '
+            using Pkg
+            Pkg.activate(; temp = true)
+            Pkg.develop(PackageSpec(path = ".tachometer-src"))
+            Pkg.add("JSON")
+            Pkg.instantiate()
+            include("benchmark/runner-noise/collect.jl")
+          '
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runner-noise-${{ matrix.runner }}-${{ matrix.rep }}
+          path: runner-noise-*.json
+          retention-days: 30
+
+  analyze:
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: runner-noise-*
+          path: results
+          merge-multiple: true
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
+      - name: Aggregate into the step summary
+        run: |
+          julia --color=yes -e '
+            using Pkg
+            Pkg.activate(; temp = true)
+            Pkg.add("JSON")
+            include("benchmark/runner-noise/analyze.jl")
+          '
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runner-noise-summary
+          path: summary.md
+          retention-days: 30

--- a/benchmark/runner-noise/analyze.jl
+++ b/benchmark/runner-noise/analyze.jl
@@ -1,0 +1,111 @@
+# Aggregate the collect.jl outputs of the runner-noise experiment into a per-runner
+# noise profile, written as markdown. Reads every *.json in NOISE_RESULTS (default
+# "results") and writes NOISE_SUMMARY (default "summary.md").
+#
+# All passes in a job measured the same commit, so:
+#   * "pair |Δ|" — relative time change between consecutive passes, the raw
+#     run-to-run jitter of a benchmark on that runner. Only changes that clear the
+#     production 1 µs floor are counted; sub-floor wiggles can never be flagged.
+#   * "false flags" — the production Tachometer policy (5% tolerance, 1 µs floor,
+#     nruns=2 with both pairs required to agree) replayed on consecutive blocks of
+#     4 passes: (b₁ t₁ b₂ t₂). Every flag is a false positive by construction.
+#   * "zero-FP tol" — the smallest tolerance at which this data would have produced
+#     no false flags under the nruns=2 policy: the largest direction-consistent,
+#     floor-clearing excess that any benchmark showed in both pairs of a block.
+#   * "drift" — per pass, the median time ratio against pass 1 across all
+#     benchmarks: whole-machine speed change within a job (tenancy/thermal), which
+#     interleaving alone cannot fully absorb.
+
+using JSON
+using Statistics: median, quantile
+using Printf: @sprintf
+
+const TOL = 0.05          # production time tolerance
+const FLOOR_NS = 1000.0   # production time floor
+
+resultsdir = get(ENV, "NOISE_RESULTS", "results")
+outfile = get(ENV, "NOISE_SUMMARY", "summary.md")
+
+jobs = [JSON.parsefile(joinpath(resultsdir, f)) for f in readdir(resultsdir) if endswith(f, ".json")]
+isempty(jobs) && error("no result JSONs found in $(resultsdir)")
+
+pct(x) = @sprintf("%.1f%%", 100 * x)
+
+# The per-pass minimum time of each benchmark, for benchmarks present in every pass.
+function job_times(job)
+    runs = sort(job["runs"]; by = r -> r["pass"])
+    names = intersect([Set(keys(r["estimates"])) for r in runs]...)
+    return Dict(name => [Float64(r["estimates"][name]["time"]) for r in runs] for name in names)
+end
+
+# Production verdict for one simulated comparison from two (baseline, target) pairs:
+# flagged only if both pairs agree in direction, clear the tolerance, and clear the floor.
+function flagged(b1, t1, b2, t2, tol)
+    red(b, t) = t / b > 1 + tol && t - b > FLOOR_NS
+    grn(b, t) = b / t > 1 + tol && b - t > FLOOR_NS
+    return (red(b1, t1) && red(b2, t2)) || (grn(b1, t1) && grn(b2, t2))
+end
+
+# The excess that survives the nruns=2 agreement gate for one block: the smaller of the
+# two pairs' relative changes when both pairs move the same way and clear the floor, else
+# 0. The max of this over all benchmarks/blocks is the tolerance needed for zero flags.
+function agreed_excess(b1, t1, b2, t2)
+    r1, r2 = t1 / b1 - 1, t2 / b2 - 1
+    sign(r1) == sign(r2) || return 0.0
+    min(abs(t1 - b1), abs(t2 - b2)) > FLOOR_NS || return 0.0
+    return min(abs(r1), abs(r2))
+end
+
+rows = String[]
+for runner in sort(unique(j["runner"] for j in jobs))
+    group = filter(j -> j["runner"] == runner, jobs)
+    cpus = sort(unique(j["cpu"] for j in group))
+    walls = [r["wall_s"] for j in group for r in j["runs"]]
+
+    pair_deltas = Float64[]     # |Δ| between consecutive passes, floor-clearing only
+    excesses = Float64[]        # agreement-gated excess per benchmark and block
+    nflags = 0                  # false flags under the production policy
+    ncomparisons = 0            # simulated nruns=2 comparisons
+    drifts = Float64[]          # max whole-suite drift within each job
+
+    for job in group
+        times = job_times(job)
+        n = length(first(values(times)))
+        for t in values(times)
+            for i in 1:(n - 1)
+                abs(t[i + 1] - t[i]) > FLOOR_NS && push!(pair_deltas, abs(t[i + 1] / t[i] - 1))
+            end
+        end
+        for lo in 1:4:(n - 3)  # disjoint blocks of 4 passes: b1 t1 b2 t2
+            ncomparisons += 1
+            for t in values(times)
+                b1, t1, b2, t2 = t[lo], t[lo + 1], t[lo + 2], t[lo + 3]
+                nflags += flagged(b1, t1, b2, t2, TOL)
+                push!(excesses, agreed_excess(b1, t1, b2, t2))
+            end
+        end
+        push!(drifts, maximum(abs(median(t[i] / t[1] for t in values(times)) - 1) for i in 2:n))
+    end
+
+    deltas = isempty(pair_deltas) ? "all < floor" :
+        "$(pct(median(pair_deltas))) / $(pct(quantile(pair_deltas, 0.95))) / $(pct(maximum(pair_deltas)))"
+    push!(
+        rows,
+        "| `$(runner)` | $(length(group)) | $(join(cpus, "<br>")) | $(round(Int, median(walls))) s " *
+            "| $(deltas) " *
+            "| $(nflags) in $(ncomparisons) | $(pct(maximum(excesses))) | $(pct(maximum(drifts))) |"
+    )
+end
+
+open(outfile, "w") do io
+    println(io, "## Runner-noise experiment — same-commit (null) comparisons\n")
+    println(io, "Every flag is a false positive: all passes measured the same commit.\n")
+    println(io, "| Runner | Jobs | CPU(s) | Pass wall | Pair \\|Δt\\| p50/p95/max | False flags @ prod policy | Zero-FP tolerance | Max drift |")
+    println(io, "|:--|--:|:--|--:|:--|:--|--:|--:|")
+    foreach(r -> println(io, r), rows)
+    println(io, "\n- **Pair |Δt|** — run-to-run change of a benchmark between consecutive passes (floor-clearing only).")
+    println(io, "- **False flags @ prod policy** — benchmark flags under the production 5% / 1 µs / nruns=2 rule, per simulated comparisons.")
+    println(io, "- **Zero-FP tolerance** — smallest time tolerance that would have produced no flags on this data (nruns=2).")
+    println(io, "- **Max drift** — largest whole-suite median shift relative to the first pass within a job.")
+end
+println("wrote $(outfile)")

--- a/benchmark/runner-noise/collect.jl
+++ b/benchmark/runner-noise/collect.jl
@@ -1,0 +1,58 @@
+# One measurement job of the runner-noise experiment (.github/workflows/RunnerNoise.yml):
+# run the benchmark suite PASSES times at a single commit and record the raw per-benchmark
+# minima of every pass. Since every pass measures the same code, any difference between
+# passes is runner noise, and the analysis (analyze.jl) can replay any tolerance/nruns
+# policy against it offline.
+#
+# Each pass goes through Tachometer.run_revision, i.e. a fresh worktree + subprocess +
+# BenchmarkTools tuning, so a pass here costs and behaves exactly like a production
+# baseline-or-target run in Benchmarks.yml.
+#
+# Driven by env vars (set by the workflow):
+#   NOISE_REPO    path to the package working copy (default ".")
+#   NOISE_REF     git rev to benchmark (default GITHUB_SHA, else HEAD)
+#   NOISE_PASSES  number of suite runs (default 8)
+#   NOISE_OUT     output JSON path (default "runner-noise.json")
+#   RUNNER_LABEL / RUNNER_REP  identify the matrix job in the output
+
+using Tachometer
+using JSON
+
+repo = get(ENV, "NOISE_REPO", ".")
+ref = get(ENV, "NOISE_REF", get(ENV, "GITHUB_SHA", "HEAD"))
+npasses = parse(Int, get(ENV, "NOISE_PASSES", "8"))
+outfile = get(ENV, "NOISE_OUT", "runner-noise.json")
+
+runs = Vector{Any}()
+for i in 1:npasses
+    println("[runner-noise] pass $(i)/$(npasses)")
+    t0 = time()
+    r = Tachometer.run_revision(repo, ref, "benchmark/benchmarks.jl")
+    r.ok || error("pass $i failed:\n" * r.log)
+    push!(
+        runs, Dict(
+            "pass" => i,
+            "wall_s" => time() - t0,
+            "estimates" => Dict(
+                k => Dict("time" => v.time, "memory" => v.memory, "allocs" => v.allocs)
+                    for (k, v) in r.estimates
+            ),
+        )
+    )
+end
+
+open(outfile, "w") do io
+    JSON.print(
+        io, Dict(
+            "runner" => get(ENV, "RUNNER_LABEL", "unknown"),
+            "rep" => get(ENV, "RUNNER_REP", "0"),
+            "ref" => ref,
+            "julia" => string(VERSION),
+            "os" => string(Sys.KERNEL),
+            "arch" => string(Sys.ARCH),
+            "cpu" => Sys.cpu_info()[1].model,
+            "runs" => runs,
+        ), 2
+    )
+end
+println("[runner-noise] wrote $(outfile)")


### PR DESCRIPTION
Test to see what CI runners are less noisy