### PR TITLE
Fixes and guards for interpolations with non-identity mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    Vincent, 2015). This is the same family of rules already used for `RefPrism` and
    `RefPyramid`, and extends tetrahedral quadrature beyond the previous maximum order 5 of
    the Keast rules. ([#1389])
+ - `function_hessian` is now exported (`shape_hessian` already was). ([#1405])
 
 ### Documentation
  - The figures for the documentation are now programmatically generated and made to have a consistent look.
@@ -23,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `ProjectedDirichlet` now updates the correct dofs when the constrained field is not the first
    field in the `DofHandler`; previously the dof lookup ignored the field offset in the cell dof
    vector (typically causing a `KeyError` during `update!`) ([#1393])
+ - `evaluate_at_grid_nodes` (and thus `write_solution`) now returns correct values for
+   interpolations with non-identity mappings by calling `reinit!` internally. ([#1405])
+ - `apply_analytical!`, `Dirichlet` conditions on a nodeset, and `PeriodicDirichlet` now
+   throw an error for interpolations with non-identity mappings (e.g. `Nedelec` and
+   `RaviartThomas`) instead of silently computing wrong values, since the dofs of such
+   interpolations are not nodal function values. ([#1405])
 
 ## [v1.5.0] - 2026-07-13
 

--- a/docs/src/reference/boundary_conditions.md
+++ b/docs/src/reference/boundary_conditions.md
@@ -13,6 +13,7 @@ ConstraintHandler
 Dirichlet
 ProjectedDirichlet
 PeriodicDirichlet
+AffineConstraint
 collect_periodic_facets
 collect_periodic_facets!
 add!

--- a/docs/src/reference/fevalues.md
+++ b/docs/src/reference/fevalues.md
@@ -33,12 +33,14 @@ Furthermore, the following functions are applicable to
 ```@docs
 shape_value(::Ferrite.AbstractValues, ::Int, ::Int)
 shape_gradient(::Ferrite.AbstractValues, ::Int, ::Int)
+shape_hessian(::Ferrite.AbstractValues, ::Int, ::Int)
 shape_symmetric_gradient
 shape_divergence
 shape_curl
 getnbasefunctions(::Ferrite.AbstractValues)
 function_value
 function_gradient
+function_hessian
 function_symmetric_gradient
 function_divergence
 function_curl

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -964,6 +964,11 @@ function add!(ch::ConstraintHandler, dbc::Dirichlet)
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
         if EntityType <: Integer
+            if !(mapping_type(interpolation) isa IdentityMapping)
+                # The node idx -> local dof idx assumption in _add! below does not hold
+                # when dofs are not nodal values (e.g. for H(div)/H(curl) interpolations)
+                throw(ArgumentError("Dirichlet conditions on a nodeset are not supported for $(interpolation), use a facetset or vertexset instead."))
+            end
             # BCValues are just dummy for nodesets so set to FacetIndex
             EntityType = FacetIndex
         end
@@ -1071,6 +1076,11 @@ function add!(ch::ConstraintHandler, pdbc::PeriodicDirichlet)
     n_comp = n_dbc_components(interpolation)
     if interpolation isa VectorizedInterpolation
         interpolation = interpolation.ip
+    end
+    if !(mapping_type(interpolation) isa IdentityMapping)
+        # Would pair only the dofs from dirichlet_facetdof_indices (which may not be all
+        # dofs on the facet) and lacks mirror_local_dofs methods
+        throw(ArgumentError("PeriodicDirichlet is not supported for $(interpolation)."))
     end
 
     if !all(c -> 0 < c <= n_comp, pdbc.components)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -1022,8 +1022,11 @@ function _evaluate_at_grid_nodes!(
         u::AbstractVector{T}, cv::CellValues, drange::UnitRange
     ) where {T}
     ue = zeros(T, length(drange))
+    # For identity mappings the physical shape values alias the reference values, but other
+    # mappings require reinit! to compute them
+    needs_reinit = !isa(mapping_type(function_interpolation(cv)), IdentityMapping)
     for cell in CellIterator(sdh)
-        # Note: We are only using the shape functions: no reinit!(cv, cell) necessary
+        needs_reinit && reinit!(cv, cell)
         @assert getnquadpoints(cv) == length(cell.nodes)
         for (i, I) in pairs(drange)
             ue[i] = u[cell.dofs[I]]

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -34,6 +34,18 @@ function apply_analytical!(
     fieldname ∉ getfieldnames(dh) && error("The fieldname $fieldname was not found in the dof handler")
     ip_geos = _geometric_interpolations(dh)
 
+    # Check all field interpolations before mutating `a` to avoid partial application
+    for sdh in dh.subdofhandlers
+        isnothing(_find_field(sdh, fieldname)) && continue
+        ip_fun = getfieldinterpolation(sdh, find_field(sdh, fieldname))
+        if !(mapping_type(ip_fun) isa IdentityMapping)
+            error(
+                "apply_analytical! is only supported for interpolations where the dof values " *
+                    "are function values at the nodes (identity mapping), got $(ip_fun)."
+            )
+        end
+    end
+
     for (sdh, ip_geo) in zip(dh.subdofhandlers, ip_geos)
         isnothing(_find_field(sdh, fieldname)) && continue
         field_idx = find_field(sdh, fieldname)

--- a/src/FEValues/common_values.jl
+++ b/src/FEValues/common_values.jl
@@ -130,6 +130,14 @@ quadrature point `q_point`.
 shape_gradient(fe_v::AbstractValues, q_point::Int, base_function::Int)
 
 """
+    shape_hessian(fe_v::AbstractValues, q_point::Int, base_function::Int)
+
+Return the hessian of shape function `base_function` evaluated in quadrature point
+`q_point`. Requires the `AbstractValues` to be constructed with `update_hessians = true`.
+"""
+shape_hessian(fe_v::AbstractValues, q_point::Int, base_function::Int)
+
+"""
     shape_symmetric_gradient(fe_v::AbstractValues, q_point::Int, base_function::Int)
 
 Return the symmetric gradient of shape function `base_function` evaluated in
@@ -257,10 +265,11 @@ function function_gradient_init(cv::AbstractValues, ::AbstractVector{T}) where {
 end
 
 """
-    function_hessian(fe_v::AbstractValues{dim}, q_point::Int, u::AbstractVector{<:AbstractFloat}, [dof_range])
+    function_hessian(fe_v::AbstractValues, q_point::Int, u::AbstractVector, [dof_range])
 
-    Compute the hessian of the function in a quadrature point. `u` is a vector with values
-    for the degrees of freedom.
+Compute the hessian of the function in a quadrature point. `u` is a vector with values
+for the degrees of freedom. Requires the `AbstractValues` to be constructed with
+`update_hessians = true`.
 """
 function function_hessian(fe_v::AbstractValues, q_point::Int, u::AbstractVector, dof_range = eachindex(u))
     n_base_funcs = getnbasefunctions(fe_v)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -44,6 +44,7 @@ export
     shape_curl,
     function_value,
     function_gradient,
+    function_hessian,
     function_symmetric_gradient,
     function_divergence,
     function_curl,

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -169,3 +169,16 @@ using LinearAlgebra
         @test_throws ErrorException apply_analytical!(zeros(ndofs(mdh)), mdh, :u, x -> 0.0)  # Should be f(x)::Vec{2}
     end
 end
+
+@testset "apply_analytical! errors for non-identity mappings" begin
+    # The dofs of e.g. H(curl) interpolations are not nodal function values, so assigning
+    # f(x) to them directly would silently compute wrong values.
+    grid = generate_grid(Triangle, (2, 2))
+    dh = DofHandler(grid)
+    add!(dh, :A, Nedelec{RefTriangle, 1}())
+    close!(dh)
+    a = rand(ndofs(dh))
+    a0 = copy(a)
+    @test_throws ErrorException apply_analytical!(a, dh, :A, x -> zero(Vec{2}))
+    @test a == a0 # `a` must not be partially modified
+end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1683,3 +1683,16 @@ end # testset
     close!(ch)
     @test_throws ErrorException("condensation of ::Symmetric matrix not supported") apply!(K2, f2, ch)
 end
+
+@testset "errors for non-identity mappings" begin
+    # The dofs of e.g. H(curl) interpolations are not nodal function values, so the
+    # node idx -> dof idx assumption for nodeset conditions does not hold, and
+    # PeriodicDirichlet would pair only the dirichlet_facetdof_indices dofs.
+    grid = generate_grid(Triangle, (2, 2))
+    dh = DofHandler(grid)
+    add!(dh, :A, Nedelec{RefTriangle, 1}())
+    close!(dh)
+    ch = ConstraintHandler(dh)
+    @test_throws ArgumentError add!(ch, Dirichlet(:A, Set([1]), Returns(0.0))) # nodeset
+    @test_throws ArgumentError add!(ch, PeriodicDirichlet(:A, Ferrite.PeriodicFacetPair[]))
+end

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -802,3 +802,27 @@ end
     #Shared face dof
     @test dofsshell[9] == 24
 end
+
+@testset "evaluate_at_grid_nodes for non-identity mappings" begin
+    # Regression test for the missing reinit! (would return garbage from an undef buffer).
+    # Single cell: at shared nodes an H(curl) field is multi-valued (last-writer-wins),
+    # so only a single-cell grid has well-defined expected values.
+    grid = Grid([Triangle((1, 2, 3))], [Node(Vec((0.0, 0.0))), Node(Vec((1.0, 0.0))), Node(Vec((0.0, 1.0)))])
+    ip = Nedelec{RefTriangle, 1}()
+    dh = DofHandler(grid)
+    add!(dh, :A, ip)
+    close!(dh)
+    u = rand(ndofs(dh))
+    vals = evaluate_at_grid_nodes(dh, u, :A)
+    ip_geo = Lagrange{RefTriangle, 1}()
+    ref_coords = Ferrite.reference_coordinates(ip_geo)
+    qr = QuadratureRule{RefTriangle}(zeros(length(ref_coords)), ref_coords)
+    cv = CellValues(qr, ip, ip_geo^2; update_gradients = false, update_detJdV = false)
+    for cc in CellIterator(dh)
+        reinit!(cv, cc)
+        ue = u[celldofs(cc)]
+        for (qp, nodeid) in pairs(cc.nodes)
+            @test vals[nodeid] ≈ function_value(cv, qp, ue)
+        end
+    end
+end


### PR DESCRIPTION
Pulled out of #1391 since these fixes are independent of the new Hermite interpolation:

- **Fix `evaluate_at_grid_nodes`** (and thus `write_solution`) returning garbage (values from an undef buffer) for interpolations with non-identity mappings (e.g. `Nedelec`, `RaviartThomas`), by calling `reinit!` internally when the mapping requires it. Includes a regression test.
- **`apply_analytical!`** now errors up front for interpolations whose dofs are not nodal function values, instead of silently assigning `f(x)` to non-nodal dofs. The check runs before any mutation of `a`, so the vector is never partially modified.
- **`Dirichlet` on a nodeset** now throws a friendly `ArgumentError` for such interpolations (previously an obscure `MethodError` from `BCValues`/`reference_coordinates`), since the node-index → local-dof assumption does not hold for non-nodal dofs.
- **`PeriodicDirichlet`** now throws for such interpolations, since it would pair only the `dirichlet_facetdof_indices` dofs and lacks `mirror_local_dofs` methods.
- **Docs**: export `function_hessian` (`shape_hessian` already was), fix its docstring formatting, add the missing `shape_hessian` docstring, add both to the FEValues reference page, and add `AffineConstraint` to the boundary conditions reference page.

#1391 will be rebased on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)