### PR TITLE
docs: zero local matrices/vectors outside the element routine

### DIFF
--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -190,11 +190,9 @@ end;
 # The function to assemble the element stiffness matrix for each element in the mesh now has a block structure like in
 # `incompressible_elasticity`.
 function assemble_element!(Ke, fe, cell, cellvalues, mp, ue, pe)
-    ## Reinitialize cell values, and reset output arrays
+    ## Reinitialize cell values
     ublock, pblock = 1, 2
     reinit!(cellvalues, cell)
-    fill!(Ke, 0.0)
-    fill!(fe, 0.0)
 
     n_basefuncs_u = getnbasefunctions(cellvalues.u)
     n_basefuncs_p = getnbasefunctions(cellvalues.p)
@@ -270,6 +268,8 @@ function assemble_global!(
         @assert size(global_dofs, 1) == nu + np # sanity check
         ue = w[global_dofsu] # displacement dofs for the current cell
         pe = w[global_dofsp] # pressure dofs for the current cell
+        fill!(ke, 0.0)
+        fill!(fe, 0.0)
         assemble_element!(ke, fe, cell, cellvalues, mp, ue, pe)
         assemble!(assembler, global_dofs, ke, fe)
     end

--- a/docs/src/literate-howto/threaded_assembly.jl
+++ b/docs/src/literate-howto/threaded_assembly.jl
@@ -96,8 +96,6 @@ create_example_2d_grid()
 
 ## Element routine
 function assemble_cell!(Ke::Matrix, fe::Vector, cellvalues::CellValues, C::SymmetricTensor, b::Vec)
-    fill!(Ke, 0)
-    fill!(fe, 0)
     for q_point in 1:getnquadpoints(cellvalues)
         dΩ = getdetJdV(cellvalues, q_point)
         for i in 1:getnbasefunctions(cellvalues)
@@ -240,6 +238,8 @@ function assemble_global!(
             ## Reinitialize the cell cache and then the cellvalues
             reinit!(cell_cache, cellidx)
             reinit!(cellvalues, cell_cache)
+            fill!(Ke, 0)
+            fill!(fe, 0)
             ## Compute the local contribution of the cell
             assemble_cell!(Ke, fe, cellvalues, C, b)
             ## Assemble local contribution
@@ -266,6 +266,8 @@ nothing # hide
 #         # Reinitialize the cell cache and then the cellvalues
 #         reinit!(cell_cache, cellidx)
 #         reinit!(cellvalues, cell_cache)
+#         fill!(Ke, 0)
+#         fill!(fe, 0)
 #         # Compute the local contribution of the cell
 #         assemble_cell!(Ke, fe, cellvalues, C, b)
 #         # Assemble local contribution

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -205,9 +205,6 @@ close!(ch);
 
 function assemble_element!(Ke::Matrix, fe::Vector, cellvalues::CellValues)
     n_basefuncs = getnbasefunctions(cellvalues)
-    ## Reset to 0
-    fill!(Ke, 0)
-    fill!(fe, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(cellvalues)
         ## Quadrature weight
@@ -230,8 +227,6 @@ function assemble_element!(Ke::Matrix, fe::Vector, cellvalues::CellValues)
 end
 
 function assemble_interface!(Ki::Matrix, iv::InterfaceValues, μ::Float64)
-    ## Reset to 0
-    fill!(Ki, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(iv)
         ## Get the normal to facet A
@@ -257,8 +252,6 @@ function assemble_interface!(Ki::Matrix, iv::InterfaceValues, μ::Float64)
 end
 
 function assemble_boundary!(fe::Vector, fv::FacetValues)
-    ## Reset to 0
-    fill!(fe, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(fv)
         ## Get the normal to facet A
@@ -295,6 +288,8 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
     for cell in CellIterator(dh)
         ## Reinitialize cellvalues for this cell
         reinit!(cellvalues, cell)
+        fill!(Ke, 0)
+        fill!(fe, 0)
         ## Compute volume integral contribution
         assemble_element!(Ke, fe, cellvalues)
         ## Assemble Ke and fe into K and f
@@ -309,6 +304,7 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
         hₑ = getdiameter(interfacecoords)
         ## Calculate μ
         μ = (1 + order)^dim / hₑ
+        fill!(Ki, 0)
         ## Compute interface surface integrals contribution
         assemble_interface!(Ki, interfacevalues, μ)
         ## Assemble Ki into K
@@ -318,6 +314,7 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
     for fc in FacetIterator(dh, ∂Ωₙ)
         ## Reinitialize facetvalues for this boundary facet
         reinit!(facetvalues, fc)
+        fill!(fe, 0)
         ## Compute boundary facet surface integrals contribution
         assemble_boundary!(fe, facetvalues)
         ## Assemble fe into f

--- a/docs/src/literate-tutorials/hyperelasticity.jl
+++ b/docs/src/literate-tutorials/hyperelasticity.jl
@@ -239,10 +239,8 @@ nothing                                                       #src
 # as usual, with loops over quadrature points and shape functions:
 
 function assemble_element!(ke, ge, cell, cv, fv, mp, ue, ΓN)
-    ## Reinitialize cell values, and reset output arrays
+    ## Reinitialize cell values
     reinit!(cv, cell)
-    fill!(ke, 0.0)
-    fill!(ge, 0.0)
 
     b = Vec{3}((0.0, -0.5, 0.0)) # Body force
     tn = 0.1 # Traction (to be scaled with surface normal)
@@ -311,6 +309,8 @@ function assemble_global!(K, g, dh, cv, fv, mp, u, ΓN)
     @timeit "assemble" for cell in CellIterator(dh)
         global_dofs = celldofs(cell)
         ue .= @view u[global_dofs] # element dofs
+        fill!(ke, 0.0)
+        fill!(ge, 0.0)
         @timeit "element assemble" assemble_element!(ke, ge, cell, cv, fv, mp, ue, ΓN)
         assemble!(assembler, global_dofs, ke, ge)
     end

--- a/docs/src/literate-tutorials/reactive_surface.jl
+++ b/docs/src/literate-tutorials/reactive_surface.jl
@@ -98,8 +98,6 @@ function assemble_element_mass!(Me::Matrix, cellvalues::CellValues)
     r₂range = 2:num_reactants:(num_reactants * n_basefuncs)
     Me₁ = @view Me[r₁range, r₁range]
     Me₂ = @view Me[r₂range, r₂range]
-    ## Reset to 0
-    fill!(Me, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(cellvalues)
         ## Get the quadrature weight
@@ -129,8 +127,6 @@ function assemble_element_diffusion!(De::Matrix, cellvalues::CellValues, materia
     r₂range = 2:num_reactants:(num_reactants * n_basefuncs)
     De₁ = @view De[r₁range, r₁range]
     De₂ = @view De[r₂range, r₂range]
-    ## Reset to 0
-    fill!(De, 0)
     ## Loop over quadrature points
     for q_point in 1:getnquadpoints(cellvalues)
         ## Get the quadrature weight
@@ -164,6 +160,8 @@ function assemble_matrices!(M::SparseMatrixCSC, D::SparseMatrixCSC, cellvalues::
     for cell in CellIterator(dh)
         ## Reinitialize cellvalues for this cell
         reinit!(cellvalues, cell)
+        fill!(Me, 0)
+        fill!(De, 0)
         ## Compute element contribution
         assemble_element_mass!(Me, cellvalues)
         assemble!(M_assembler, celldofs(cell), Me)


### PR DESCRIPTION
Most tutorials follow the pattern of resetting the local arrays (`Ke`, `fe`, `re`, ...) in the assembly loop and letting the element routine only *accumulate* into them. A few examples did the `fill!`ing inside the element routine instead, which is inconsistent and a bad thing to copy from the docs (it makes the element routine unusable for accumulating multiple contributions into the same local arrays).

Moved the zeroing out to the caller in:

- `reactive_surface.jl` (`assemble_element_mass!`, `assemble_element_diffusion!`)
- `dg_heat_equation.jl` (`assemble_element!`, `assemble_interface!`, `assemble_boundary!`)
- `hyperelasticity.jl` (`assemble_element!`)
- `quasi_incompressible_hyperelasticity.jl` (`assemble_element!`)
- `threaded_assembly.jl` (`assemble_cell!`, including the commented-out `tforeach` variant)

The rest of the tutorials, gallery and how-to examples were checked and already zero in the assembly loop.

All touched examples were run locally and give unchanged results (the reference `norm(u)` checks in `dg_heat_equation` and `hyperelasticity` pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)