### PR TITLE
Fix interface_coupling behavior in add_interface_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
  - Atomic assembly support for BlockAssembler. ([#1452])
+ - `add_sparsity_entries!` (and thereby `allocate_matrix`) now guarantees that passing
+   `interface_coupling` adds the requested interface entries since forgetting to pass
+   `topology` now throws an error instead of ignoring the requested `interface_coupling`.
+   Calls that pass both keyword arguments behave exactly as before. ([#1468])
 
 ### Added
  - `ExclusiveTopology` now supports grids with mixed reference dimensions (e.g. a 3D grid
@@ -1366,4 +1370,5 @@ poking into Ferrite internals:
 [#1428]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1428
 [#1432]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1432
 [#1434]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1434
+[#1468]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1468
 [#1438]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1438

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
  - Atomic assembly support for BlockAssembler. ([#1452])
  - `add_sparsity_entries!` (and thereby `allocate_matrix`) now guarantees that passing
-   `interface_coupling` adds the requested interface entries since forgetting to pass
-   `topology` now throws an error instead of ignoring the requested `interface_coupling`.
-   Calls that pass both keyword arguments behave exactly as before. ([#1468])
+   `interface_coupling` adds the requested interface entries: the `topology` keyword
+   argument is now optional and, when not passed, constructed from the grid (previously
+   `interface_coupling` without `topology` was silently ignored). Passing an existing
+   topology is still recommended for performance reasons, in particular since one is
+   typically needed for `InterfaceIterator` in the assembly loop anyway. Calls that pass
+   both keyword arguments behave exactly as before. ([#1468])
 
 ### Added
  - `ExclusiveTopology` now supports grids with mixed reference dimensions (e.g. a 3D grid

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -165,10 +165,12 @@ dh = DofHandler(grid)
 add!(dh, :u, ip)
 close!(dh);
 
-# However, when generating the sparsity pattern we need to pass the topology and the cross-element coupling matrix when we're using
-# discontinuous interpolations. The cross-element coupling matrix is of size [1,1] in this case as
-# we have only one field and one DofHandler.
-K = allocate_matrix(dh, topology = topology, interface_coupling = trues(1, 1));
+# However, when generating the sparsity pattern we need to request the cross-element
+# coupling explicitly with the `interface_coupling` keyword argument when we're using
+# discontinuous interpolations (by default DoFs of neighboring cells are not coupled). The
+# cross-element coupling matrix is of size 1 × 1 in this case as we have only one field.
+# The topology is also required, for locating the interfaces.
+K = allocate_matrix(dh, interface_coupling = [true;;], topology = topology);
 
 # ### Boundary conditions
 # The Dirichlet boundary conditions are treated
@@ -274,7 +276,11 @@ end
 # We define the function `assemble_global` to loop over all elements and internal facets
 # (interfaces), as well as the external facets involved in Neumann boundary conditions.
 
-function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, interfacevalues::InterfaceValues, K::SparseMatrixCSC, dh::DofHandler, order::Int, dim::Int)
+function assemble_global(
+        cellvalues::CellValues, facetvalues::FacetValues, interfacevalues::InterfaceValues,
+        K::SparseMatrixCSC, dh::DofHandler, topology::ExclusiveTopology,
+        order::Int, dim::Int
+    )
     ## Allocate the element stiffness matrix and element force vector
     n_basefuncs = getnbasefunctions(cellvalues)
     Ke = zeros(n_basefuncs, n_basefuncs)
@@ -295,8 +301,8 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
         ## Assemble Ke and fe into K and f
         assemble!(assembler, celldofs(cell), Ke, fe)
     end
-    ## Loop over all interfaces
-    for ic in InterfaceIterator(dh)
+    ## Loop over all interfaces, reusing the topology constructed above
+    for ic in InterfaceIterator(dh, topology)
         ## Reinitialize interfacevalues for this interface
         reinit!(interfacevalues, ic)
         ## Calculate the characteristic size hₑ as the face diameter
@@ -322,7 +328,7 @@ function assemble_global(cellvalues::CellValues, facetvalues::FacetValues, inter
     end
     return K, f
 end
-K, f = assemble_global(cellvalues, facetvalues, interfacevalues, K, dh, order, dim);
+K, f = assemble_global(cellvalues, facetvalues, interfacevalues, K, dh, topology, order, dim);
 #md nothing # hide
 
 # ### Solution of the system

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -214,7 +214,7 @@ Convenience method for doing the common task of calling [`add_cell_entries!`](@r
 [`add_interface_entries!`](@ref), and [`add_constraint_entries!`](@ref), depending on what
 arguments are passed:
  - `add_cell_entries!` is always called
- - `add_interface_entries!` is called if `topology` is provided (i.e. not `nothing`)
+ - `add_interface_entries!` is called if `interface_coupling` is provided (i.e. not `nothing`)
  - `add_constraint_entries!` is called if the ConstraintHandler is provided
 
 For more details about arguments and keyword arguments, see the respective functions.
@@ -235,7 +235,8 @@ function add_sparsity_entries!(
     # Add all entries
     add_diagonal_entries!(sp)
     add_cell_entries!(sp, dh, ch; keep_constrained, coupling)
-    if topology !== nothing
+    if interface_coupling !== nothing
+        topology === nothing && error("`interface_coupling` requires passing the `topology` keyword argument")
         add_interface_entries!(sp, dh, ch; topology, keep_constrained, interface_coupling)
     end
     if ch !== nothing

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -214,7 +214,9 @@ Convenience method for doing the common task of calling [`add_cell_entries!`](@r
 [`add_interface_entries!`](@ref), and [`add_constraint_entries!`](@ref), depending on what
 arguments are passed:
  - `add_cell_entries!` is always called
- - `add_interface_entries!` is called if `interface_coupling` is provided (i.e. not `nothing`)
+ - `add_interface_entries!` is called if `interface_coupling` is provided (i.e. not
+   `nothing`). Passing `topology` is optional, but recommended for performance reasons
+   (see [`add_interface_entries!`](@ref)).
  - `add_constraint_entries!` is called if the ConstraintHandler is provided
 
 For more details about arguments and keyword arguments, see the respective functions.
@@ -236,7 +238,6 @@ function add_sparsity_entries!(
     add_diagonal_entries!(sp)
     add_cell_entries!(sp, dh, ch; keep_constrained, coupling)
     if interface_coupling !== nothing
-        topology === nothing && error("`interface_coupling` requires passing the `topology` keyword argument")
         add_interface_entries!(sp, dh, ch; topology, keep_constrained, interface_coupling)
     end
     if ch !== nothing
@@ -285,7 +286,7 @@ end
 """
     add_interface_entries!(
         sp::SparsityPattern, dh::DofHandler, ch::Union{ConstraintHandler, Nothing};
-        topology::ExclusiveTopology, keep_constrained::Bool = true,
+        topology::Union{ExclusiveTopology, Nothing} = nothing, keep_constrained::Bool = true,
         interface_coupling::AbstractMatrix{Bool},
     )
 
@@ -293,7 +294,10 @@ Add entries to the sparsity pattern `sp` corresponding to DoF couplings on the i
 between cells as described by the DofHandler `dh`.
 
 # Keyword arguments
- - `topology`: the topology corresponding to the grid.
+ - `topology`: the topology corresponding to the grid. If not passed it is constructed
+   from the grid. Since the construction is relatively expensive it is recommended to
+   pass an existing topology, in particular since one is typically needed for e.g.
+   [`InterfaceIterator`](@ref) in the assembly loop anyway.
  - `keep_constrained`: whether or not entries for constrained DoFs should be kept
    (`keep_constrained = true`) or eliminated (`keep_constrained = false`) from the sparsity
    pattern. `keep_constrained = false` requires passing the ConstraintHandler `ch`.
@@ -305,13 +309,16 @@ between cells as described by the DofHandler `dh`.
 """
 function add_interface_entries!(
         sp::SparsityPattern, dh::DofHandler, ch::Union{ConstraintHandler, Nothing} = nothing;
-        topology::ExclusiveTopology, keep_constrained::Bool = true,
+        topology::Union{ExclusiveTopology, Nothing} = nothing, keep_constrained::Bool = true,
         interface_coupling::AbstractMatrix{Bool},
     )
     if !keep_constrained
         ch === nothing && error("must pass ConstraintHandler when `keep_constrained = true`")
         isclosed(ch) || error("the ConstraintHandler must be closed")
         ch.dh === dh || error("the DofHandler and the ConstraintHandler's DofHandler must be the same")
+    end
+    if topology === nothing
+        topology = ExclusiveTopology(get_grid(dh))
     end
     return _add_interface_entries!(sp, dh, ch, topology, keep_constrained, interface_coupling)
 end

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -332,6 +332,8 @@ end
     for p in patterns
         @test_throws ErrorException add_sparsity_entries!(p, dh, ch_bad; keep_constrained = false)
     end
+    # interface_coupling requires the topology for locating the interfaces
+    @test_throws ErrorException("`interface_coupling` requires passing the `topology` keyword argument") add_sparsity_entries!(SparsityPattern(ndofs(dh), ndofs(dh)), dh; interface_coupling = trues(2, 2))
 end
 
 @testset "FastSparsityPattern" begin

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -332,8 +332,10 @@ end
     for p in patterns
         @test_throws ErrorException add_sparsity_entries!(p, dh, ch_bad; keep_constrained = false)
     end
-    # interface_coupling requires the topology for locating the interfaces
-    @test_throws ErrorException("`interface_coupling` requires passing the `topology` keyword argument") add_sparsity_entries!(SparsityPattern(ndofs(dh), ndofs(dh)), dh; interface_coupling = trues(2, 2))
+    # interface_coupling: the topology is constructed automatically when not passed
+    sp_ic = add_sparsity_entries!(SparsityPattern(ndofs(dh), ndofs(dh)), dh; interface_coupling = trues(2, 2))
+    sp_ic_topo = add_sparsity_entries!(SparsityPattern(ndofs(dh), ndofs(dh)), dh; interface_coupling = trues(2, 2), topology = ExclusiveTopology(grid))
+    compare_patterns(sp_ic, sp_ic_topo)
 end
 
 @testset "FastSparsityPattern" begin


### PR DESCRIPTION
The first patch just make sure that a passed `interface_coupling` isn't ignored when
`topology` is missing (bugfix).

The second commit can be discussed: it creates the topology internally when it is needed and
when not passed. You can still pass it for performance reasons since you most likely would
need it for the interface iterations anyway. Note that `InterfaceIterator` already created
one internally.

There is of course a cost of doing this but compared to the full pipeline it doesn't really
matter (see also #1466). Here are some benchmarks from running the DG tutorial for
reference:

```
┌───────────────────────┬──────────────────┬──────────────┬──────────────┬──────────────┐
│         step          │ n=40 (6.4k dofs) │  n=80 (26k)  │ n=160 (102k) │ n=240 (230k) │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ solve K \ f           │ 10.1ms (46%)     │ 39.7ms (45%) │ 608ms (74%)  │ 751ms (55%)  │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ allocate_matrix       │ 5.2ms (24%)      │ 23.1ms (26%) │ 119ms (15%)  │ 288ms (21%)  │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ assembly (interfaces) │ 5.2ms (24%)      │ 20.5ms (23%) │ 83ms (10%)   │ 301ms (22%)  │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ ExclusiveTopology     │ 0.6ms (2.7%)     │ 1.5ms (1.8%) │ 5.7ms (0.7%) │ 18ms (1.3%)  │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ assembly (cells)      │ 0.3ms            │ 1.0ms        │ 4.3ms        │ 9.3ms        │
├───────────────────────┼──────────────────┼──────────────┼──────────────┼──────────────┤
│ close!(dh)            │ 0.09ms           │ 0.2ms        │ 0.7ms        │ 2.2ms        │
└───────────────────────┴──────────────────┴──────────────┴──────────────┴──────────────┘
```
