### PR TITLE
Move the benchmark CI to ubuntu-24.04-arm and require three agreeing passes

### DIFF
--- a/.github/workflows/BenchmarkTracking.yml
+++ b/.github/workflows/BenchmarkTracking.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.ref_type != 'tag'
     # Must match the runner in Benchmarks.yml: this series is what the PR noise band is derived
     # from, and a series recorded on a different runner says nothing about variance on this one.
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     concurrency:
       group: tachometer-record-${{ github.sha }}

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -23,14 +23,17 @@ concurrency:
 jobs:
   benchmark:
     name: Benchmark
-    # Apple Silicon rather than ubuntu-latest: this suite is single-threaded CPU work, where the
-    # macOS runners are both faster and less noisy than the shared Linux VMs. Keep this in sync
-    # with the `record` job in BenchmarkTracking.yml -- the noise band is derived from that time
-    # series, and variance is a property of the runner.
-    runs-on: macos-latest
-    # A pass is ~40 s locally (~10 s to build the suite, ~30 s to run it), and `nruns: 2`
-    # means four of them, two per revision; the rest of the budget is checkout, package
-    # instantiation and precompilation for both revisions.
+    # Chosen empirically by the RunnerNoise experiment (same-commit null comparisons, 5 jobs x
+    # 8 passes per runner, actions/runs/30251228313): the arm runners had by far the least noise
+    # (run-to-run |dt| p50 0.8% vs 4.4% on macos-latest, whole-suite drift 0.3% vs 6.9%) and a
+    # homogeneous CPU fleet, where macos-latest drifted mid-job and ubuntu-latest mixed three
+    # CPU models across five jobs. Keep this in sync with the `record` job in
+    # BenchmarkTracking.yml -- the noise band is derived from that time series, and variance is
+    # a property of the runner.
+    runs-on: ubuntu-24.04-arm
+    # A pass is ~2 min on this runner, and `nruns: 3` means six of them, three per revision;
+    # the rest of the budget is checkout, package instantiation and precompilation for both
+    # revisions.
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -58,10 +61,11 @@ jobs:
         with:
           julia-version: '1'
           script: benchmark/benchmarks.jl
-          # Two interleaved passes per revision: a regression has to reproduce in both. On a
-          # no-op diff a single pass reported 10 regressions and 13 improvements out of 337
-          # benchmarks, all of them noise.
-          nruns: '2'
+          # Three interleaved passes per revision: a regression has to reproduce in all three.
+          # In the RunnerNoise null comparisons on this runner, nruns=2 still let through 16
+          # false flags in 10 comparisons; nruns=3 left 3, all from the known-bimodal
+          # matrix-from-pattern benchmarks, which the learned noise band absorbs over time.
+          nruns: '3'
           time-tolerance: '0.05'
           time-floor: '1us'
           noise-history: ${{ runner.temp }}/tacho-history/benchmarks/data


### PR DESCRIPTION
## What

Switch `runs-on` from `macos-latest` to `ubuntu-24.04-arm` in `Benchmarks.yml` and `BenchmarkTracking.yml` (they must move together: the PR noise band is derived from the tracking series, and variance is a property of the runner), and bump `nruns` from 2 to 3.

## Why

Decided empirically by the RunnerNoise experiment from #1403 ([run](https://github.com/Ferrite-FEM/Ferrite.jl/actions/runs/30251228313); same-commit null comparisons, so every flag is a false positive):

| Runner | Pair \|Δt\| p50/p95 | False flags (10 null comparisons) | Zero-FP tolerance | Max drift |
|:--|:--|--:|--:|--:|
| `ubuntu-24.04-arm` | 0.8% / 9.4% | 16 | 12.6% | 0.3% |
| `ubuntu-latest` | 2.1% / 16.3% | 29 | 52.2% | 0.5% |
| `macos-latest` (current) | 4.4% / 20.0% | 37 | 20.2% | 6.9% |

On `macos-latest` the false flags were spread across 26 different benchmarks with whole-suite drift up to 6.9% within a job — the shared virtual Mac host speeds up and slows down mid-job, which no per-benchmark noise model can absorb. That is what produced the seven spurious regression flags on #1393 (verified spurious by rerunning the same commit pair locally). `ubuntu-latest` mixed three CPU models (EPYC 7763 / EPYC 9V74 / Xeon 8573C) across its five jobs.

On `ubuntu-24.04-arm` the machine is essentially steady (drift 0.3%) and the residual false flags are concentrated in six benchmarks, dominated by the known-bimodal `sparsity-pattern/matrix-from-pattern/*` family — a suite pathology rather than runner noise. Replaying the raw experiment data with `nruns: 3` leaves only those (3 flags in 5 comparisons vs 6+ scattered ones on macOS), so three agreeing passes are now required.

## Cost and caveats

- A pass is ~2 min on this runner, so `nruns: 3` costs ~12 min of suite time per PR, well inside the 45 min timeout.
- The learned noise model is keyed to the runner regime, so it effectively resets with this switch: expect the flat 5% tolerance (and possibly the bimodal matrix-from-pattern benchmarks flaring) until a few master commits have been recorded on the new runner. Longer term the bimodality is worth fixing in the suite itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
