### PR TITLE
fix: support mapped interpolations in PointValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - New tutorial: Elastodynamics and modal analysis of a cantilever beam (mass matrix, generalized eigenvalue problem, Rayleigh damping, Newmark time integration).
 
 ### Fixes
+ - `PointValues` can now be reinitialized with the current cell, enabling evaluation of
+   interpolations with non-identity mappings such as Nedelec and Raviart-Thomas elements.
+   ([#1420])
  - `FacetIterator` now works with `AbstractVector{FacetIndex}` and `AbstractSet{FacetIndex}` inputs as documented, instead of requiring an `OrderedSet` ([#1384])
  - `ProjectedDirichlet` now updates the correct dofs when the constrained field is not the first
    field in the `DofHandler`; previously the dof lookup ignored the field offset in the cell dof

--- a/src/FEValues/PointValues.jl
+++ b/src/FEValues/PointValues.jl
@@ -10,9 +10,10 @@ arbitrary points of the domain together with a [`PointEvalHandler`](@ref).
 
 `PointValues` are reinitialized like other `CellValues`, but since the local reference
 coordinate of the "quadrature point" changes this needs to be passed to [`reinit!`](@ref),
-in addition to the element coordinates: `reinit!(pv, coords, local_coord)`. Alternatively,
-it can be reinitialized with a [`PointLocation`](@ref) when iterating a `PointEvalHandler`
-with a [`PointIterator`](@ref).
+in addition to the element coordinates: `reinit!(pv, coords, local_coord)`. For
+interpolations with non-identity mappings, the cell must also be passed:
+`reinit!(pv, cell, coords, local_coord)`. Alternatively, it can be reinitialized with a
+[`PointLocation`](@ref) when iterating a `PointEvalHandler` with a [`PointIterator`](@ref).
 
 For function/gradient evaluation, `PointValues` are used in the same way as
 `CellValues`, i.e. by using [`function_value`](@ref), [`function_gradient`](@ref), etc,
@@ -63,7 +64,16 @@ function_symmetric_gradient(pv::PointValues, u::AbstractVector, args...) =
 
 # reinit! on PointValues must first update N and dNdξ for the new "quadrature point"
 # and then call the regular reinit! for the wrapped CellValues to update dNdx
-function reinit!(pv::PointValues, x::AbstractVector{<:Vec{sdim}}, ξ::Vec{rdim}) where {sdim, rdim}
+@inline function reinit!(pv::PointValues, x::AbstractVector, ξ::Vec)
+    return reinit!(pv, nothing, x, ξ)
+end
+
+function reinit!(
+        pv::PointValues,
+        cell::Union{AbstractCell, Nothing},
+        x::AbstractVector{<:Vec{sdim}},
+        ξ::Vec{rdim},
+    ) where {sdim, rdim}
     # Update the quadrature point location
     qr_points = getpoints(pv.cv.qr)
     qr_points[1] = ξ
@@ -71,7 +81,7 @@ function reinit!(pv::PointValues, x::AbstractVector{<:Vec{sdim}}, ξ::Vec{rdim})
     precompute_values!(pv.cv.fun_values, qr_points)
     precompute_values!(pv.cv.geo_mapping, qr_points)
     # Regular reinit
-    reinit!(pv.cv, x)
+    reinit!(pv.cv, cell, x)
     return nothing
 end
 

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -365,11 +365,13 @@ end
 Element of a [`PointIterator`](@ref), typically used to reinitialize
 [`PointValues`](@ref). Fields:
  - `cid::Int`: ID of the cell containing the point
+ - `cell::AbstractCell`: cell containing the point
  - `local_coord::Vec`: the local (reference) coordinate of the point
  - `coords::Vector{Vec}`: the coordinates of the cell
 """
-struct PointLocation{V}
+struct PointLocation{C <: AbstractCell, V}
     cid::Int
+    cell::C
     local_coord::V
     coords::Vector{V}
 end
@@ -384,7 +386,7 @@ function Base.iterate(p::PointIterator, state = 1)
         local_coord = (p.ph.local_coords[state])::Vec
         n = nnodes_per_cell(p.ph.grid, cid)
         getcoordinates!(resize!(p.coords, n), p.ph.grid, cid)
-        point = PointLocation(cid, local_coord, p.coords)
+        point = PointLocation(cid, p.ph.grid.cells[cid], local_coord, p.coords)
         return (point, state + 1)
     end
 end
@@ -392,6 +394,6 @@ end
 cellid(p::PointLocation) = p.cid
 
 function reinit!(pv::PointValues, point::PointLocation)
-    reinit!(pv, point.coords, point.local_coord)
+    reinit!(pv, point.cell, point.coords, point.local_coord)
     return pv
 end

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -452,6 +452,31 @@ function test_pe_first_point_missing()
     return
 end
 
+function test_pe_mapped_interpolations()
+    cell = Triangle((1, 2, 3))
+    coords = Vec{2, Float64}.([(0.0, 0.0), (2.0, 0.5), (0.5, 2.0)])
+    grid = Grid([cell], Node.(coords))
+    local_coords = Vec{2, Float64}.([(0.2, 0.3), (0.1, 0.4)])
+
+    for ip in (Nedelec{RefTriangle, 1}(), RaviartThomas{RefTriangle, 1}())
+        qr = QuadratureRule{RefTriangle}(ones(length(local_coords)), local_coords)
+        cv = CellValues(qr, ip)
+        reinit!(cv, cell, coords)
+        points = [spatial_coordinate(cv, qp, coords) for qp in eachindex(local_coords)]
+        ph = PointEvalHandler(grid, points)
+        pv = PointValues(cv)
+        u = collect(1.0:getnbasefunctions(ip))
+
+        for (qp, point) in enumerate(PointIterator(ph))
+            @test point !== nothing
+            reinit!(pv, point)
+            @test function_value(pv, u) ≈ function_value(cv, qp, u)
+            @test function_gradient(pv, u) ≈ function_gradient(cv, qp, u)
+        end
+    end
+    return
+end
+
 @testset "PointEvalHandler" begin
     @testset "scalar field" begin
         test_pe_scalar_field()
@@ -486,6 +511,10 @@ end
 
     @testset "failure cases" begin
         test_pe_first_point_missing()
+    end
+
+    @testset "mapped interpolations" begin
+        test_pe_mapped_interpolations()
     end
 end
 

--- a/test/test_pointevaluation.jl
+++ b/test/test_pointevaluation.jl
@@ -532,4 +532,21 @@ end
     @test shape_divergence(pvv, 1, 1) ≈ shape_divergence(cvv, 2, 1)
     @test shape_curl(pvv, 1, 1) ≈ shape_curl(cvv, 2, 1)
     @test shape_symmetric_gradient(pvv, 1, 1) ≈ shape_symmetric_gradient(cvv, 2, 1)
+
+    # PointValues for interpolations with non-identity mappings
+    cell = Triangle((1, 2, 3))
+    x_mapped = Vec{2, Float64}.([(0.0, 0.0), (2.0, 0.5), (0.5, 2.0)])
+    ξs = Vec{2, Float64}.([(0.2, 0.3), (0.1, 0.4)])
+    for ip_mapped in (Nedelec{RefTriangle, 1}(), RaviartThomas{RefTriangle, 1}())
+        qr_mapped = QuadratureRule{RefTriangle}([1.0, 1.0], ξs)
+        cv_mapped = CellValues(qr_mapped, ip_mapped)
+        reinit!(cv_mapped, cell, x_mapped)
+        pv_mapped = PointValues(cv_mapped)
+        u_mapped = rand(getnbasefunctions(ip_mapped))
+        for (qp, ξ) in pairs(ξs)
+            reinit!(pv_mapped, cell, x_mapped, ξ)
+            @test function_value(pv_mapped, u_mapped) ≈ function_value(cv_mapped, qp, u_mapped)
+            @test function_gradient(pv_mapped, u_mapped) ≈ function_gradient(cv_mapped, qp, u_mapped)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

- I added a cell-aware `PointValues` reinitialization path for interpolations with non-identity mappings.
- I documented the new `reinit!(pv, cell, coords, local_coord)` signature and added a changelog entry.
- I added regression coverage for both Nedelec and Raviart-Thomas point evaluation.

## Validation

- `julia --project=. -e 'include("test/test_pointevaluation.jl")'` — 1033 PointEvalHandler tests and 26 PointValues tests passed.
- Runic 1.7 formatting check on the changed Julia and Markdown files.
- `git diff --check origin/master...HEAD`

I left the full cross-platform test matrix to upstream CI.

Fixes #1420
