### PR TITLE
Simplify Tachometer benchmark workflows using the packaged actions

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -40,35 +40,22 @@ jobs:
         with:
           fetch-depth: 0 # full history so that the merge-base can be resolved
 
-      # The noise model is derived READ-ONLY from the master time series published by
-      # BenchmarkTracking.yml, so a PR can never train it. Extract it from the trusted gh-pages
-      # ref into a directory OUTSIDE the PR checkout (via `git archive`, so a PR-committed
-      # directory can't stand in for it). Until gh-pages has benchmark data the directory is
-      # empty and the flat time-tolerance below is used instead.
-      - name: Fetch published history (read-only noise source)
-        run: |
-          dest="${RUNNER_TEMP}/tacho-history"
-          rm -rf "$dest"; mkdir -p "$dest"
-          if git fetch --no-tags --depth=1 origin gh-pages 2>/dev/null; then
-            git archive FETCH_HEAD benchmarks/data 2>/dev/null | tar -x -C "$dest" 2>/dev/null || true
-          fi
-        continue-on-error: true
-
       # Intentionally unpinned: Tachometer is developed alongside this setup, so track its
       # default branch rather than bumping a SHA here on every change.
+      #
+      # The action fetches the noise model itself (`noise-history: auto`): it is derived
+      # READ-ONLY from the master time series published by BenchmarkTracking.yml on gh-pages,
+      # extracted via `git archive` into a directory outside the PR checkout, so a PR can
+      # neither train it nor substitute a committed directory for it. Until gh-pages has
+      # benchmark data the flat time tolerance (5%) is used instead.
       - uses: KristofferC/Tachometer.jl@main
         id: tachometer
         with:
-          julia-version: '1'
-          script: benchmark/benchmarks.jl
           # Three interleaved passes per revision: a regression has to reproduce in all three.
           # In the RunnerNoise null comparisons on this runner, nruns=2 still let through 16
           # false flags in 10 comparisons; nruns=3 left 3, all from the known-bimodal
           # matrix-from-pattern benchmarks, which the learned noise band absorbs over time.
           nruns: '3'
-          time-tolerance: '0.05'
-          time-floor: '1us'
-          noise-history: ${{ runner.temp }}/tacho-history/benchmarks/data
 
       # `errored` means no comparison was produced at all -- the suite failed to load or run on
       # one of the revisions. Without this the job is green either way, which is how the

--- a/.github/workflows/BenchmarksReport.yml
+++ b/.github/workflows/BenchmarksReport.yml
@@ -1,10 +1,12 @@
-# Trusted half of the two-workflow Tachometer setup: this never runs code from the PR, it only
-# re-renders the artifact produced by Benchmarks.yml and posts it as a sticky PR comment.
+# Trusted half of the two-workflow Tachometer setup: this never runs code from the PR. The
+# reporter action resolves the PR from the trusted workflow_run event, downloads the benchmark
+# artifact produced by Benchmarks.yml, validates and re-renders report.json, and updates the
+# sticky PR comment (marking it stale while a new run is in progress).
 name: Benchmark report
 
 on:
   workflow_run:
-    workflows: [Benchmarks]
+    workflows: [Benchmarks] # must match the `name` in Benchmarks.yml
     types: [requested, completed]
 
 permissions:
@@ -13,121 +15,17 @@ permissions:
   contents: read
 
 jobs:
-  mark:
-    name: Mark previous results stale
-    runs-on: ubuntu-latest
-    if: >-
-      github.event.action == 'requested' &&
-      github.event.workflow_run.event == 'pull_request'
-    concurrency:
-      group: tachometer-mark-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
-      cancel-in-progress: true
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-      HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
-      RUN_URL: ${{ github.event.workflow_run.html_url }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          repository: KristofferC/Tachometer.jl
-          ref: main
-          path: .tachometer-action
-
-      - name: Flag the sticky comment as re-running
-        run: |
-          set -euo pipefail
-          pr="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-                | jq -r --arg b "$HEAD_BRANCH" --arg r "$HEAD_REPO" \
-                  '[.[] | select(.state=="open" and .head.ref==$b and .head.repo.full_name==$r)][0].number // empty')"
-          if [ -z "$pr" ]; then
-            echo "no matching open PR for ${HEAD_SHA}; nothing to mark"
-            exit 0
-          fi
-          bash .tachometer-action/scripts/mark-running.sh \
-            "$REPO" "$pr" "tachometer" "$HEAD_SHA" "$RUN_URL"
-
   report:
-    name: Post report
+    name: Report
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
-    if: >-
-      github.event.action == 'completed' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
     concurrency:
-      group: tachometer-report-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
-      cancel-in-progress: false
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      REPO: ${{ github.repository }}
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-      HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+      # Requested and completed events use separate groups: a quick "running" marker never
+      # waits behind a report, while newer markers supersede old ones.
+      group: tachometer-report-${{ github.event.action }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: ${{ github.event.action == 'requested' }}
     steps:
-      - name: Resolve target PR
-        id: pr
-        run: |
-          set -euo pipefail
-          pr="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-                | jq -r --arg b "$HEAD_BRANCH" --arg r "$HEAD_REPO" \
-                  '[.[] | select(.state=="open" and .head.ref==$b and .head.repo.full_name==$r)][0].number // empty')"
-          if [ -z "$pr" ]; then
-            echo "no matching open PR for ${HEAD_SHA}; skipping"
-            exit 0
-          fi
-
-          cur="$(gh api "repos/${REPO}/pulls/${pr}" --jq '.head.sha')"
-          if [ "$cur" != "$HEAD_SHA" ]; then
-            echo "PR #${pr} head moved; skipping stale report"
-            exit 0
-          fi
-          echo "number=${pr}" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@v7
-        if: steps.pr.outputs.number != ''
-        with:
-          repository: KristofferC/Tachometer.jl
-          ref: main
-          path: .tachometer-action
-
-      - uses: julia-actions/setup-julia@v3
-        if: steps.pr.outputs.number != ''
-        with:
-          version: '1'
-      - name: Install the trusted renderer
-        if: steps.pr.outputs.number != ''
-        run: julia --project=.tacho -e 'using Pkg; Pkg.develop(PackageSpec(path=".tachometer-action")); Pkg.instantiate()'
-
-      - name: Download report artifacts
-        if: steps.pr.outputs.number != ''
-        uses: actions/download-artifact@v4
-        with:
-          pattern: tachometer-report-*
-          path: artifacts
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Re-render and post
-        if: steps.pr.outputs.number != ''
-        env:
-          PR: ${{ steps.pr.outputs.number }}
-        run: |
-          set -euo pipefail
-          cur="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')"
-          [ "$cur" = "$HEAD_SHA" ] || { echo "PR #$PR head moved; skipping stale report"; exit 0; }
-
-          script="$(julia --project=.tacho -e 'using Tachometer; print(joinpath(pkgdir(Tachometer),"scripts","comment.sh"))')"
-          shopt -s nullglob
-          for dir in artifacts/*/; do
-            [ -f "$dir/report.json" ] || continue
-            bytes=$(wc -c < "$dir/report.json"); [ "$bytes" -le 2000000 ] || { echo "report.json too large; skipping $dir"; continue; }
-            marker="$(cat "$dir/marker.txt" 2>/dev/null || echo tachometer)"
-            [[ "$marker" =~ ^[A-Za-z0-9._-]+$ ]] || marker=tachometer
-            TACHOMETER_MODE=render TACHOMETER_MARKER="$marker" \
-              TACHOMETER_RUN_URL="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${{ github.event.workflow_run.id }}" \
-              TACHOMETER_REPORT_IN="$dir/report.json" TACHOMETER_REPORT_OUT="$dir/rendered.md" \
-              julia --project=.tacho --startup-file=no -e 'using Tachometer; Tachometer.main()'
-            bash "$script" "$REPO" "$PR" "$marker" "$dir/rendered.md"
-          done
+      # Intentionally unpinned, same as in Benchmarks.yml: Tachometer is developed alongside
+      # this setup. Note that this action runs with the pull-requests write token, so pin it
+      # to a reviewed commit SHA if that ever changes.
+      - uses: KristofferC/Tachometer.jl/reporter@main


### PR DESCRIPTION
Tachometer.jl now packages more of the PR-benchmark setup as reusable actions, so the two workflows here can shrink to match the upstream examples.

**`Benchmarks.yml`**
- Drop the manual "Fetch published history" step: the action's `noise-history: auto` default now performs the identical read-only `git archive` extraction of `benchmarks/data` from gh-pages itself (still outside the PR checkout, so a PR can neither train the noise model nor substitute a committed directory for it).
- Drop `julia-version`, `script`, `time-tolerance`, `time-floor`, and the explicit `noise-history` input — all just restated the action's current defaults. Only `nruns: '3'` remains as configuration.
- Keep the `status == 'errored'` guard: the action still does not fail the job on its own when the suite fails to load or run.
- Keep the RunnerNoise-experiment comments documenting the runner and `nruns` choices.

**`BenchmarksReport.yml`** (133 → 30 lines)
- Replace the hand-rolled `mark`/resolve-PR/install-renderer/re-render/comment jobs with the packaged `KristofferC/Tachometer.jl/reporter` composite action, which does the same thing: resolve the PR from the trusted `workflow_run` event only, download the artifact, validate and re-render `report.json`, and update the sticky comment.
- Inherited improvement from the upstream example: `requested` and `completed` events now use separate concurrency groups, so the "stale" marker never queues behind a full report.

`BenchmarkTracking.yml` is untouched — it is already functionally identical to the new upstream `examples/track.yml`.

Both workflows keep tracking `@main` per the existing intentional-unpinning comment; the report workflow now notes that the reporter runs with a write token and is the one to pin if that policy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)