### PR TITLE
Make interface_coupling self-sufficient for interface assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    assembly](https://ferrite-fem.github.io/Ferrite.jl/stable/howto/threaded_assembly/).
    ([#1417])
 
+### Changed
+ - `interface_coupling` in `allocate_matrix`/`add_sparsity_entries!`/`add_interface_entries!`
+   is now self-sufficient for interface assembly: `interface_coupling[i, j] = true` creates
+   entries for *every* (test dof of field `i`, trial dof of field `j`) pair within the union
+   of the dofs of the two cells sharing an interface. Previously, pairs where either dof was
+   shared between the two cells (continuous interpolations), as well as pairs where both
+   dofs belong to the same cell, were left to the cell `coupling` to provide, so assembling
+   interface terms with nonzero values at shared dofs (e.g. flux-type couplings of
+   continuous fields) could hit missing sparsity pattern entries when a restricted cell
+   `coupling` was used. Patterns built with full cell coupling (the default,
+   `coupling = nothing`) are unchanged; the additional entries appear only for `topology`
+   builds that combine a restricted cell `coupling` with `interface_coupling`. ([#1432])
+
 ### Documentation
  - The figures for the documentation are now programmatically generated and made to have a consistent look.
  - New tutorial: Elastodynamics and modal analysis of a cantilever beam (mass matrix, generalized eigenvalue problem, Rayleigh damping, Newmark time integration).
@@ -1250,3 +1263,4 @@ poking into Ferrite internals:
 [#1414]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1414
 [#1416]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1416
 [#1421]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1421
+[#1432]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1432

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -296,11 +296,11 @@ between cells as described by the DofHandler `dh`.
  - `keep_constrained`: whether or not entries for constrained DoFs should be kept
    (`keep_constrained = true`) or eliminated (`keep_constrained = false`) from the sparsity
    pattern. `keep_constrained = false` requires passing the ConstraintHandler `ch`.
- - `interface_coupling`: the coupling between fields/components across the interface.
-   `interface_coupling[i, j] = true` means that entries exist for (rows of field/component
-   `i` in one cell) × (columns of field/component `j` in the other cell), for both
-   orientations of every interface. As for cell `coupling`, rows correspond to test
-   functions and columns to trial functions.
+ - `interface_coupling`: the coupling between fields/components in interface integrals.
+   `interface_coupling[i, j] = true` means that, for every interface, entries exist for
+   *every* pair of (test DoF of field/component `i`, trial DoF of field/component `j`)
+   within the union of the DoFs of the two cells sharing the interface. As for cell
+   `coupling`, rows correspond to test functions and columns to trial functions.
 """
 function add_interface_entries!(
         sp::SparsityPattern, dh::DofHandler, ch::Union{ConstraintHandler, Nothing} = nothing;
@@ -631,46 +631,41 @@ function _add_interface_entries!(
     )
     # Expanded coupling masks, lazily created per (row cell sdh, column cell sdh) pair
     couplings = Dict{NTuple{2, Int}, Matrix{Bool}}()
-    to_check = Dict{Int, Vector{Int}}()
     for ic in InterfaceIterator(dh, topology)
         # TODO: This looks like it can be optimized for the common case where
         #       the cells are in the same subdofhandler
         sdhs_idx = dh.cell_to_subdofhandler[cellid.([ic.a, ic.b])]
         sdhs = dh.subdofhandlers[sdhs_idx]
-        # Two iterations, one per orientation of the interface: the first iteration adds
-        # the entries with rows from `ic.a` and columns from `ic.b`, the second iteration
-        # the entries with rows from `ic.b` and columns from `ic.a`. Both directions are
+        # An interface integral is assembled over the stacked dof vector
+        # [dofs(ic.a); dofs(ic.b)] and its local matrix can be dense within every field
+        # block allowed by the mask (including the same-side blocks, since jump/average
+        # terms expand into same-side products). The pattern must therefore contain every
+        # (test dof, trial dof) pair allowed by the mask from the union of the two cells.
+        # This is realized by looping over all four (row cell, column cell) combinations:
+        # the two cross combinations and the two same-side combinations. Each pair is
         # gated by the coupling mask with the row cell as the first (test function) index
-        # and the neighbor cell as the second (trial function) index.
-        for it in 1:2
-            sdh = sdhs[it]
-            sdh2 = sdhs[it == 1 ? 2 : 1]
-            cell_dofs = celldofs(it == 1 ? ic.a : ic.b)
-            neighbor_dofs = celldofs(it == 1 ? ic.b : ic.a)
-            coupling_sdh = get!(couplings, (sdhs_idx[it], sdhs_idx[it == 1 ? 2 : 1])) do
+        # and the column cell as the second (trial function) index. Pairs that are also
+        # produced by the cell pass, or by neighboring interfaces, are deduplicated by
+        # `add_entry!`.
+        for row_i in 1:2, col_i in 1:2
+            sdh = sdhs[row_i]
+            sdh2 = sdhs[col_i]
+            row_dofs = celldofs(row_i == 1 ? ic.a : ic.b)
+            col_dofs = celldofs(col_i == 1 ? ic.a : ic.b)
+            coupling_sdh = get!(couplings, (sdhs_idx[row_i], sdhs_idx[col_i])) do
                 _coupling_to_local_dof_coupling(dh, interface_coupling, sdh, sdh2)
             end
-            for cell_field in sdh.field_names
-                dofrange1 = dof_range(sdh, cell_field)
-                cell_field_dofs = @view cell_dofs[dofrange1]
-                for neighbor_field in sdh2.field_names
-                    dofrange2 = dof_range(sdh2, neighbor_field)
-                    neighbor_field_dofs = @view neighbor_dofs[dofrange2]
+            for row_field in sdh.field_names
+                dofrange1 = dof_range(sdh, row_field)
+                row_field_dofs = @view row_dofs[dofrange1]
+                for col_field in sdh2.field_names
+                    dofrange2 = dof_range(sdh2, col_field)
+                    col_field_dofs = @view col_dofs[dofrange2]
 
-                    empty!(to_check)
                     for (j, dof_j) in enumerate(dofrange2)
                         for (i, dof_i) in enumerate(dofrange1)
                             coupling_sdh[dof_i, dof_j] || continue
-                            push!(get!(Vector{Int}, to_check, j), i)
-                        end
-                    end
-
-                    for (j, is) in to_check
-                        # Avoid coupling the shared dof in continuous interpolations as cross-element. They're coupled in the local coupling matrix.
-                        neighbor_field_dofs[j] ∈ cell_dofs && continue
-                        for i in is
-                            cell_field_dofs[i] ∈ neighbor_dofs && continue
-                            _add_interface_entry(sp, cell_field_dofs, neighbor_field_dofs, i, j, keep_constrained, ch)
+                            _add_interface_entry(sp, row_field_dofs, col_field_dofs, i, j, keep_constrained, ch)
                         end
                     end
                 end

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -647,48 +647,64 @@ end
         end
         return false
     end
-    function _check_dofs(K, dh, sdh, cell_idx, coupling, coupling_idx, vdim, neighbors, is_cross_element)
+    ncopies(ip) = ip isa VectorizedInterpolation ? Ferrite.get_n_copies(ip) : 1
+    function _check_dofs(K, dh, sdh, cell_idx, coupling, interface_coupling, neighbors, is_cross_element, has_interface)
+        cooccur(i, j) = any(c -> i ∈ celldofs(dh, c) && j ∈ celldofs(dh, c), 1:getncells(dh.grid))
+        nfields = length(Ferrite.getfieldnames(dh))
+        # Index into the mask for (field, component): field-level masks (one row/col per
+        # field) are indexed by the field index, component-level masks by the component
+        # index. Note: this relies on the sdh field names being a prefix of the global
+        # field names, as noted for `check_coupling` below.
+        function mask_index(mask, sdh, field_idx, dim)
+            size(mask, 1) == nfields && return field_idx
+            return sum(Int[ncopies(sdh.field_interpolations[f]) for f in 1:(field_idx - 1)]) + dim
+        end
         for field1_idx in eachindex(sdh.field_names)
             i_dofs = dof_range(sdh, field1_idx)
-            ip1 = sdh.field_interpolations[field1_idx]
-            vdim[1] = typeof(ip1) <: VectorizedInterpolation && size(coupling)[1] == 4 ? Ferrite.get_n_copies(ip1) : 1
-            for dim1 in 1:vdim[1]
+            vdim1 = ncopies(sdh.field_interpolations[field1_idx])
+            for dim1 in 1:vdim1
                 for cell2_idx in neighbors
                     sdh2 = dh.subdofhandlers[dh.cell_to_subdofhandler[cell2_idx]]
-                    coupling_idx[2] = 1
                     for field2_idx in eachindex(sdh2.field_names)
                         j_dofs = dof_range(sdh2, field2_idx)
-                        ip2 = sdh2.field_interpolations[field2_idx]
-                        vdim[2] = typeof(ip2) <: VectorizedInterpolation && size(coupling)[1] == 4 ? Ferrite.get_n_copies(ip2) : 1
-                        for dim2 in 1:vdim[2]
-                            i_dofs_v = i_dofs[dim1:vdim[1]:end]
-                            j_dofs_v = j_dofs[dim2:vdim[2]:end]
+                        vdim2 = ncopies(sdh2.field_interpolations[field2_idx])
+                        for dim2 in 1:vdim2
+                            cc = coupling[mask_index(coupling, sdh, field1_idx, dim1), mask_index(coupling, sdh2, field2_idx, dim2)]
+                            icc = interface_coupling[mask_index(interface_coupling, sdh, field1_idx, dim1), mask_index(interface_coupling, sdh2, field2_idx, dim2)]
+                            i_dofs_v = i_dofs[dim1:vdim1:end]
+                            j_dofs_v = j_dofs[dim2:vdim2:end]
                             for i_idx in i_dofs_v, j_idx in j_dofs_v
                                 i = celldofs(dh, cell_idx)[i_idx]
                                 j = celldofs(dh, cell2_idx)[j_idx]
-                                is_cross_element && (i ∈ celldofs(dh, cell2_idx) || j ∈ celldofs(dh, cell_idx)) && continue
-                                @test is_stored(K, i, j) == coupling[coupling_idx...]
+                                if is_cross_element
+                                    # The interface pass adds every masked pair within
+                                    # the union of the two cells' dofs; pairs that (also)
+                                    # co-occur in a cell get entries from the cell pass.
+                                    expected = icc || (cc && cooccur(i, j))
+                                else
+                                    # Same-cell pairs: from the cell pass, or from the
+                                    # same-side blocks of the interface pass if the cell
+                                    # has at least one interior facet.
+                                    expected = cc || (icc && has_interface)
+                                end
+                                @test is_stored(K, i, j) == expected
                             end
-                            coupling_idx[2] += 1
                         end
                     end
                 end
-                coupling_idx[1] += 1
             end
         end
     end
     function check_coupling(dh, topology, K, coupling, interface_coupling)
         for cell_idx in eachindex(getcells(dh.grid))
             sdh = dh.subdofhandlers[dh.cell_to_subdofhandler[cell_idx]]
-            coupling_idx = [1, 1]
-            interface_coupling_idx = [1, 1]
-            vdim = [1, 1]
-            # test inner coupling
-            _check_dofs(K, dh, sdh, cell_idx, coupling, coupling_idx, vdim, [cell_idx], false)
-            # test cross-element coupling
-            neighborhood = Ferrite.get_facet_facet_neighborhood(topology, grid)
+            neighborhood = Ferrite.get_facet_facet_neighborhood(topology, dh.grid)
             neighbors = [neighborhood[cell_idx, i] for i in 1:size(neighborhood, 2)]
-            _check_dofs(K, dh, sdh, cell_idx, interface_coupling, interface_coupling_idx, vdim, [i[1][1] for i in neighbors[.!isempty.(neighbors)]], true)
+            has_interface = any(!isempty, neighbors)
+            # test inner coupling
+            _check_dofs(K, dh, sdh, cell_idx, coupling, interface_coupling, [cell_idx], false, has_interface)
+            # test cross-element coupling
+            _check_dofs(K, dh, sdh, cell_idx, coupling, interface_coupling, [i[1][1] for i in neighbors[.!isempty.(neighbors)]], true, has_interface)
         end
     end
     grid = generate_grid(Quadrilateral, (2, 2))
@@ -738,6 +754,99 @@ end
             for i in prows, j in pcols
                 @test is_stored(K, i, j)
             end
+        end
+    end
+
+    # Interface coupling must be self-sufficient: for every interface, entries exist for
+    # every masked (test dof, trial dof) pair within the union of the two cells' dofs
+    # (including dofs shared between the cells (continuous interpolations) and the same-side
+    # blocks) without relying on the cell coupling to provide them.
+    let
+        grid = generate_grid(Line, (2,))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefLine, 1}())
+        add!(dh, :p, Lagrange{RefLine, 1}())
+        close!(dh)
+        # celldofs: A = [1, 2, 3, 4] (u@n1, u@n2, p@n1, p@n2), B = [2, 5, 4, 6]
+        topology = ExclusiveTopology(grid)
+        cc = [true false; false true] # cell coupling: u-u, p-p only
+        ic = [false true; false false] # interface coupling: u rows, p columns
+        sp = Ferrite.add_sparsity_entries!(
+            init_sparsity_pattern(dh), dh;
+            coupling = cc, topology = topology, interface_coupling = ic
+        )
+        # Every u row (1, 2, 5) couples to every p column (3, 4, 6), including the
+        # shared dof 4 and the same-side pairs such as (1, 3)
+        @test sort(collect(Ferrite.eachrow(sp, 1))) == [1, 2, 3, 4, 6]
+        @test sort(collect(Ferrite.eachrow(sp, 2))) == [1, 2, 3, 4, 5, 6]
+        @test sort(collect(Ferrite.eachrow(sp, 5))) == [2, 3, 4, 5, 6]
+        # No p rows couple to u columns ([p, u] = false)
+        @test sort(collect(Ferrite.eachrow(sp, 3))) == [3, 4]
+        @test sort(collect(Ferrite.eachrow(sp, 4))) == [3, 4, 6]
+    end
+    # Assembly smoke test: ∫_Γ {{δu}} {{p}} dΓ produces nonzero values for shared dofs and
+    # same-side pairs; the pattern from restricted cell coupling + interface coupling
+    # must support assembling it
+    let
+        grid = generate_grid(Quadrilateral, (2, 1))
+        topology = ExclusiveTopology(grid)
+        dh = DofHandler(grid)
+        ip = Lagrange{RefQuadrilateral, 1}()
+        add!(dh, :u, ip)
+        add!(dh, :p, ip)
+        close!(dh)
+        cc = [true false; false true]
+        ic = [false true; false false]
+        K = allocate_matrix(dh; coupling = cc, topology = topology, interface_coupling = ic)
+        iv = InterfaceValues(FacetQuadratureRule{RefQuadrilateral}(2), ip)
+        sdh = dh.subdofhandlers[1]
+        drng_u = dof_range(sdh, :u)
+        drng_p = dof_range(sdh, :p)
+        ncdofs = ndofs_per_cell(dh)
+        assembler = start_assemble(K)
+        for interface in InterfaceIterator(dh, topology)
+            reinit!(iv, interface)
+            Ke = zeros(2 * ncdofs, 2 * ncdofs)
+            # Map interface shape function index (here-side 1:4, there-side 5:8) to the
+            # index in the stacked dof vector [celldofs(a); celldofs(b)]
+            stackedindex(i, drng) = i <= length(drng) ? drng[i] : ncdofs + drng[i - length(drng)]
+            for qp in 1:getnquadpoints(iv)
+                dΓ = getdetJdV(iv, qp)
+                for i in 1:getnbasefunctions(iv)
+                    δu = shape_value_average(iv, qp, i)
+                    for j in 1:getnbasefunctions(iv)
+                        p = shape_value_average(iv, qp, j)
+                        Ke[stackedindex(i, drng_u), stackedindex(j, drng_p)] += δu * p * dΓ
+                    end
+                end
+            end
+            # The stacked dof vector contains the shared (continuous) dofs twice, which
+            # the assembler does not support: accumulate the duplicated rows/columns onto
+            # the unique dofs before assembling
+            idofs = interfacedofs(interface)
+            udofs = unique(idofs)
+            uindex = [findfirst(==(d), udofs) for d in idofs]
+            Kc = zeros(length(udofs), length(udofs))
+            for i in axes(Ke, 1), j in axes(Ke, 2)
+                Kc[uindex[i], uindex[j]] += Ke[i, j]
+            end
+            # This throws a missing sparsity entry error if the pattern misses the
+            # shared-dof strips or the same-side blocks
+            assemble!(assembler, udofs, Kc)
+        end
+        # The trace of p at the shared nodes is nonzero on the facet, so the shared dof
+        # columns must have nonzero values in the rows of the u dofs on the facet
+        shared_u_dofs = intersect(celldofs(dh, 1)[drng_u], celldofs(dh, 2)[drng_u])
+        shared_p_dofs = intersect(celldofs(dh, 1)[drng_p], celldofs(dh, 2)[drng_p])
+        for i in shared_u_dofs, j in shared_p_dofs
+            @test K[i, j] > 0
+        end
+        # Same-side pairs: u rows on the facet couple to p columns away from the facet
+        # with value zero here ({{p}} has zero trace for interior dofs), but the entries
+        # must exist in the pattern
+        other_p_dofs = setdiff(celldofs(dh, 1)[drng_p], shared_p_dofs)
+        for i in shared_u_dofs, j in other_p_dofs
+            @test is_stored(K, i, j)
         end
     end
 


### PR DESCRIPTION
Declaring interface_coupling[f1, f2] now means that, for every interface,
entries exist for every (test dof of f1, trial dof of f2) pair within the
union of the dofs of the two cells sharing the interface. Follow-up to
the orientation/block-semantics fix in #1428.

Previously the interface pass skipped every pair where either dof is
shared between the two cells (continuous interpolations) and never
considered pairs where both dofs belong to the same cell, so those
entries existed only when the cell coupling provided them. Interface
terms with nonzero values at shared dofs (e.g. flux-type couplings of
continuous fields, or any jump/average product expanding into same-side
terms) could then hit missing sparsity pattern entries when a restricted
cell coupling was used.

The interface pass now loops over all four (row cell, column cell)
combinations of an interface and adds every masked pair, with duplicates
against the cell pass merged by add_entry! as usual. Patterns built with
full cell coupling (the default coupling = nothing) are unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
