### PR TITLE
Correct transpose error in `_condense!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - The error thrown when assembling into a matrix entry that is missing from the sparsity
    pattern now reports the row that is actually missing, rather than an unrelated row that
    happened to be stored in the same column ([#1414])
+ - Fix bug applying the transpose operation in condensation of `AffineConstraints`. This bug gave
+   silently wrong results when used on non-symmetric system matrices, but did not affect system matrices
+   that were symmetric ([#1426])
+
 
 ## [v1.5.0] - 2026-07-13
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -824,7 +824,7 @@ function _condense!(K::SparseMatrixCSC, f::AbstractVector, dofcoefficients::Vect
                         addindex!(K, v * Kval, row, d)
                     end
                 else
-                    for (d1, v1) in col_coeffs, (d2, v2) in row_coeffs
+                    for (d1, v1) in row_coeffs, (d2, v2) in col_coeffs
                         addindex!(K, v1 * v2 * Kval, d1, d2)
                     end
                 end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -334,7 +334,7 @@ end
         close!(ch)
 
         C, _ = Ferrite.create_constraint_matrix(ch)
-        K = sparse(reshape(1.0:121.0, 11, 11))
+        K = sparse(reshape(1.0:ndofs(dh)^2, ndofs(dh), ndofs(dh)))
         Kcondensed = C' * K * C
         apply!(K, ch)
         @test K[ch.free_dofs, ch.free_dofs] == Kcondensed

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -334,7 +334,7 @@ end
         close!(ch)
 
         C, _ = Ferrite.create_constraint_matrix(ch)
-        K = sparse(reshape(1.0:ndofs(dh)^2, ndofs(dh), ndofs(dh)))
+        K = sparse(reshape(1.0:(ndofs(dh)^2), ndofs(dh), ndofs(dh)))
         Kcondensed = C' * K * C
         apply!(K, ch)
         @test K[ch.free_dofs, ch.free_dofs] == Kcondensed

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -327,6 +327,19 @@ end
     add!(dh, :u, Lagrange{RefLine, 1}())
     close!(dh)
 
+    @testset "nonsymmetric matrix condensation" begin
+        ch = ConstraintHandler(dh)
+        add!(ch, AffineConstraint(1, [3 => 2.0], 0.0))
+        add!(ch, AffineConstraint(2, [4 => 3.0], 0.0))
+        close!(ch)
+
+        C, _ = Ferrite.create_constraint_matrix(ch)
+        K = sparse(reshape(1.0:121.0, 11, 11))
+        Kcondensed = C' * K * C
+        apply!(K, ch)
+        @test K[ch.free_dofs, ch.free_dofs] == Kcondensed
+    end
+
     test_acs = [
         # Simple homogeneous constraint
         [AffineConstraint(4, [(7 => 1.0)], 0.0)],


### PR DESCRIPTION
Discovered (by 🤖) in a downstream package causing a failure for stiffness matrix.

Fixes there and looks correct, but need to find a clear test to show that this is correct before merging.

(Feel free to use more powerful bots (or humans) to directly add tests to this PR, or make a separate)