### PR TITLE
avoid assembler pathological slowdown when rows become more dense

### DIFF
--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -20,12 +20,46 @@ end
     )
     current_row = 1
     ld = length(coldofs)
+    ncols = size(K, 2)
+    threshold = Ferrite.SPARSE_COLUMN_SEARCH_RATIO * ld
     return @inbounds for Krow in sortedrowdofs
         maxlookups = sym ? current_row : ld
         Kerow = rowpermutation[current_row]
         ci = 1 # col index pointer for the local matrix
         Ci = 1 # col index pointer for the global matrix
         nzr = nzrange(K, Krow)
+        # Fast paths for rows holding many entries per local column, mirroring the
+        # corresponding column fast paths in `Ferrite._assemble_inner!` for
+        # `SparseMatrixCSC` in src/assembler.jl
+        if length(nzr) == ncols
+            offset = first(nzr) - 1
+            for ci in 1:maxlookups
+                val = Ke[Kerow, colpermutation[ci]]
+                iszero(val) || Ferrite._addindex!(K.nzval, offset + sortedcoldofs[ci], val, atomic)
+            end
+            current_row += 1
+            continue
+        end
+        if length(nzr) > (sym ? Ferrite.SPARSE_COLUMN_SEARCH_RATIO * maxlookups : threshold)
+            lo = first(nzr)
+            hi = last(nzr)
+            for ci in 1:maxlookups
+                Kecol_dof = sortedcoldofs[ci]
+                C = searchsortedfirst(K.colval, Kecol_dof, lo, hi, Base.Order.Forward)
+                if C <= hi && K.colval[C] == Kecol_dof
+                    val = Ke[Kerow, colpermutation[ci]]
+                    iszero(val) || Ferrite._addindex!(K.nzval, C, val, atomic)
+                    lo = C + 1
+                else
+                    # No entry exists in the global matrix for this column, which is
+                    # allowed as long as the value which would have been inserted is zero.
+                    iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kecol_dof)
+                    lo = C
+                end
+            end
+            current_row += 1
+            continue
+        end
         while Ci <= length(nzr) && ci <= maxlookups
             C = nzr[Ci]
             Kcol = K.colval[C]
@@ -44,7 +78,7 @@ end
             else # Kcol > Kecol_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kcol)
+                iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kecol_dof)
                 # Advance the local matrix row pointer
                 ci += 1
             end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -372,6 +372,10 @@ end
     return _assemble_inner!(K, Ke, rowdofs, sortedrowdofs, rowpermutation, coldofs, sortedcoldofs, colpermutation, sym, atomic)
 end
 
+# Number of stored entries per local row above which a column is searched with binary
+# search instead of the linear merge walk in `_assemble_inner!`.
+const SPARSE_COLUMN_SEARCH_RATIO = 8
+
 @propagate_inbounds function _assemble_inner!(
         K::SparseMatrixCSC, Ke::AbstractMatrix,
         rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
@@ -382,12 +386,45 @@ end
     Krows = rowvals(K)
     Kvals = nonzeros(K)
     ld = length(rowdofs)
+    nrows = size(K, 1)
     @inbounds for Kcol in sortedcoldofs
         maxlookups = sym ? current_col : ld
         Kecol = colpermutation[current_col]
+        nzr = nzrange(K, Kcol)
+        # Fast path for a fully dense column
+        if length(nzr) == nrows
+            offset = first(nzr) - 1
+            for ri in 1:maxlookups
+                val = Ke[rowpermutation[ri], Kecol]
+                iszero(val) || _addindex!(Kvals, offset + sortedrowdofs[ri], val, atomic)
+            end
+            current_col += 1
+            continue
+        end
+        # Fast path for a column with many entries per local row, but not dense enough for
+        # the branch above
+        if length(nzr) > SPARSE_COLUMN_SEARCH_RATIO * maxlookups
+            lo = first(nzr)
+            hi = last(nzr)
+            for ri in 1:maxlookups
+                Kerow_dof = sortedrowdofs[ri]
+                R = searchsortedfirst(Krows, Kerow_dof, lo, hi, Base.Order.Forward)
+                if R <= hi && Krows[R] == Kerow_dof
+                    val = Ke[rowpermutation[ri], Kecol]
+                    iszero(val) || _addindex!(Kvals, R, val, atomic)
+                    lo = R + 1
+                else
+                    # No entry exists in the global matrix for this row, which is allowed
+                    # as long as the value which would have been inserted is zero.
+                    iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof, Kcol)
+                    lo = R
+                end
+            end
+            current_col += 1
+            continue
+        end
         ri = 1 # row index pointer for the local matrix
         Ri = 1 # row index pointer for the global matrix
-        nzr = nzrange(K, Kcol)
         while Ri <= length(nzr) && ri <= maxlookups
             R = nzr[Ri]
             Krow = Krows[R]

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -213,6 +213,94 @@ end
     @test_throws errr(1, 2) assemble!(as, [2, 1], [1.0 0.0; 3.0 4.0])
 end
 
+@testset "assemble! dense column fast paths" begin
+    # Columns with many stored entries compared to the number of local dofs are
+    # processed with binary search instead of the linear merge walk, and fully dense
+    # columns with direct indexing (see `_assemble_inner!` for `SparseMatrixCSC`).
+    N = 40
+    dofs = [19, 40, 3] # intentionally unsorted
+    ratio = Ferrite.SPARSE_COLUMN_SEARCH_RATIO
+    entries = Set{Tuple{Int, Int}}((d1, d2) for d1 in dofs, d2 in dofs)
+    for i in 1:N # fully dense column (and row) 3
+        push!(entries, (i, 3), (3, i))
+    end
+    for i in 1:30 # column (and row) 19: dense enough for the binary search path
+        push!(entries, (i, 19), (19, i))
+    end
+    K = sparse(first.(collect(entries)), last.(collect(entries)), zeros(length(entries)), N, N)
+    @test length(nzrange(K, 3)) == N                    # dense column fast path
+    @test length(nzrange(K, 19)) > ratio * length(dofs) # binary search fast path
+    @test length(nzrange(K, 40)) < ratio * length(dofs) # linear merge walk
+
+    f = zeros(N)
+    Ke = rand(3, 3)
+    Ke[1, 1] = 0 # exercise the iszero skip in the binary search path (entry (19, 19))
+    Ke[2, 3] = 0 # exercise the iszero skip in the dense column path (entry (40, 3))
+    fe = rand(3)
+    for atomic in (false, true)
+        a = start_assemble(K, f; atomic)
+        D = zeros(N, N)
+        F = zeros(N)
+        for _ in 1:2
+            assemble!(a, dofs, Ke, fe)
+            D[dofs, dofs] += Ke
+            F[dofs] += fe
+        end
+        @test Matrix(K) == D
+        @test f == F
+    end
+
+    # A local dof missing from a binary searched column is allowed when the local
+    # value is zero, and errors otherwise
+    dofs2 = [5, 19, 32] # rows 5 and 19 are stored in column 19, row 32 is not
+    Ke2 = zeros(3, 3)
+    Ke2[1, 2] = 1.0 # entry (5, 19)
+    Ke2[2, 2] = 2.0 # entry (19, 19)
+    a = start_assemble(K)
+    assemble!(a, dofs2, Ke2)
+    @test K[5, 19] == 1.0
+    @test K[19, 19] == 2.0
+    Ke2[3, 2] = 3.0 # entry (32, 19) is not in the sparsity pattern
+    @test_throws ErrorException assemble!(a, dofs2, Ke2)
+
+    # Symmetric assembler: the binary search threshold scales with the number of
+    # lookups for the current column
+    entries = Set{Tuple{Int, Int}}()
+    for i in 1:N # fully dense (stored) column 40
+        push!(entries, (i, 40))
+    end
+    for i in 1:19 # binary search path for column 19
+        push!(entries, (i, 19))
+    end
+    for i in 1:20 # binary search path for column 25, with row 25 missing
+        push!(entries, (i, 25))
+    end
+    push!(entries, (2, 2))
+    S = Symmetric(sparse(first.(collect(entries)), last.(collect(entries)), zeros(length(entries)), N, N))
+    @test length(nzrange(S.data, 40)) == N
+    @test length(nzrange(S.data, 19)) > ratio * 2 # 2 lookups when processing column 19 of [2, 19, 40]
+    sdofs = [2, 19, 40]
+    Kes = rand(3, 3)
+    Kes = Kes + Kes' # symmetric element matrix
+    for atomic in (false, true)
+        a = start_assemble(S; atomic)
+        Ds = zeros(N, N)
+        for _ in 1:2
+            assemble!(a, sdofs, Kes)
+            Ds[sdofs, sdofs] += Kes
+        end
+        @test Matrix(S) == Ds
+    end
+    ## Missing entries in binary searched columns
+    Kem = [1.0 2.0; 2.0 0.0]
+    a = start_assemble(S)
+    assemble!(a, [19, 25], Kem)
+    @test S[19, 19] == 1.0
+    @test S[19, 25] == 2.0
+    Kem[2, 2] = 3.0 # entry (25, 25) is not in the sparsity pattern
+    @test_throws ErrorException assemble!(a, [19, 25], Kem)
+end
+
 @testset "assemble! with atomic accumulation" begin
     grid = generate_grid(Quadrilateral, (10, 10))
     dh = DofHandler(grid)

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -130,6 +130,56 @@ using SparseArrays, LinearAlgebra
         @test all(K[rdofs, cdofs] .== 2Ke)
         @test all(f[rdofs] .== 2fe)
 
+        # Dense row fast paths: rows with many stored entries compared to the number
+        # of local dofs are processed with binary search instead of the linear merge
+        # walk, and fully dense rows with direct indexing (see `_assemble_inner!` for
+        # `SparseMatrixCSR` in ext/FerriteSparseMatrixCSR.jl)
+        N = 40
+        dofs = [19, 40, 3] # intentionally unsorted
+        ratio = Ferrite.SPARSE_COLUMN_SEARCH_RATIO
+        entries = Set{Tuple{Int, Int}}((d1, d2) for d1 in dofs, d2 in dofs)
+        for i in 1:N # fully dense row (and column) 3
+            push!(entries, (3, i), (i, 3))
+        end
+        for i in 1:30 # row (and column) 19: dense enough for the binary search path
+            push!(entries, (19, i), (i, 19))
+        end
+        K = sparsecsr(first.(collect(entries)), last.(collect(entries)), zeros(length(entries)), N, N)
+        @test length(nzrange(K, 3)) == N                    # dense row fast path
+        @test length(nzrange(K, 19)) > ratio * length(dofs) # binary search fast path
+        @test length(nzrange(K, 40)) < ratio * length(dofs) # linear merge walk
+
+        f = zeros(N)
+        Ke = rand(3, 3)
+        Ke[1, 1] = 0 # exercise the iszero skip in the binary search path (entry (19, 19))
+        Ke[3, 2] = 0 # exercise the iszero skip in the dense row path (entry (3, 40))
+        fe = rand(3)
+        for atomic in (false, true)
+            a = start_assemble(K, f; atomic)
+            D = zeros(N, N)
+            F = zeros(N)
+            for _ in 1:2
+                assemble!(a, dofs, Ke, fe)
+                D[dofs, dofs] += Ke
+                F[dofs] += fe
+            end
+            @test Matrix(K) == D
+            @test f == F
+        end
+
+        # A local dof missing from a binary searched row is allowed when the local
+        # value is zero, and errors otherwise
+        dofs2 = [5, 19, 32] # columns 5 and 19 are stored in row 19, column 32 is not
+        Ke2 = zeros(3, 3)
+        Ke2[2, 1] = 1.0 # entry (19, 5)
+        Ke2[2, 2] = 2.0 # entry (19, 19)
+        a = start_assemble(K)
+        assemble!(a, dofs2, Ke2)
+        @test K[19, 5] == 1.0
+        @test K[19, 19] == 2.0
+        Ke2[2, 3] = 3.0 # entry (19, 32) is not in the sparsity pattern
+        @test_throws ErrorException assemble!(a, dofs2, Ke2)
+
         # Check if coupling works
         grid = generate_grid(Quadrilateral, (2, 2))
         ip = Lagrange{RefQuadrilateral, 1}()


### PR DESCRIPTION
I've hit this slowdown twice now, first in #1395 and then doing some stuff on #1422. It basically happens when you have some dof that couples with all cells. The linear stepping we do now then becomes extremely inefficient.

With the following benchmark:

```julia
using Ferrite, SparseArrays, SparseMatricesCSR, BenchmarkTools

scatter!(K, cells, Ke) = (a = start_assemble(K); for dofs in cells; assemble!(a, dofs, Ke); end)

# Regular mesh: must not regress.
grid = generate_grid(Hexahedron, (25, 25, 25))
dh = DofHandler(grid); add!(dh, :u, Lagrange{RefHexahedron, 1}()); close!(dh)
mesh_cells = [copy(celldofs(dh, c)) for c in 1:getncells(grid)]
Ke = ones(8, 8)

# Every cell also shares the dof `g`, like a global field. Sized g x g the column/row of
# `g` is dense; padded to 2g x 2g it is long but not dense (the two fast paths).
nl, ncells = 8, 4000
g = nl + ncells
cells = [vcat(collect(c:(c + nl - 1)), [g]) for c in 1:ncells]
I, J = Int[], Int[]
for dofs in cells, j in dofs, i in dofs
    push!(I, i); push!(J, j)
end
V = zeros(length(I))
Keg = ones(nl + 1, nl + 1)

for (fmt, Kmesh, Klong, Kdense) in (
        ("CSC", allocate_matrix(dh), sparse(I, J, V, 2g, 2g), sparse(I, J, V, g, g)),
        ("CSR", allocate_matrix(SparseMatrixCSR, dh), sparsecsr(I, J, V, 2g, 2g), sparsecsr(I, J, V, g, g)),
    )
    print(fmt, " regular "); @btime scatter!($Kmesh, $mesh_cells, $Ke)
    print(fmt, " long    "); @btime scatter!($Klong, $cells, $Keg)
    print(fmt, " dense   "); @btime scatter!($Kdense, $cells, $Keg)
end
```

I get

```
Before:
CSC regular   1.704 ms (9 allocations: 496 bytes)
CSC long      6.479 ms (9 allocations: 496 bytes)
CSC dense     6.498 ms (9 allocations: 496 bytes)
CSR regular   2.225 ms (9 allocations: 496 bytes)
CSR long      8.048 ms (9 allocations: 496 bytes)
CSR dense     8.104 ms (9 allocations: 496 bytes)

After:
CSC regular   1.747 ms (9 allocations: 496 bytes)
CSC long      1.101 ms (9 allocations: 496 bytes)
CSC dense     429.042 μs (9 allocations: 496 bytes)
CSR regular   2.262 ms (9 allocations: 496 bytes)
CSR long      1.177 ms (9 allocations: 496 bytes)
CSR dense     492.917 μs (9 allocations: 496 bytes)
```

The slowdown can be made arbitrarily bad by increasing the size of the mesh.
