### PR TITLE
assembler: report the missing row in the sparsity pattern error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `ProjectedDirichlet` now updates the correct dofs when the constrained field is not the first
    field in the `DofHandler`; previously the dof lookup ignored the field offset in the cell dof
    vector (typically causing a `KeyError` during `update!`) ([#1393])
+ - The error thrown when assembling into a matrix entry that is missing from the sparsity
+   pattern now reports the row that is actually missing, rather than an unrelated row that
+   happened to be stored in the same column ([#1414])
 
 ## [v1.5.0] - 2026-07-13
 
@@ -1196,3 +1199,4 @@ poking into Ferrite internals:
 [#1228]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1228
 [#1235]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1235
 [#1389]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1389
+[#1414]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1414

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -359,7 +359,7 @@ end
             else # Krow > Kerow_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Krow, Kcol)
+                iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof, Kcol)
                 # Advance the local matrix row pointer
                 ri += 1
             end

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -207,8 +207,8 @@ end
     @test_throws errr(2, 1) assemble!(a, [1, 2], [1.0 0.0; 3.0 4.0])
     @test_throws errr(2, 1) assemble!(a, [2, 1], [1.0 2.0; 0.0 4.0])
     ## Errors above diagonal
-    @test_throws errr(2, 2) assemble!(a, [1, 2], [1.0 2.0; 0.0 4.0])
-    @test_throws errr(2, 2) assemble!(as, [1, 2], [1.0 2.0; 0.0 4.0])
-    @test_throws errr(2, 2) assemble!(a, [2, 1], [1.0 0.0; 3.0 4.0])
-    @test_throws errr(2, 2) assemble!(as, [2, 1], [1.0 0.0; 3.0 4.0])
+    @test_throws errr(1, 2) assemble!(a, [1, 2], [1.0 2.0; 0.0 4.0])
+    @test_throws errr(1, 2) assemble!(as, [1, 2], [1.0 2.0; 0.0 4.0])
+    @test_throws errr(1, 2) assemble!(a, [2, 1], [1.0 0.0; 3.0 4.0])
+    @test_throws errr(1, 2) assemble!(as, [2, 1], [1.0 0.0; 3.0 4.0])
 end


### PR DESCRIPTION
When the assembly merge walk finds no entry in the global matrix for a local row, it reported `Krow` — the row the global matrix pointer happened to be sitting on — rather than `Kerow_dof`, the row that is actually missing from the pattern.

For an element writing `K[1, 2]` into a matrix whose column 2 only stores row 2, the error named `K[2, 2]`, an entry that exists and is perfectly assemblable. That sends you looking at the wrong dof.

The "remaining entries in this column" loop immediately below already reports `sortedrowdofs[i]` correctly, so this only affects the case where the missing row is followed by a stored row in the same column.

Four expectations in `test_assemble.jl` encoded the old behaviour; in all four the missing entry is `K[1, 2]` and was reported as `K[2, 2]`.

Split out of #1395, where it was noticed while adding a second lookup path to `_assemble_inner!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)