### PR TITLE
Optimize ExclusiveTopology construction and queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Experimental CUDA GPU support for assembly using type-stable, non-allocating element
    routines. ([#1291])
 
+### Performance
+ - Faster `ExclusiveTopology` construction (about 1.5x for hexahedral and 1.7x for
+   tetrahedral grids), `vertex_star_stencils` (roughly 30x), and `getneighborhood` with an
+   `EdgeIndex` (roughly 4x). ([#XXXX])
+
 ## [v1.6.0] - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
  - Faster `ExclusiveTopology` construction (about 1.5x for hexahedral and 1.7x for
    tetrahedral grids), `vertex_star_stencils` (roughly 30x), and `getneighborhood` with an
-   `EdgeIndex` (roughly 4x). ([#XXXX])
+   `EdgeIndex` (roughly 4x). ([#1466])
 
 ## [v1.6.0] - 2026-08-02
 

--- a/benchmark/benchmarks-mesh.jl
+++ b/benchmark/benchmarks-mesh.jl
@@ -14,15 +14,23 @@ let g = SUITE["mesh"]["generate_grid"]
 end
 
 # Topology: construction and neighborhood queries. Hexahedra exercise the 3D path with
-# faces and edges, triangles the simplex path where cells share only vertices diagonally.
+# faces and edges, triangles and tetrahedra the simplex paths where cells share only
+# vertices diagonally (with many more neighbors per cell in 3D).
 SUITE["mesh"]["topology"] = BenchmarkGroup()
 let g = SUITE["mesh"]["topology"]
     hexgrid = generate_grid(Hexahedron, (10, 10, 10))
+    quadgrid = generate_grid(Quadrilateral, (25, 25))
     trigrid = generate_grid(Triangle, (25, 25))
+    tetgrid = generate_grid(Tetrahedron, (8, 8, 8))
     hextopo = ExclusiveTopology(hexgrid)
     g["ExclusiveTopology (Hexahedron 10×10×10)"] = @benchmarkable ExclusiveTopology($hexgrid) evals = 1
+    g["ExclusiveTopology (Quadrilateral 25×25)"] = @benchmarkable ExclusiveTopology($quadgrid) evals = 1
     g["ExclusiveTopology (Triangle 25×25)"] = @benchmarkable ExclusiveTopology($trigrid) evals = 1
+    g["ExclusiveTopology (Tetrahedron 8×8×8)"] = @benchmarkable ExclusiveTopology($tetgrid) evals = 1
     g["getneighborhood all cells (Hexahedron 10×10×10)"] = @benchmarkable FerriteBenchmarkHelpers.neighborhood_sweep($hextopo, $hexgrid) evals = 1
+    # getneighborhood through the EdgeIndex path, which recomputes the full neighborhood
+    # for each query since only the exclusive neighbors are stored for 3D cells.
+    g["getneighborhood all edges (Hexahedron 10×10×10)"] = @benchmarkable FerriteBenchmarkHelpers.edge_neighborhood_sweep($hextopo, $hexgrid) evals = 1
     # Iteration over the raw vertex/edge/face adjacency storage (issue #1019).
     g["neighbor iteration (Hexahedron 10×10×10)"] = @benchmarkable FerriteBenchmarkHelpers.neighbor_index_sum($hextopo) evals = 1
     # getneighborhood through the FacetIndex path for every skeleton facet (issue #1019).

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -118,6 +118,21 @@ function neighbor_index_sum(top::ExclusiveTopology)
     return acc
 end
 
+# getneighborhood through the EdgeIndex path for every edge of every cell. For cells with
+# reference dimension 3 only the exclusive edge neighborhood is stored, so the full
+# neighborhood is recomputed for each query.
+function edge_neighborhood_sweep(top, grid)
+    acc = 0
+    for c in 1:getncells(grid)
+        for e in 1:Ferrite.nedges(getcells(grid, c))
+            for n in getneighborhood(top, grid, EdgeIndex(c, e))
+                acc += n[1] + n[2]
+            end
+        end
+    end
+    return acc
+end
+
 # getneighborhood for every facet of the (precomputed) facet skeleton: the FacetIndex
 # query path, as used e.g. when assembling over interior facets (see issue #1019).
 function skeleton_neighborhood_sweep(top, grid, skeleton)

--- a/src/Grid/topology.jl
+++ b/src/Grid/topology.jl
@@ -72,7 +72,7 @@ function ExclusiveTopology(grid::AbstractGrid{sdim}) where {sdim}
     ncells = length(cells)
 
     max_vertices, max_edges, max_faces = _max_nentities_per_cell(cells)
-    vertex_to_cell = build_vertex_to_cell(cells; max_vertices, nnodes)
+    vertex_to_cell = build_vertex_to_cell(cells; nnodes)
     cell_neighbor = build_cell_neighbor(grid, cells, vertex_to_cell; ncells)
 
     # Here we don't use the convenience constructor taking a function,
@@ -96,10 +96,25 @@ function ExclusiveTopology(grid::AbstractGrid{sdim}) where {sdim}
             if num_shared_vertices == 1
                 _add_single_vertex_neighbor!(vertex_vertex_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id)
             elseif num_shared_vertices == 2 # Shared edge (or two separate vertices)
-                _add_single_edge_neighbor!(edge_edge_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id) ||
+                # For cells with reference dimension <= 2 the pairwise search is over so
+                # few edges that it beats collecting the shared vertices for a targeted
+                # lookup first (the branch is static for concrete cell types).
+                added = if getrefdim(cell) == 3
+                    g1, g2, _, _ = _first_shared_vertices(cell, neighbor_cell)
+                    _add_edge_neighbor!(edge_edge_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id, sortedge_fast((g1, g2)))
+                else
+                    _add_single_edge_neighbor!(edge_edge_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id)
+                end
+                added || _add_single_vertex_neighbor!(vertex_vertex_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id)
+            elseif num_shared_vertices == 3 # Shared triangular face (or lower-dimensional entities)
+                g1, g2, g3, _ = _first_shared_vertices(cell, neighbor_cell)
+                _add_face_neighbor!(face_face_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id, sortface_fast((g1, g2, g3))) ||
+                    _add_single_edge_neighbor!(edge_edge_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id) ||
                     _add_single_vertex_neighbor!(vertex_vertex_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id)
-            elseif num_shared_vertices >= 3 # Shared face (or lower-dimensional entities)
-                _add_single_face_neighbor!(face_face_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id) ||
+            elseif num_shared_vertices >= 4 # Shared quadrilateral face (or lower-dimensional entities)
+                g1, g2, g3, g4 = _first_shared_vertices(cell, neighbor_cell)
+                _add_face_neighbor!(face_face_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id, sortface_fast((g1, g2, g3, g4))) ||
+                    _add_single_face_neighbor!(face_face_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id) ||
                     _add_single_edge_neighbor!(edge_edge_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id) ||
                     _add_single_vertex_neighbor!(vertex_vertex_neighbor_buf, cell, cell_id, neighbor_cell, neighbor_cell_id)
             else
@@ -161,13 +176,37 @@ function _num_shared_vertices(cell_a::C1, cell_b::C2) where {C1, C2}
     num_shared_vertices = 0
     for vertex in vertices(cell_a)
         for vertex_neighbor in vertices(cell_b)
-            if vertex_neighbor == vertex
-                num_shared_vertices += 1
-                continue
-            end
+            # Branch-free accumulation so that the loops vectorize (a cell never contains
+            # the same vertex twice, so each match is a distinct shared vertex).
+            num_shared_vertices += Int(vertex_neighbor == vertex)
         end
     end
     return num_shared_vertices
+end
+
+# Global ids of the first four vertices shared by `cell_a` and `cell_b` (0 if fewer), used
+# to look up the shared edge or face directly instead of comparing all pairs of them.
+function _first_shared_vertices(cell_a::C1, cell_b::C2) where {C1, C2}
+    num_shared_vertices = 0
+    g1 = g2 = g3 = 0
+    for vertex in vertices(cell_a)
+        for vertex_neighbor in vertices(cell_b)
+            if vertex_neighbor == vertex
+                num_shared_vertices += 1
+                if num_shared_vertices == 1
+                    g1 = vertex
+                elseif num_shared_vertices == 2
+                    g2 = vertex
+                elseif num_shared_vertices == 3
+                    g3 = vertex
+                else
+                    return (g1, g2, g3, vertex)
+                end
+                break
+            end
+        end
+    end
+    return (g1, g2, g3, 0)
 end
 
 "Return the highest number of vertices, edges, and faces per cell"
@@ -188,6 +227,37 @@ function _max_nentities_per_cell(cells::Vector{C}) where {C}
         end
         return max_vertices, max_edges, max_faces
     end
+end
+
+# Add the face neighbor when the shared face is known to consist of the shared vertices,
+# with `sorted_face` their unique representation from `sortface_fast` (3 indices identify
+# a face, also for quadrilateral faces, see `sortface_fast`).
+# Return `true` if both cells have such a face and the entry was recorded.
+function _add_face_neighbor!(face_table::ConstructionBuffer, cell::AbstractCell, cell_id::Int, cell_neighbor::AbstractCell, cell_neighbor_id::Int, sorted_face::Tuple{Int, Int, Int})
+    lfi = _find_local_entity(faces(cell), sortface_fast, sorted_face)
+    lfi == 0 && return false
+    lfi2 = _find_local_entity(faces(cell_neighbor), sortface_fast, sorted_face)
+    lfi2 == 0 && return false
+    push_at_index!(face_table, FaceIndex(cell_neighbor_id, lfi2), cell_id, lfi)
+    return true
+end
+
+# Like `_add_face_neighbor!` but for the edge with sorted vertices `sorted_edge`.
+function _add_edge_neighbor!(edge_table::ConstructionBuffer, cell::AbstractCell, cell_id::Int, cell_neighbor::AbstractCell, cell_neighbor_id::Int, sorted_edge::Tuple{Int, Int})
+    lei = _find_local_entity(edges(cell), sortedge_fast, sorted_edge)
+    lei == 0 && return false
+    lei2 = _find_local_entity(edges(cell_neighbor), sortedge_fast, sorted_edge)
+    lei2 == 0 && return false
+    push_at_index!(edge_table, EdgeIndex(cell_neighbor_id, lei2), cell_id, lei)
+    return true
+end
+
+# Local index of the entity in `entities` whose sorted vertices are `sorted_entity`, or 0.
+function _find_local_entity(entities::Tuple, sortfun::F, sorted_entity::Tuple) where {F}
+    for (i, entity) in pairs(entities)
+        sortfun(entity) == sorted_entity && return i
+    end
+    return 0
 end
 
 # The `_add_single_*_neighbor!` functions return `true` if a shared entity was found and
@@ -235,15 +305,30 @@ function _add_single_vertex_neighbor!(vertex_table::ConstructionBuffer, cell::Ab
     return found
 end
 
-function build_vertex_to_cell(cells; max_vertices, nnodes)
-    vertex_to_cell = ArrayOfVectorViews(sizehint!(Int[], max_vertices * nnodes), (nnodes,); sizehint = max_vertices) do cov
-        for (cellid, cell) in enumerate(cells)
-            for vertex in vertices(cell)
-                push_at_index!(cov, cellid, vertex)
-            end
+function build_vertex_to_cell(cells; nnodes)
+    # Two-pass construction: count the number of cells for each vertex, compute the view
+    # offsets, and then fill in the cell ids. This allocates exactly the required memory
+    # and avoids the data relocations of the generic `ConstructionBuffer` approach.
+    nextidx = zeros(Int, nnodes)
+    for cell in cells
+        for vertex in vertices(cell)
+            nextidx[vertex] += 1
         end
     end
-    return vertex_to_cell
+    indices = Vector{Int}(undef, nnodes + 1)
+    indices[1] = 1
+    for v in 1:nnodes
+        indices[v + 1] = indices[v] + nextidx[v]
+        nextidx[v] = indices[v] # Next free data slot for vertex v
+    end
+    data = Vector{Int}(undef, indices[end] - 1)
+    for (cellid, cell) in enumerate(cells)
+        for vertex in vertices(cell)
+            data[nextidx[vertex]] = cellid
+            nextidx[vertex] += 1
+        end
+    end
+    return ArrayOfVectorViews(indices, data, LinearIndices(1:nnodes); checkargs = false)
 end
 
 function build_cell_neighbor(grid, cells, vertex_to_cell; ncells)
@@ -253,23 +338,28 @@ function build_cell_neighbor(grid, cells, vertex_to_cell; ncells)
     data = empty!(Vector{Int}(undef, ncells * sizehint))
 
     indices = Vector{Int}(undef, ncells + 1)
-    cell_neighbor_ids = Int[]
+    # last_recorded_by[c] is the latest cell that pushed c as its neighbor, giving O(1)
+    # deduplication instead of a linear scan over the neighbors found so far.
+    last_recorded_by = zeros(Int, ncells)
     n = 1
     for (cell_id, cell) in enumerate(cells)
-        empty!(cell_neighbor_ids)
+        indices[cell_id] = n
         for vertex in vertices(cell)
             for vertex_cell_id in vertex_to_cell[vertex]
-                if vertex_cell_id != cell_id
-                    vertex_cell_id ∈ cell_neighbor_ids || push!(cell_neighbor_ids, vertex_cell_id)
+                if vertex_cell_id != cell_id && last_recorded_by[vertex_cell_id] != cell_id
+                    last_recorded_by[vertex_cell_id] = cell_id
+                    push!(data, vertex_cell_id)
+                    n += 1
                 end
             end
         end
-        indices[cell_id] = n
-        append!(data, cell_neighbor_ids)
-        n += length(cell_neighbor_ids)
     end
     indices[end] = n
-    sizehint!(data, length(data)) # Tell julia that we won't add more data
+    # Free the excess capacity if a significant part would be reclaimed (the shrink copies
+    # the data, so it is not worth it for the typically well-matched size hints).
+    if 4 * length(data) < 3 * ncells * sizehint
+        sizehint!(data, length(data))
+    end
     return ArrayOfVectorViews(indices, data, LinearIndices(1:ncells))
 end
 
@@ -326,20 +416,25 @@ end
 # shared by potentially many cells and only the exclusive neighborhood is stored.
 function _getneighborhood_edge3(top::ExclusiveTopology, grid::AbstractGrid, edgeidx::EdgeIndex, include_self)
     cellid, local_edgeidx = edgeidx[1], edgeidx[2]
-    cell_edges = edges(getcells(grid, cellid))
-    nonlocal_edgeid = cell_edges[local_edgeidx]
-    cell_neighbors = getneighborhood(top, grid, CellIndex(cellid))
-    self_reference_local = EdgeIndex[]
-    for neighbor_cellid in cell_neighbors
-        local_neighbor_edgeid = findfirst(x -> issubset(x, nonlocal_edgeid), edges(getcells(grid, neighbor_cellid)))
-        local_neighbor_edgeid === nothing && continue
-        push!(self_reference_local, EdgeIndex(neighbor_cellid, local_neighbor_edgeid))
+    v1, v2 = edges(getcells(grid, cellid))[local_edgeidx]
+    stored_neighbors = top.edge_edge_neighbor[cellid, local_edgeidx]
+    nstored = length(stored_neighbors)
+    neighbors = EdgeIndex[]
+    sizehint!(neighbors, nstored + 4 + include_self)
+    append!(neighbors, stored_neighbors)
+    for neighbor_cellid in top.cell_neighbor[cellid]
+        for (i, edge) in pairs(edges(getcells(grid, neighbor_cellid)))
+            if (edge[1] == v1 && edge[2] == v2) || (edge[1] == v2 && edge[2] == v1)
+                # The recomputed candidates are distinct (at most one per neighbor cell),
+                # so only the stored entries can duplicate them.
+                candidate = EdgeIndex(neighbor_cellid, i)
+                candidate ∈ view(neighbors, 1:nstored) || push!(neighbors, candidate)
+                break
+            end
+        end
     end
-    if include_self
-        neighbors = unique([top.edge_edge_neighbor[cellid, local_edgeidx]; self_reference_local; edgeidx])
-    else
-        neighbors = unique([top.edge_edge_neighbor[cellid, local_edgeidx]; self_reference_local])
-    end
+    # The edge itself is never a neighbor of itself, so no duplication check is needed.
+    include_self && push!(neighbors, edgeidx)
     return view(neighbors, 1:length(neighbors))
 end
 
@@ -362,17 +457,24 @@ function vertex_star_stencils(top::ExclusiveTopology, grid::Grid)
     stencil_table = ArrayOfVectorViews(VertexIndex[], (getnnodes(grid),); sizehint = 10) do buf
         # Vertex Connectivity
         for (global_vertexid, cellset) in enumerate(top.vertex_to_cell)
-            for cell in cellset
-                neighbor_boundary = edges(cells[cell])
-                neighbor_connected_faces = neighbor_boundary[findall(x -> global_vertexid ∈ x, neighbor_boundary)]
-                this_local_vertex = findfirst(i -> toglobal(grid, VertexIndex(cell, i)) == global_vertexid, 1:nvertices(cells[cell]))
-                push_at_index!(buf, VertexIndex(cell, this_local_vertex), global_vertexid)
-                other_vertices = findfirst.(x -> x != global_vertexid, neighbor_connected_faces)
-                any(other_vertices .=== nothing) && continue
-                neighbor_vertices_global = getindex.(neighbor_connected_faces, other_vertices)
-                neighbor_vertices_local = [VertexIndex(cell, local_vertex) for local_vertex in findall(x -> x ∈ neighbor_vertices_global, vertices(cells[cell]))]
-                for vertex_index in neighbor_vertices_local
-                    push_at_index!(buf, vertex_index, global_vertexid)
+            for cell_id in cellset
+                cell_vertices = vertices(cells[cell_id])
+                # The vertex itself is part of the stencil
+                for (lvi, gvi) in pairs(cell_vertices)
+                    if gvi == global_vertexid
+                        push_at_index!(buf, VertexIndex(cell_id, lvi), global_vertexid)
+                        break
+                    end
+                end
+                # All vertices connected to it by an edge of this cell
+                for (lvi, gvi) in pairs(cell_vertices)
+                    gvi == global_vertexid && continue
+                    for edge in edges(cells[cell_id])
+                        if (edge[1] == global_vertexid && edge[2] == gvi) || (edge[2] == global_vertexid && edge[1] == gvi)
+                            push_at_index!(buf, VertexIndex(cell_id, lvi), global_vertexid)
+                            break
+                        end
+                    end
                 end
             end
         end


### PR DESCRIPTION
Benchmark script:

```julia
using Ferrite, BenchmarkTools

grids = [
    "Quadrilateral 40×40" => generate_grid(Quadrilateral, (40, 40)),
    "Triangle 40×40" => generate_grid(Triangle, (40, 40)),
    "Hexahedron 15×15×15" => generate_grid(Hexahedron, (15, 15, 15)),
    "Tetrahedron 10×10×10" => generate_grid(Tetrahedron, (10, 10, 10)),
]

println("== ExclusiveTopology construction ==")
for (name, grid) in grids
    print(rpad(name, 22))
    @btime ExclusiveTopology($grid)
end

hexgrid = last(grids[3])
top = ExclusiveTopology(hexgrid)

println("== getneighborhood (Hexahedron 15×15×15, interior cell) ==")
print("CellIndex:   "); @btime getneighborhood($top, $hexgrid, CellIndex(1000))
print("VertexIndex: "); @btime getneighborhood($top, $hexgrid, VertexIndex(1000, 1))
print("EdgeIndex:   "); @btime getneighborhood($top, $hexgrid, EdgeIndex(1000, 1))
print("FaceIndex:   "); @btime getneighborhood($top, $hexgrid, FaceIndex(1000, 1))

println("== Bulk operations (Hexahedron 15×15×15) ==")
# facetskeleton caches its result, so reset the cache in setup
print("facetskeleton:        ")
@btime Ferrite.facetskeleton($top, $hexgrid) setup = ($top.facet_skeleton = nothing) evals = 1
print("vertex_star_stencils: ")
@btime vertex_star_stencils($top, $hexgrid)
```


Before

```
== ExclusiveTopology construction ==
Quadrilateral 40×40     268.124 μs (56 allocations: 1.11 MiB)
Triangle 40×40          560.734 μs (61 allocations: 2.65 MiB)
Hexahedron 15×15×15     3.325 ms (61 allocations: 7.04 MiB)
Tetrahedron 10×10×10    8.893 ms (70 allocations: 22.40 MiB)
== getneighborhood (Hexahedron 15×15×15, interior cell) ==
CellIndex:     1.302 ns (0 allocations: 0 bytes)
VertexIndex:   35.899 ns (2 allocations: 192 bytes)
EdgeIndex:     715.496 ns (91 allocations: 7.45 KiB)
FaceIndex:     14.068 ns (0 allocations: 0 bytes)
== Bulk operations (Hexahedron 15×15×15) ==
facetskeleton:          18.430 μs (3 allocations: 168.82 KiB)
vertex_star_stencils:   46.345 ms (1341942 allocations: 77.70 MiB)
```

After

```
== ExclusiveTopology construction ==
Quadrilateral 40×40     231.444 μs (53 allocations: 1.05 MiB)
Triangle 40×40          465.972 μs (53 allocations: 2.33 MiB)
Hexahedron 15×15×15     2.183 ms (55 allocations: 6.17 MiB)
Tetrahedron 10×10×10    4.933 ms (55 allocations: 18.18 MiB)
== getneighborhood (Hexahedron 15×15×15, interior cell) ==
CellIndex:     1.104 ns (0 allocations: 0 bytes)
VertexIndex:   30.075 ns (2 allocations: 192 bytes)
EdgeIndex:     185.959 ns (2 allocations: 144 bytes)
FaceIndex:     8.363 ns (0 allocations: 0 bytes)
== Bulk operations (Hexahedron 15×15×15) ==
facetskeleton:          17.939 μs (3 allocations: 168.82 KiB)
vertex_star_stencils:   1.618 ms (36 allocations: 20.35 MiB)
```

In table format

```
┌──────────────────────────────────────┬─────────────────────────────────────┬─────────────────────────────────┬─────────┐
│              Benchmark               │               Before                │              After              │ Speedup │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Construction                         │                                     │                                 │         │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Quadrilateral 40×40                  │ 268.1 μs (56 allocs, 1.11 MiB)      │ 231.4 μs (53 allocs, 1.05 MiB)  │ 1.16x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Triangle 40×40                       │ 560.7 μs (61 allocs, 2.65 MiB)      │ 466.0 μs (53 allocs, 2.33 MiB)  │ 1.20x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Hexahedron 15×15×15                  │ 3.325 ms (61 allocs, 7.04 MiB)      │ 2.183 ms (55 allocs, 6.17 MiB)  │ 1.52x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Tetrahedron 10×10×10                 │ 8.893 ms (70 allocs, 22.40 MiB)     │ 4.933 ms (55 allocs, 18.18 MiB) │ 1.80x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ getneighborhood (hex, interior cell) │                                     │                                 │         │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ CellIndex                            │ 1.30 ns                             │ 1.10 ns                         │ ~1x     │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ VertexIndex                          │ 35.9 ns (2 allocs)                  │ 30.1 ns (2 allocs)              │ 1.19x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ EdgeIndex                            │ 715.5 ns (91 allocs, 7.45 KiB)      │ 186.0 ns (2 allocs, 144 B)      │ 3.85x   │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ FaceIndex                            │ 14.1 ns                             │ 8.4 ns                          │ ~1x     │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ Bulk operations (hex 15×15×15)       │                                     │                                 │         │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ facetskeleton                        │ 18.4 μs                             │ 17.9 μs                         │ ~1x     │
├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────┼─────────┤
│ vertex_star_stencils                 │ 46.35 ms (1.34 M allocs, 77.70 MiB) │ 1.62 ms (36 allocs, 20.35 MiB)  │ 28.6x   │
└──────────────────────────────────────┴─────────────────────────────────────┴─────────────────────────────────┴─────────┘
```

