### PR TITLE
Fix typo in FacetIterator documentation

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -281,7 +281,7 @@ FaceIterator(args...) = error("FaceIterator is deprecated, use FacetIterator ins
 """
     FacetIterator(gridordh::Union{Grid, AbstractDofHandler}, facetset::AbstractVecOrSet{FacetIndex})
 
-Create a `FacetIterator` to conveniently iterate over the faces in `facestet`. The elements of
+Create a `FacetIterator` to conveniently iterate over the faces in `facetset`. The elements of
 the iterator are [`FacetCache`](@ref)s which are properly `reinit!`ialized. See
 [`FacetCache`](@ref) for more details.
 
@@ -298,6 +298,7 @@ for faceindex in facetset
     reinit!(fc, faceindex)
     # ...
 end
+```
 """
 struct FacetIterator{FC <: FacetCache}
     fc::FC


### PR DESCRIPTION
Fixes the typo `facestet` to `facetset` and adds a missing code block terminator to the end of the doc comment, so the code block is displayed correctly.