### PR TITLE
assembler: avoid deprecated integer pointers in llvmcall

### DIFF
--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -433,19 +433,25 @@ end
 # additions -- the task join at the end of a threaded assembly loop is the synchronization
 # point that makes the accumulated values visible.
 for (T, llvmT) in ((Float64, "double"), (Float32, "float"))
+    # Julia 1.12 passes `Ptr` arguments as actual LLVM pointers, before that they are passed
+    # as integers which have to be converted with `inttoptr`.
+    ir = if VERSION >= v"1.12.0-DEV"
+        """
+        %rv = atomicrmw fadd ptr %0, $llvmT %1 monotonic
+        ret void
+        """
+    else
+        """
+        %p = inttoptr i$(Sys.WORD_SIZE) %0 to $(llvmT)*
+        %rv = atomicrmw fadd $(llvmT)* %p, $llvmT %1 monotonic
+        ret void
+        """
+    end
     @eval @propagate_inbounds function _atomic_add!(x::Vector{$T}, i::Int, v::$T)
         @boundscheck checkbounds(x, i)
         GC.@preserve x begin
             p = pointer(x, i)
-            Base.llvmcall(
-                $(
-                    """
-                    %p = inttoptr i$(Sys.WORD_SIZE) %0 to $(llvmT)*
-                    %rv = atomicrmw fadd $(llvmT)* %p, $llvmT %1 monotonic
-                    ret void
-                    """
-                ), Cvoid, Tuple{Ptr{$T}, $T}, p, v
-            )
+            Base.llvmcall($ir, Cvoid, Tuple{Ptr{$T}, $T}, p, v)
         end
         return
     end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -433,8 +433,6 @@ end
 # additions -- the task join at the end of a threaded assembly loop is the synchronization
 # point that makes the accumulated values visible.
 for (T, llvmT) in ((Float64, "double"), (Float32, "float"))
-    # Julia 1.12 passes `Ptr` arguments as actual LLVM pointers, before that they are passed
-    # as integers which have to be converted with `inttoptr`.
     ir = if VERSION >= v"1.12.0-DEV"
         """
         %rv = atomicrmw fadd ptr %0, $llvmT %1 monotonic


### PR DESCRIPTION
Fixes the deprecation warning reported in https://github.com/Ferrite-FEM/Ferrite.jl/pull/1417#issuecomment-5140458386:

```
┌ WARNING: llvmcall with integer pointers is deprecated.
│ Use actual pointers instead, replacing i32 or i64 with i8* or ptr
└ in (::var"##examples/threaded_assembly#287".TestMultiThreading.var"#28#29"{scratch, C, b})(Any) at .../OhMyThreads/src/macro_impl.jl
```

Julia 1.12 (JuliaLang/julia#53687) passes `Ptr` arguments to `llvmcall` as actual LLVM pointers, so the `inttoptr` in `_atomic_add!` hits the backwards-compatibility path in `src/ccall.cpp`, which warns under `--depwarn=yes` (as in the docs build) and errors under `--depwarn=error`. The warning is attributed to the OhMyThreads closure since `_atomic_add!` inlines into it.

Older versions still need `inttoptr` (the pointer-typed IR fails to parse there), so the IR is selected based on `VERSION`.

Verified on 1.10, 1.11, 1.12 and 1.13 (1.12+ with `--depwarn=error`) that the primitive still lowers to a single `atomicrmw fadd` and that atomic assembly matches serial assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)