### PR TITLE
docs: extend the topology section of the grid topic guide and add figures

### DIFF
--- a/docs/diagrams.jl
+++ b/docs/diagrams.jl
@@ -292,6 +292,208 @@ function projected_dirichlet(io, t)
     return print(io, "</svg>\n")
 end
 
+# --- topology figures ---------------------------------------------------------
+
+# Node positions of an n x n quadrilateral grid; index 1 is the bottom/left.
+topo_xs(x0, s, n) = [x0 + (i - 1) * s for i in 1:(n + 1)]
+topo_ys(ybot, s, n) = [ybot - (j - 1) * s for j in 1:(n + 1)]
+
+function topo_gridlines(io, xs, ys, t; c = t.ink, w = 2.0)
+    for x in xs
+        line(io, x, ys[1], x, ys[end]; c, w)
+    end
+    for y in ys
+        line(io, xs[1], y, xs[end], y; c, w)
+    end
+    return
+end
+
+# Center of cell number c (cells numbered row-major from the bottom left).
+function topo_cellcenter(xs, ys, c)
+    n = length(xs) - 1
+    i, j = (c - 1) % n + 1, (c - 1) ÷ n + 1
+    return (xs[i] + xs[i + 1]) / 2, (ys[j] + ys[j + 1]) / 2
+end
+
+"""
+Exclusive neighborhood classification: the neighbors of cell 5 in a 3 x 3 grid,
+colored by the highest-dimensional entity they share with cell 5.
+"""
+function topology_cell_neighbors(io, t)
+    W, H = 430, 424
+    header(io, W, H, t)
+    xs = topo_xs(65.0, 100.0, 3)
+    ys = topo_ys(350.0, 100.0, 3)
+
+    for c in (2, 4, 6, 8) # sharing an edge with cell 5
+        cx, cy = topo_cellcenter(xs, ys, c)
+        rect(io, cx - 50, cy - 50, 100, 100; fill = t.exact, op = 0.18)
+    end
+    for c in (1, 3, 7, 9) # sharing only a vertex with cell 5
+        cx, cy = topo_cellcenter(xs, ys, c)
+        rect(io, cx - 50, cy - 50, 100, 100; fill = t.node, op = 0.18)
+    end
+    rect(io, xs[2], ys[3], 100, 100; fill = "url(#hatch)")
+    topo_gridlines(io, xs, ys, t)
+    for c in 1:9
+        cx, cy = topo_cellcenter(xs, ys, c)
+        pill(io, cx, cy, string(c); fill = t.cell, fg = t.onaccent, w = 28)
+    end
+
+    y = H - 20
+    rect(io, 40, y - 7, 14, 14; fill = "url(#hatch)", stroke = t.ink, sw = 1.2)
+    text(io, 62, y + 5, "the cell"; c = t.muted, size = 14, anchor = "start")
+    rect(io, 140, y - 7, 14, 14; fill = t.exact, op = 0.3, stroke = t.exact, sw = 1.2)
+    text(io, 162, y + 5, "edge neighbors"; c = t.muted, size = 14, anchor = "start")
+    rect(io, 272, y - 7, 14, 14; fill = t.node, op = 0.3, stroke = t.node, sw = 1.2)
+    text(io, 294, y + 5, "vertex neighbors"; c = t.muted, size = 14, anchor = "start")
+    return print(io, "</svg>\n")
+end
+
+"""
+One entity, several local views: an edge shared by two cells and a vertex shared
+by four cells, addressed as (cell, local entity) index pairs.
+"""
+function topology_entity_views(io, t)
+    W, H = 620, 306
+    header(io, W, H, t)
+
+    # left: the edge shared by cells 5 and 6
+    x0, y0, s = 60.0, 95.0, 110.0
+    rect(io, x0, y0, 2s, s; fill = t.tint, op = t.tintop)
+    path(io, "M$(f(x0)),$(f(y0)) H$(f(x0 + 2s)) V$(f(y0 + s)) H$(f(x0)) Z"; c = t.ink, w = 2.2)
+    line(io, x0 + s, y0, x0 + s, y0 + s; c = t.exact, w = 3.5)
+    # local edge numbers, the two views of the shared edge highlighted
+    for (k, hl) in ((0, 2), (1, 4)) # cell offset, highlighted local edge
+        cx = x0 + k * s + s / 2
+        for (i, (ex, ey)) in enumerate(
+                [(cx, y0 + s - 8), (x0 + (k + 1) * s - 12, y0 + s / 2 + 4), (cx, y0 + 18), (x0 + k * s + 12, y0 + s / 2 + 4)]
+            )
+            c, weight = i == hl ? (t.exact, "700") : (t.muted, "400")
+            text(io, ex, ey, string(i); c, size = 13, weight)
+        end
+    end
+    pill(io, x0 + s / 2, y0 + s / 2, "5"; fill = t.cell, fg = t.onaccent)
+    pill(io, x0 + 3s / 2, y0 + s / 2, "6"; fill = t.cell, fg = t.onaccent)
+    text(io, x0 + s, 262, "EdgeIndex(5, 2) ↔ EdgeIndex(6, 4)"; c = t.ink, size = 15)
+    text(io, x0 + s, 284, "two views of the same edge"; c = t.muted, size = 14)
+
+    # right: the vertex shared by cells 5, 6, 8, and 9
+    vx0, vy0, vs = 380.0, 60.0, 90.0
+    vcx, vcy = vx0 + vs, vy0 + vs
+    rect(io, vx0, vy0, 2vs, 2vs; fill = t.tint, op = t.tintop)
+    path(io, "M$(f(vx0)),$(f(vy0)) H$(f(vx0 + 2vs)) V$(f(vy0 + 2vs)) H$(f(vx0)) Z"; c = t.ink, w = 2.2)
+    line(io, vcx, vy0, vcx, vy0 + 2vs; c = t.ink, w = 2.0)
+    line(io, vx0, vcy, vx0 + 2vs, vcy; c = t.ink, w = 2.0)
+    # local number of the shared vertex in each of the four cells
+    for (nr, dx, dy, an) in [(3, -12, 20, "end"), (4, 12, 20, "start"), (2, -12, -12, "end"), (1, 12, -12, "start")]
+        text(io, vcx + dx, vcy + dy, string(nr); c = t.exact, size = 13, weight = "700", anchor = an)
+    end
+    dot(io, vcx, vcy, 7.5; c = t.exact)
+    for (c, dx, dy) in [(5, -1, 1), (6, 1, 1), (8, -1, -1), (9, 1, -1)]
+        pill(io, vcx + dx * vs / 2, vcy + dy * vs / 2, string(c); fill = t.cell, fg = t.onaccent)
+    end
+    text(io, vcx, 262, "VertexIndex: (5, 3), (6, 4), (8, 2), (9, 1)"; c = t.ink, size = 15)
+    text(io, vcx, 284, "four views of the same vertex"; c = t.muted, size = 14)
+    return print(io, "</svg>\n")
+end
+
+"""
+The facet skeleton: each of the 24 unique facets of the 3 x 3 grid exactly once,
+split into interior and boundary facets.
+"""
+function topology_facet_skeleton(io, t)
+    W, H = 430, 410
+    header(io, W, H, t)
+    xs = topo_xs(65.0, 100.0, 3)
+    ys = topo_ys(350.0, 100.0, 3)
+    topo_gridlines(io, xs, ys, t; c = t.muted, w = 1.2)
+    g = 9.0 # gap at the nodes so that each facet reads as its own segment
+    for i in 1:4, j in 1:3 # vertical facets
+        c = i in (2, 3) ? t.cell : t.exact
+        line(io, xs[i], ys[j] - g, xs[i], ys[j + 1] + g; c, w = 3.5)
+    end
+    for j in 1:4, i in 1:3 # horizontal facets
+        c = j in (2, 3) ? t.cell : t.exact
+        line(io, xs[i] + g, ys[j], xs[i + 1] - g, ys[j]; c, w = 3.5)
+    end
+    for x in xs, y in ys
+        dot(io, x, y, 3.0; c = t.muted)
+    end
+
+    y = H - 20
+    line(io, 60, y, 94, y; c = t.cell, w = 3.5)
+    text(io, 104, y + 5, "interior facet"; c = t.muted, size = 14, anchor = "start")
+    line(io, 235, y, 269, y; c = t.exact, w = 3.5)
+    text(io, 279, y + 5, "boundary facet"; c = t.muted, size = 14, anchor = "start")
+    return print(io, "</svg>\n")
+end
+
+"""
+A grid with mixed reference dimensions: a `Line` cell lying on the edge of a
+`Quadrilateral`, drawn offset from the shared nodes for clarity.
+"""
+function topology_mixed_dim(io, t)
+    W, H = 430, 400
+    header(io, W, H, t)
+    x0, x1, lx = 120.0, 260.0, 284.0
+    ys = (50.0, 190.0, 330.0)
+
+    rect(io, x0, ys[1], x1 - x0, ys[3] - ys[1]; fill = t.tint, op = t.tintop)
+    path(io, "M$(f(x0)),$(f(ys[1])) H$(f(x1)) V$(f(ys[3])) H$(f(x0)) Z"; c = t.ink, w = 2.2)
+    line(io, x0, ys[2], x1, ys[2]; c = t.ink, w = 2.0)
+
+    # the line cell, offset from the edge it sits on
+    line(io, lx, ys[1], lx, ys[2]; c = t.cell, w = 4.5)
+    for y in (ys[1], ys[2])
+        line(io, x1, y, lx, y; c = t.muted, w = 1.2, dash = "3 4")
+        dot(io, lx, y, 5.5; c = t.node)
+    end
+
+    # global node numbers
+    for (n, x, y, dx, dy, an) in [
+            (1, x0, ys[3], -13, 6, "end"), (2, x1, ys[3], 13, 6, "start"),
+            (3, x0, ys[2], -13, 6, "end"), (4, x1, ys[2], -8, 24, "end"),
+            (5, x0, ys[1], -13, 6, "end"), (6, x1, ys[1], -8, -12, "end"),
+        ]
+        dot(io, x, y, 6.0; c = t.node)
+        text(io, x + dx, y + dy, string(n); c = t.node, size = 18, anchor = an, weight = "700")
+    end
+
+    pill(io, (x0 + x1) / 2, (ys[1] + ys[2]) / 2, "1"; fill = t.cell, fg = t.onaccent, w = 28)
+    pill(io, (x0 + x1) / 2, (ys[2] + ys[3]) / 2, "3"; fill = t.cell, fg = t.onaccent, w = 28)
+    pill(io, lx, (ys[1] + ys[2]) / 2, "2"; fill = t.cell, fg = t.onaccent, w = 28)
+
+    text(io, W / 2, 365, "cell 2 is a Line lying on the right edge of cell 1"; c = t.muted, size = 14)
+    text(io, W / 2, 385, "(drawn offset for clarity)"; c = t.muted, size = 14)
+    return print(io, "</svg>\n")
+end
+
+"""
+The star (stencil) of a vertex: the vertex itself and all vertices connected to
+it by an edge.
+"""
+function topology_vertex_star(io, t)
+    W, H = 430, 410
+    header(io, W, H, t)
+    xs = topo_xs(65.0, 100.0, 3)
+    ys = topo_ys(350.0, 100.0, 3)
+    topo_gridlines(io, xs, ys, t; c = t.muted, w = 1.2)
+    cx, cy = xs[3], ys[3]
+    for (nx, ny) in ((xs[2], ys[3]), (xs[4], ys[3]), (xs[3], ys[2]), (xs[3], ys[4]))
+        line(io, cx, cy, nx, ny; c = t.cell, w = 3.5)
+        dot(io, nx, ny, 6.5; c = t.node)
+    end
+    dot(io, cx, cy, 8.0; c = t.exact)
+
+    y = H - 20
+    dot(io, 67, y, 7.0; c = t.exact)
+    text(io, 82, y + 5, "center vertex"; c = t.muted, size = 14, anchor = "start")
+    dot(io, 227, y, 6.5; c = t.node)
+    text(io, 242, y + 5, "edge-connected vertices"; c = t.muted, size = 14, anchor = "start")
+    return print(io, "</svg>\n")
+end
+
 # --- driver -------------------------------------------------------------------
 
 const FIGURES = [
@@ -299,6 +501,11 @@ const FIGURES = [
     "global_mesh" => global_mesh,
     "fe_mapping" => fe_mapping,
     "projected_dirichlet" => projected_dirichlet,
+    "topology_cell_neighbors" => topology_cell_neighbors,
+    "topology_entity_views" => topology_entity_views,
+    "topology_facet_skeleton" => topology_facet_skeleton,
+    "topology_mixed_dim" => topology_mixed_dim,
+    "topology_vertex_star" => topology_vertex_star,
 ]
 
 function main(dir = @__DIR__)

--- a/docs/src/topics/assets/topology_cell_neighbors-dark.svg
+++ b/docs/src/topics/assets/topology_cell_neighbors-dark.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 424" width="430" height="424">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#dfe4ea"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#98a2b0" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="165.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#00c9a0" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="150.0" width="100.0" height="100.0" rx="0" fill="#00c9a0" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="150.0" width="100.0" height="100.0" rx="0" fill="#00c9a0" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="165.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#00c9a0" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#56b4e9" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#56b4e9" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#56b4e9" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#56b4e9" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="165.0" y="150.0" width="100.0" height="100.0" rx="0" fill="url(#hatch)" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<rect x="101.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="305.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">1</text>
+<rect x="201.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="305.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<rect x="301.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="305.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">3</text>
+<rect x="101.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="205.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">4</text>
+<rect x="201.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="205.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="301.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="205.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<rect x="101.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="105.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">7</text>
+<rect x="201.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="105.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">8</text>
+<rect x="301.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="105.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">9</text>
+<rect x="40.0" y="397.0" width="14.0" height="14.0" rx="0" fill="url(#hatch)" fill-opacity="1" stroke="#dfe4ea" stroke-width="1.2"/>
+<text x="62.0" y="409.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">the cell</text>
+<rect x="140.0" y="397.0" width="14.0" height="14.0" rx="0" fill="#00c9a0" fill-opacity="0.3" stroke="#00c9a0" stroke-width="1.2"/>
+<text x="162.0" y="409.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">edge neighbors</text>
+<rect x="272.0" y="397.0" width="14.0" height="14.0" rx="0" fill="#56b4e9" fill-opacity="0.3" stroke="#56b4e9" stroke-width="1.2"/>
+<text x="294.0" y="409.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">vertex neighbors</text>
+</svg>

--- a/docs/src/topics/assets/topology_cell_neighbors-light.svg
+++ b/docs/src/topics/assets/topology_cell_neighbors-light.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 424" width="430" height="424">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#1c2024"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#5d6773" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="165.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#009e73" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="150.0" width="100.0" height="100.0" rx="0" fill="#009e73" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="150.0" width="100.0" height="100.0" rx="0" fill="#009e73" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="165.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#009e73" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#0072b2" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="250.0" width="100.0" height="100.0" rx="0" fill="#0072b2" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="65.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#0072b2" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="265.0" y="50.0" width="100.0" height="100.0" rx="0" fill="#0072b2" fill-opacity="0.18" stroke="none" stroke-width="2.0"/>
+<rect x="165.0" y="150.0" width="100.0" height="100.0" rx="0" fill="url(#hatch)" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<rect x="101.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="305.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">1</text>
+<rect x="201.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="305.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<rect x="301.0" y="289.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="305.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">3</text>
+<rect x="101.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="205.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">4</text>
+<rect x="201.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="205.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="301.0" y="189.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="205.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<rect x="101.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="105.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">7</text>
+<rect x="201.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="215.0" y="105.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">8</text>
+<rect x="301.0" y="89.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="315.0" y="105.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">9</text>
+<rect x="40.0" y="397.0" width="14.0" height="14.0" rx="0" fill="url(#hatch)" fill-opacity="1" stroke="#1c2024" stroke-width="1.2"/>
+<text x="62.0" y="409.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">the cell</text>
+<rect x="140.0" y="397.0" width="14.0" height="14.0" rx="0" fill="#009e73" fill-opacity="0.3" stroke="#009e73" stroke-width="1.2"/>
+<text x="162.0" y="409.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">edge neighbors</text>
+<rect x="272.0" y="397.0" width="14.0" height="14.0" rx="0" fill="#0072b2" fill-opacity="0.3" stroke="#0072b2" stroke-width="1.2"/>
+<text x="294.0" y="409.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">vertex neighbors</text>
+</svg>

--- a/docs/src/topics/assets/topology_entity_views-dark.svg
+++ b/docs/src/topics/assets/topology_entity_views-dark.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 306" width="620" height="306">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#dfe4ea"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#98a2b0" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="60.0" y="95.0" width="220.0" height="110.0" rx="0" fill="#56b4e9" fill-opacity="0.05" stroke="none" stroke-width="2.0"/>
+<path d="M60.0,95.0 H280.0 V205.0 H60.0 Z" fill="none" stroke="#dfe4ea" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="170.0" y1="95.0" x2="170.0" y2="205.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<text x="115.0" y="197.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">1</text>
+<text x="158.0" y="154.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<text x="115.0" y="113.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">3</text>
+<text x="72.0" y="154.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">4</text>
+<text x="225.0" y="197.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">1</text>
+<text x="268.0" y="154.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">2</text>
+<text x="225.0" y="113.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">3</text>
+<text x="182.0" y="154.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="middle">4</text>
+<rect x="102.0" y="139.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="155.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="212.0" y="139.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="225.0" y="155.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<text x="170.0" y="262.0" fill="#dfe4ea" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="400" font-style="normal" text-anchor="middle">EdgeIndex(5, 2) ↔ EdgeIndex(6, 4)</text>
+<text x="170.0" y="284.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">two views of the same edge</text>
+<rect x="380.0" y="60.0" width="180.0" height="180.0" rx="0" fill="#56b4e9" fill-opacity="0.05" stroke="none" stroke-width="2.0"/>
+<path d="M380.0,60.0 H560.0 V240.0 H380.0 Z" fill="none" stroke="#dfe4ea" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="470.0" y1="60.0" x2="470.0" y2="240.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="380.0" y1="150.0" x2="560.0" y2="150.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<text x="458.0" y="170.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="end">3</text>
+<text x="482.0" y="170.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="start">4</text>
+<text x="458.0" y="138.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="end">2</text>
+<text x="482.0" y="138.0" fill="#00c9a0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="start">1</text>
+<circle cx="470.0" cy="150.0" r="7.5" fill="#00c9a0"/>
+<rect x="412.0" y="184.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="425.0" y="200.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="502.0" y="184.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="515.0" y="200.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<rect x="412.0" y="94.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="425.0" y="110.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">8</text>
+<rect x="502.0" y="94.5" width="26.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="515.0" y="110.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">9</text>
+<text x="470.0" y="262.0" fill="#dfe4ea" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="400" font-style="normal" text-anchor="middle">VertexIndex: (5, 3), (6, 4), (8, 2), (9, 1)</text>
+<text x="470.0" y="284.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">four views of the same vertex</text>
+</svg>

--- a/docs/src/topics/assets/topology_entity_views-light.svg
+++ b/docs/src/topics/assets/topology_entity_views-light.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 306" width="620" height="306">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#1c2024"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#5d6773" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="60.0" y="95.0" width="220.0" height="110.0" rx="0" fill="#0072b2" fill-opacity="0.08" stroke="none" stroke-width="2.0"/>
+<path d="M60.0,95.0 H280.0 V205.0 H60.0 Z" fill="none" stroke="#1c2024" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="170.0" y1="95.0" x2="170.0" y2="205.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<text x="115.0" y="197.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">1</text>
+<text x="158.0" y="154.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<text x="115.0" y="113.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">3</text>
+<text x="72.0" y="154.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">4</text>
+<text x="225.0" y="197.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">1</text>
+<text x="268.0" y="154.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">2</text>
+<text x="225.0" y="113.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="400" font-style="normal" text-anchor="middle">3</text>
+<text x="182.0" y="154.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="middle">4</text>
+<rect x="102.0" y="139.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="115.0" y="155.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="212.0" y="139.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="225.0" y="155.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<text x="170.0" y="262.0" fill="#1c2024" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="400" font-style="normal" text-anchor="middle">EdgeIndex(5, 2) ↔ EdgeIndex(6, 4)</text>
+<text x="170.0" y="284.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">two views of the same edge</text>
+<rect x="380.0" y="60.0" width="180.0" height="180.0" rx="0" fill="#0072b2" fill-opacity="0.08" stroke="none" stroke-width="2.0"/>
+<path d="M380.0,60.0 H560.0 V240.0 H380.0 Z" fill="none" stroke="#1c2024" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="470.0" y1="60.0" x2="470.0" y2="240.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="380.0" y1="150.0" x2="560.0" y2="150.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<text x="458.0" y="170.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="end">3</text>
+<text x="482.0" y="170.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="start">4</text>
+<text x="458.0" y="138.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="end">2</text>
+<text x="482.0" y="138.0" fill="#009e73" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="13" font-weight="700" font-style="normal" text-anchor="start">1</text>
+<circle cx="470.0" cy="150.0" r="7.5" fill="#009e73"/>
+<rect x="412.0" y="184.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="425.0" y="200.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">5</text>
+<rect x="502.0" y="184.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="515.0" y="200.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">6</text>
+<rect x="412.0" y="94.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="425.0" y="110.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">8</text>
+<rect x="502.0" y="94.5" width="26.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="515.0" y="110.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">9</text>
+<text x="470.0" y="262.0" fill="#1c2024" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="400" font-style="normal" text-anchor="middle">VertexIndex: (5, 3), (6, 4), (8, 2), (9, 1)</text>
+<text x="470.0" y="284.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">four views of the same vertex</text>
+</svg>

--- a/docs/src/topics/assets/topology_facet_skeleton-dark.svg
+++ b/docs/src/topics/assets/topology_facet_skeleton-dark.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 410" width="430" height="410">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#dfe4ea"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#98a2b0" stroke-width="1.1"/></pattern>
+</defs>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="341.0" x2="65.0" y2="259.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="65.0" y1="241.0" x2="65.0" y2="159.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="65.0" y1="141.0" x2="65.0" y2="59.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="341.0" x2="165.0" y2="259.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="241.0" x2="165.0" y2="159.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="141.0" x2="165.0" y2="59.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="341.0" x2="265.0" y2="259.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="241.0" x2="265.0" y2="159.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="141.0" x2="265.0" y2="59.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="341.0" x2="365.0" y2="259.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="241.0" x2="365.0" y2="159.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="141.0" x2="365.0" y2="59.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="350.0" x2="156.0" y2="350.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="350.0" x2="256.0" y2="350.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="350.0" x2="356.0" y2="350.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="250.0" x2="156.0" y2="250.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="250.0" x2="256.0" y2="250.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="250.0" x2="356.0" y2="250.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="150.0" x2="156.0" y2="150.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="150.0" x2="256.0" y2="150.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="150.0" x2="356.0" y2="150.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="50.0" x2="156.0" y2="50.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="50.0" x2="256.0" y2="50.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="50.0" x2="356.0" y2="50.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="65.0" cy="350.0" r="3.0" fill="#98a2b0"/>
+<circle cx="65.0" cy="250.0" r="3.0" fill="#98a2b0"/>
+<circle cx="65.0" cy="150.0" r="3.0" fill="#98a2b0"/>
+<circle cx="65.0" cy="50.0" r="3.0" fill="#98a2b0"/>
+<circle cx="165.0" cy="350.0" r="3.0" fill="#98a2b0"/>
+<circle cx="165.0" cy="250.0" r="3.0" fill="#98a2b0"/>
+<circle cx="165.0" cy="150.0" r="3.0" fill="#98a2b0"/>
+<circle cx="165.0" cy="50.0" r="3.0" fill="#98a2b0"/>
+<circle cx="265.0" cy="350.0" r="3.0" fill="#98a2b0"/>
+<circle cx="265.0" cy="250.0" r="3.0" fill="#98a2b0"/>
+<circle cx="265.0" cy="150.0" r="3.0" fill="#98a2b0"/>
+<circle cx="265.0" cy="50.0" r="3.0" fill="#98a2b0"/>
+<circle cx="365.0" cy="350.0" r="3.0" fill="#98a2b0"/>
+<circle cx="365.0" cy="250.0" r="3.0" fill="#98a2b0"/>
+<circle cx="365.0" cy="150.0" r="3.0" fill="#98a2b0"/>
+<circle cx="365.0" cy="50.0" r="3.0" fill="#98a2b0"/>
+<line x1="60.0" y1="390.0" x2="94.0" y2="390.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<text x="104.0" y="395.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">interior facet</text>
+<line x1="235.0" y1="390.0" x2="269.0" y2="390.0" stroke="#00c9a0" stroke-width="3.5" stroke-linecap="round"/>
+<text x="279.0" y="395.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">boundary facet</text>
+</svg>

--- a/docs/src/topics/assets/topology_facet_skeleton-light.svg
+++ b/docs/src/topics/assets/topology_facet_skeleton-light.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 410" width="430" height="410">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#1c2024"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#5d6773" stroke-width="1.1"/></pattern>
+</defs>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="341.0" x2="65.0" y2="259.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="65.0" y1="241.0" x2="65.0" y2="159.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="65.0" y1="141.0" x2="65.0" y2="59.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="341.0" x2="165.0" y2="259.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="241.0" x2="165.0" y2="159.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="165.0" y1="141.0" x2="165.0" y2="59.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="341.0" x2="265.0" y2="259.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="241.0" x2="265.0" y2="159.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="265.0" y1="141.0" x2="265.0" y2="59.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="341.0" x2="365.0" y2="259.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="241.0" x2="365.0" y2="159.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="365.0" y1="141.0" x2="365.0" y2="59.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="350.0" x2="156.0" y2="350.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="350.0" x2="256.0" y2="350.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="350.0" x2="356.0" y2="350.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="250.0" x2="156.0" y2="250.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="250.0" x2="256.0" y2="250.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="250.0" x2="356.0" y2="250.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="150.0" x2="156.0" y2="150.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="150.0" x2="256.0" y2="150.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="150.0" x2="356.0" y2="150.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="74.0" y1="50.0" x2="156.0" y2="50.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="174.0" y1="50.0" x2="256.0" y2="50.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="274.0" y1="50.0" x2="356.0" y2="50.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="65.0" cy="350.0" r="3.0" fill="#5d6773"/>
+<circle cx="65.0" cy="250.0" r="3.0" fill="#5d6773"/>
+<circle cx="65.0" cy="150.0" r="3.0" fill="#5d6773"/>
+<circle cx="65.0" cy="50.0" r="3.0" fill="#5d6773"/>
+<circle cx="165.0" cy="350.0" r="3.0" fill="#5d6773"/>
+<circle cx="165.0" cy="250.0" r="3.0" fill="#5d6773"/>
+<circle cx="165.0" cy="150.0" r="3.0" fill="#5d6773"/>
+<circle cx="165.0" cy="50.0" r="3.0" fill="#5d6773"/>
+<circle cx="265.0" cy="350.0" r="3.0" fill="#5d6773"/>
+<circle cx="265.0" cy="250.0" r="3.0" fill="#5d6773"/>
+<circle cx="265.0" cy="150.0" r="3.0" fill="#5d6773"/>
+<circle cx="265.0" cy="50.0" r="3.0" fill="#5d6773"/>
+<circle cx="365.0" cy="350.0" r="3.0" fill="#5d6773"/>
+<circle cx="365.0" cy="250.0" r="3.0" fill="#5d6773"/>
+<circle cx="365.0" cy="150.0" r="3.0" fill="#5d6773"/>
+<circle cx="365.0" cy="50.0" r="3.0" fill="#5d6773"/>
+<line x1="60.0" y1="390.0" x2="94.0" y2="390.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<text x="104.0" y="395.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">interior facet</text>
+<line x1="235.0" y1="390.0" x2="269.0" y2="390.0" stroke="#009e73" stroke-width="3.5" stroke-linecap="round"/>
+<text x="279.0" y="395.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">boundary facet</text>
+</svg>

--- a/docs/src/topics/assets/topology_mixed_dim-dark.svg
+++ b/docs/src/topics/assets/topology_mixed_dim-dark.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 400" width="430" height="400">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#dfe4ea"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#98a2b0" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="120.0" y="50.0" width="140.0" height="280.0" rx="0" fill="#56b4e9" fill-opacity="0.05" stroke="none" stroke-width="2.0"/>
+<path d="M120.0,50.0 H260.0 V330.0 H120.0 Z" fill="none" stroke="#dfe4ea" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="120.0" y1="190.0" x2="260.0" y2="190.0" stroke="#dfe4ea" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="284.0" y1="50.0" x2="284.0" y2="190.0" stroke="#e69f00" stroke-width="4.5" stroke-linecap="round"/>
+<line x1="260.0" y1="50.0" x2="284.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round" stroke-dasharray="3 4"/>
+<circle cx="284.0" cy="50.0" r="5.5" fill="#56b4e9"/>
+<line x1="260.0" y1="190.0" x2="284.0" y2="190.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round" stroke-dasharray="3 4"/>
+<circle cx="284.0" cy="190.0" r="5.5" fill="#56b4e9"/>
+<circle cx="120.0" cy="330.0" r="6.0" fill="#56b4e9"/>
+<text x="107.0" y="336.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">1</text>
+<circle cx="260.0" cy="330.0" r="6.0" fill="#56b4e9"/>
+<text x="273.0" y="336.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="start">2</text>
+<circle cx="120.0" cy="190.0" r="6.0" fill="#56b4e9"/>
+<text x="107.0" y="196.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">3</text>
+<circle cx="260.0" cy="190.0" r="6.0" fill="#56b4e9"/>
+<text x="252.0" y="214.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">4</text>
+<circle cx="120.0" cy="50.0" r="6.0" fill="#56b4e9"/>
+<text x="107.0" y="56.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">5</text>
+<circle cx="260.0" cy="50.0" r="6.0" fill="#56b4e9"/>
+<text x="252.0" y="38.0" fill="#56b4e9" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">6</text>
+<rect x="176.0" y="109.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="190.0" y="125.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">1</text>
+<rect x="176.0" y="249.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="190.0" y="265.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">3</text>
+<rect x="270.0" y="109.5" width="28.0" height="21.0" rx="10.5" fill="#e69f00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="284.0" y="125.25" fill="#12171c" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<text x="215.0" y="365.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">cell 2 is a Line lying on the right edge of cell 1</text>
+<text x="215.0" y="385.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">(drawn offset for clarity)</text>
+</svg>

--- a/docs/src/topics/assets/topology_mixed_dim-light.svg
+++ b/docs/src/topics/assets/topology_mixed_dim-light.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 400" width="430" height="400">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#1c2024"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#5d6773" stroke-width="1.1"/></pattern>
+</defs>
+<rect x="120.0" y="50.0" width="140.0" height="280.0" rx="0" fill="#0072b2" fill-opacity="0.08" stroke="none" stroke-width="2.0"/>
+<path d="M120.0,50.0 H260.0 V330.0 H120.0 Z" fill="none" stroke="#1c2024" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="120.0" y1="190.0" x2="260.0" y2="190.0" stroke="#1c2024" stroke-width="2.0" stroke-linecap="round"/>
+<line x1="284.0" y1="50.0" x2="284.0" y2="190.0" stroke="#d55e00" stroke-width="4.5" stroke-linecap="round"/>
+<line x1="260.0" y1="50.0" x2="284.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round" stroke-dasharray="3 4"/>
+<circle cx="284.0" cy="50.0" r="5.5" fill="#0072b2"/>
+<line x1="260.0" y1="190.0" x2="284.0" y2="190.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round" stroke-dasharray="3 4"/>
+<circle cx="284.0" cy="190.0" r="5.5" fill="#0072b2"/>
+<circle cx="120.0" cy="330.0" r="6.0" fill="#0072b2"/>
+<text x="107.0" y="336.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">1</text>
+<circle cx="260.0" cy="330.0" r="6.0" fill="#0072b2"/>
+<text x="273.0" y="336.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="start">2</text>
+<circle cx="120.0" cy="190.0" r="6.0" fill="#0072b2"/>
+<text x="107.0" y="196.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">3</text>
+<circle cx="260.0" cy="190.0" r="6.0" fill="#0072b2"/>
+<text x="252.0" y="214.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">4</text>
+<circle cx="120.0" cy="50.0" r="6.0" fill="#0072b2"/>
+<text x="107.0" y="56.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">5</text>
+<circle cx="260.0" cy="50.0" r="6.0" fill="#0072b2"/>
+<text x="252.0" y="38.0" fill="#0072b2" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="18" font-weight="700" font-style="normal" text-anchor="end">6</text>
+<rect x="176.0" y="109.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="190.0" y="125.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">1</text>
+<rect x="176.0" y="249.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="190.0" y="265.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">3</text>
+<rect x="270.0" y="109.5" width="28.0" height="21.0" rx="10.5" fill="#d55e00" fill-opacity="1" stroke="none" stroke-width="2.0"/>
+<text x="284.0" y="125.25" fill="#ffffff" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="15" font-weight="700" font-style="normal" text-anchor="middle">2</text>
+<text x="215.0" y="365.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">cell 2 is a Line lying on the right edge of cell 1</text>
+<text x="215.0" y="385.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="middle">(drawn offset for clarity)</text>
+</svg>

--- a/docs/src/topics/assets/topology_vertex_star-dark.svg
+++ b/docs/src/topics/assets/topology_vertex_star-dark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 410" width="430" height="410">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#dfe4ea"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#98a2b0" stroke-width="1.1"/></pattern>
+</defs>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#98a2b0" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="150.0" x2="165.0" y2="150.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="165.0" cy="150.0" r="6.5" fill="#56b4e9"/>
+<line x1="265.0" y1="150.0" x2="365.0" y2="150.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="365.0" cy="150.0" r="6.5" fill="#56b4e9"/>
+<line x1="265.0" y1="150.0" x2="265.0" y2="250.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="265.0" cy="250.0" r="6.5" fill="#56b4e9"/>
+<line x1="265.0" y1="150.0" x2="265.0" y2="50.0" stroke="#e69f00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="265.0" cy="50.0" r="6.5" fill="#56b4e9"/>
+<circle cx="265.0" cy="150.0" r="8.0" fill="#00c9a0"/>
+<circle cx="67.0" cy="390.0" r="7.0" fill="#00c9a0"/>
+<text x="82.0" y="395.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">center vertex</text>
+<circle cx="227.0" cy="390.0" r="6.5" fill="#56b4e9"/>
+<text x="242.0" y="395.0" fill="#98a2b0" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">edge-connected vertices</text>
+</svg>

--- a/docs/src/topics/assets/topology_vertex_star-light.svg
+++ b/docs/src/topics/assets/topology_vertex_star-light.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 410" width="430" height="410">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+        orient="auto-start-reverse"><path d="M0,0.6 L10,5 L0,9.4 z" fill="#1c2024"/></marker>
+<pattern id="hatch" width="7" height="7" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+<line x1="0" y1="0" x2="0" y2="7" stroke="#5d6773" stroke-width="1.1"/></pattern>
+</defs>
+<line x1="65.0" y1="350.0" x2="65.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="165.0" y1="350.0" x2="165.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="350.0" x2="265.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="365.0" y1="350.0" x2="365.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="350.0" x2="365.0" y2="350.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="250.0" x2="365.0" y2="250.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="150.0" x2="365.0" y2="150.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="65.0" y1="50.0" x2="365.0" y2="50.0" stroke="#5d6773" stroke-width="1.2" stroke-linecap="round"/>
+<line x1="265.0" y1="150.0" x2="165.0" y2="150.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="165.0" cy="150.0" r="6.5" fill="#0072b2"/>
+<line x1="265.0" y1="150.0" x2="365.0" y2="150.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="365.0" cy="150.0" r="6.5" fill="#0072b2"/>
+<line x1="265.0" y1="150.0" x2="265.0" y2="250.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="265.0" cy="250.0" r="6.5" fill="#0072b2"/>
+<line x1="265.0" y1="150.0" x2="265.0" y2="50.0" stroke="#d55e00" stroke-width="3.5" stroke-linecap="round"/>
+<circle cx="265.0" cy="50.0" r="6.5" fill="#0072b2"/>
+<circle cx="265.0" cy="150.0" r="8.0" fill="#009e73"/>
+<circle cx="67.0" cy="390.0" r="7.0" fill="#009e73"/>
+<text x="82.0" y="395.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">center vertex</text>
+<circle cx="227.0" cy="390.0" r="6.5" fill="#0072b2"/>
+<text x="242.0" y="395.0" fill="#5d6773" font-family="Lato,'Helvetica Neue',Helvetica,Arial,sans-serif" font-size="14" font-weight="400" font-style="normal" text-anchor="start">edge-connected vertices</text>
+</svg>

--- a/docs/src/topics/grid.md
+++ b/docs/src/topics/grid.md
@@ -201,8 +201,8 @@ that vertices, edges, and faces denote entities of fixed dimension 0, 1, and 2,
 independent of the spatial dimension of the grid, see
 [Entity naming](@ref entity-naming-docs). In addition, [`FacetIndex`](@ref) addresses
 *facets*, i.e. the entities separating cells: vertices in 1D, edges in 2D, and faces in
-3D. Since an
-interior entity is part of more than one cell it has multiple valid indices, one for each
+3D. Since an interior entity is part of more than
+one cell it has multiple valid indices, one for each
 cell containing it:
 
 ![Local views of an edge shared by two cells and a vertex shared by four cells](./assets/topology_entity_views-light.svg)

--- a/docs/src/topics/grid.md
+++ b/docs/src/topics/grid.md
@@ -147,39 +147,196 @@ In order to use boundaries, e.g. for Dirichlet constraints in the ConstraintHand
 
 ## Topology
 
-Ferrite.jl's `Grid` type offers experimental features w.r.t. topology information. The functions [`getneighborhood`](@ref) and [`facetskeleton`](@ref)
-are the interface to obtain topological information.The [`getneighborhood`](@ref) can construct lists of directly connected entities based on a given entity
-(`CellIndex`, `FacetIndex`, `FaceIndex`, `EdgeIndex`, or `VertexIndex`). Please remember that the dimensions of faces (dim=2) and edges (dim=1) are fixed, i.e.
-they are defined independent of the spatial dimension of the grid. You can consult [the entity naming page](@ref entity-naming-docs) for details.
-The [`facetskeleton`](@ref) function can be used to evaluate integrals over material interfaces or computing element interface values such as jumps.
+A `Grid` stores each cell as a tuple of global node ids, but does not directly answer
+questions like "which cells are neighbors of cell 5?" or "which facets are on the interior
+of the domain?". This kind of connectivity information can be computed with
+[`ExclusiveTopology`](@ref):
 
-When working with the topology it can be helpful to express algorithms in terms of
-dimension and co-dimension. This can be especially interesting when dealing with
-embedded elements in mixed dimensional grids, because the neighbour can now have a
-different reference dimension. For example we could have a line attached to a
-quadrilateral in 2D as sketched below:
+```@repl topology
+using Ferrite #hide
+grid = generate_grid(Quadrilateral, (3, 3));
+topology = ExclusiveTopology(grid);
 ```
-+-----+ +
-|     | |
-|  1  | 2
-|     | |
-+-----+ +
-|     |
-|  3  |
-|     |
-+-----+
+
+!!! warning "Experimental feature"
+    `ExclusiveTopology` is an experimental feature and may change in future releases.
+    It only works for conforming grids, i.e. grids without "hanging nodes", and requires
+    the highest reference dimension among the cells to equal the spatial dimension
+    (purely embedded grids, e.g. a shell grid of `Quadrilateral`s in 3D space, are not
+    supported).
+
+The examples in this section use the 3 × 3 quadrilateral grid constructed above, with
+cells numbered row-wise starting in the bottom left corner.
+
+### Neighborhood of a cell
+
+Two cells are considered neighbors if they share at least one vertex. The name
+*exclusive* refers to how the neighborhood is classified and stored: each pair of
+neighboring cells is only connected through the highest-dimensional entity they share.
+Cells sharing a face are *face neighbors*, cells sharing an edge, but no face, are *edge
+neighbors*, and cells sharing only a vertex are *vertex neighbors*. In the grid below,
+cell 5 has four edge neighbors (cells 2, 4, 6, and 8) and four vertex neighbors (cells 1,
+3, 7, and 9). (Face neighbors only exist in 3D, and in 1D all neighbors are vertex
+neighbors.)
+
+![The neighbors of cell 5, classified by the entity they share with it](./assets/topology_cell_neighbors-light.svg)
+![The neighbors of cell 5, classified by the entity they share with it](./assets/topology_cell_neighbors-dark.svg)
+
+Neighborhood queries go through [`getneighborhood`](@ref). Passing a `CellIndex` returns
+all neighboring cells, regardless of how they are connected:
+
+```@repl topology
+getneighborhood(topology, grid, CellIndex(5))
 ```
-Then we can handle the following cases
+
+The returned collections are lightweight `AbstractVector` views -- treat them as
+read-only and `collect` them if an independent copy is needed.
+
+### Neighborhood of vertices, edges, and faces
+
+Vertices, edges, and faces are addressed by a `(cell id, local entity id)` pair, wrapped
+in [`VertexIndex`](@ref), [`EdgeIndex`](@ref), or [`FaceIndex`](@ref), where the local
+numbering is defined by the cell's reference shape (see [Reference shapes](@ref)). Note
+that vertices, edges, and faces denote entities of fixed dimension 0, 1, and 2,
+independent of the spatial dimension of the grid, see
+[Entity naming](@ref entity-naming-docs). In addition, [`FacetIndex`](@ref) addresses
+*facets*, i.e. the entities separating cells: vertices in 1D, edges in 2D, and faces in
+3D. Since an
+interior entity is part of more than one cell it has multiple valid indices, one for each
+cell containing it:
+
+![Local views of an edge shared by two cells and a vertex shared by four cells](./assets/topology_entity_views-light.svg)
+![Local views of an edge shared by two cells and a vertex shared by four cells](./assets/topology_entity_views-dark.svg)
+
+For these index types `getneighborhood` returns the *other* local views of the same
+entity, i.e. how the entity is addressed from the neighboring cells:
+
+```@repl topology
+getneighborhood(topology, grid, FacetIndex(5, 2))
+getneighborhood(topology, grid, VertexIndex(5, 3))
+```
+
+With the optional argument `include_self` set to `true` the queried entity itself is
+also included, thus giving all equivalent representations:
+
+```@repl topology
+getneighborhood(topology, grid, VertexIndex(5, 3), true)
+```
+
+### The facet skeleton
+
+A loop over all facets of all cells visits interior facets twice: once from each of the
+two cells sharing it. [`facetskeleton`](@ref) instead returns an iterable with every
+unique facet of the grid exactly once, where interior facets are represented by the cell
+with the lowest cell id:
+
+![The facet skeleton: every unique facet of the grid exactly once](./assets/topology_facet_skeleton-light.svg)
+![The facet skeleton: every unique facet of the grid exactly once](./assets/topology_facet_skeleton-dark.svg)
+
+```@repl topology
+skeleton = facetskeleton(topology, grid);
+length(skeleton)
+```
+
+For this grid the skeleton contains 24 unique facets (12 interior and 12 on the
+boundary), compared to the 9 × 4 = 36 cell-local facets. The skeleton is
+useful when something should be computed once per facet, e.g. integrals over material
+interfaces. For integrating jump and average terms over interior facets, as needed in
+discontinuous Galerkin methods, the [`InterfaceIterator`](@ref) (which uses the topology
+internally) is more convenient, see the
+[Discontinuous Galerkin heat equation](@ref tutorial-dg-heat-equation) tutorial.
+
+### Mixed reference dimensions
+
+Grids mixing cells of different reference dimension are supported, as long as the
+highest reference dimension equals the spatial dimension. As an example, consider a
+`Line` cell attached to the right edge of a quadrilateral:
+
+![A line cell attached to the edge of a quadrilateral](./assets/topology_mixed_dim-light.svg)
+![A line cell attached to the edge of a quadrilateral](./assets/topology_mixed_dim-dark.svg)
+
+```@repl topology
+nodes = Node.(Vec.([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.0, 2.0), (1.0, 2.0)]));
+cells = [
+    Quadrilateral((3, 4, 6, 5)), # top quadrilateral (cell 1)
+    Line((4, 6)),                # line on the right edge of cell 1 (cell 2)
+    Quadrilateral((1, 2, 4, 3)), # bottom quadrilateral (cell 3)
+];
+mixed_grid = Grid(cells, nodes);
+mixed_topology = ExclusiveTopology(mixed_grid);
+```
+
+The neighborhood is classified by the shared entity just as before, so the line cell is
+an edge neighbor of cell 1. For `FacetIndex` queries the facet dimension is resolved
+from the reference dimension of the indexed cell: the facets of the quadrilateral cell 1
+are edges, and querying them finds the neighboring quadrilateral as well as the line
+cell:
+
+```@repl topology
+getneighborhood(mixed_topology, mixed_grid, FacetIndex(1, 1)) # bottom edge
+getneighborhood(mixed_topology, mixed_grid, FacetIndex(1, 2)) # right edge
+```
+
+To distinguish bulk neighbors from embedded ones, [`Ferrite.entity_dim`](@ref) and
+[`Ferrite.entity_codim`](@ref) are useful: an edge of a quadrilateral (reference
+dimension 2) has co-dimension 2 - 1 = 1, whereas the edge making up the whole line cell
+(reference dimension 1) has co-dimension 0:
+
+```@repl topology
+Ferrite.entity_codim(mixed_grid, EdgeIndex(3, 3)) # facet of a bulk cell
+Ferrite.entity_codim(mixed_grid, EdgeIndex(2, 1)) # embedded cell itself
+```
+
+This can be used to dispatch on the type of coupling, e.g.:
+
 ```julia
-for local_face_index in 1:4
-    for neighbor in getneighborhood(topo, mixed_grid, FacetIndex(1, local_face_index)) # neighbor is an EdgeIndex
-        if Ferrite.entity_codim(mixed_grid, neighbor) == 0
-            # This case is the standard facet-to-facet coupling with element 3 in this example
-        elseif Ferrite.entity_codim(mixed_grid, neighbor) == 1
-            # neighbor is the embedded element 2
-        end
+for facet_nr in 1:4, neighbor in getneighborhood(mixed_topology, mixed_grid, FacetIndex(1, facet_nr))
+    if Ferrite.entity_codim(mixed_grid, neighbor) == 1
+        # standard facet-to-facet coupling with another bulk cell (here cell 3)
+    elseif Ferrite.entity_codim(mixed_grid, neighbor) == 0
+        # coupling with an embedded cell (here the line cell 2)
     end
 end
 ```
-Please note that this relation is not symmetric and we cannot use the exact same code
-when dealing with the "1D subdomain" (containing a single element in this example).
+
+Note that these relations are not symmetric: seen from the line cell the facets are
+vertices, so the same facet-based code cannot be reused from the embedded side:
+
+```@repl topology
+getneighborhood(mixed_topology, mixed_grid, FacetIndex(2, 1))
+```
+
+Finally, the bulk operations [`facetskeleton`](@ref) (and thereby
+[`InterfaceIterator`](@ref)) do not support grids with mixed reference dimensions, since
+they assume a common facet dimension across the whole grid.
+
+### Vertex stars
+
+[`vertex_star_stencils`](@ref) computes the *star* of every vertex in the grid: the
+vertex itself and all vertices connected to it by an edge. The stencil of a specific
+vertex is then extracted with [`getstencil`](@ref):
+
+![The star of a vertex: the vertex itself and all edge-connected vertices](./assets/topology_vertex_star-light.svg)
+![The star of a vertex: the vertex itself and all edge-connected vertices](./assets/topology_vertex_star-dark.svg)
+
+```@repl topology
+stencils = vertex_star_stencils(topology, grid);
+getstencil(stencils, grid, VertexIndex(5, 3))
+```
+
+The vertices in the star are given by their local views from the cells containing the
+center vertex. Vertex stars are useful for node-based operations, e.g. constructing
+stencils for finite-difference-like approximations.
+
+### Topology-aware boundary sets
+
+The topology is also used by [`addboundaryfacetset!`](@ref) and
+[`addboundaryvertexset!`](@ref). In contrast to [`addfacetset!`](@ref) and
+[`addvertexset!`](@ref), which consider all entities for which the passed predicate
+holds, these restrict the search to entities on the domain boundary, i.e. entities of
+facets without neighbors:
+
+```@repl topology
+addboundaryfacetset!(grid, topology, "east", x -> x[1] ≈ 1.0);
+getfacetset(grid, "east")
+```


### PR DESCRIPTION
I felt our topology docs were a bit sparse so I did a bit of back and forth with Claude to try improve them and add some nice figures. 

🤖:

Document ExclusiveTopology, getneighborhood, facetskeleton, mixed reference dimensions, vertex star stencils, and the topology-aware boundary set constructors with runnable examples, and add theme-aware figures illustrating the concepts.

The entity_codim branches in the mixed-dimensional example from #1369 were swapped (a bulk facet neighbor has codim 1, an embedded cell codim 0); the rewritten example is verified by execution.