### PR TITLE
Add multi-field support to FacetValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `CellValues`; `MultiFieldCellValues` remains as an alias for this case and behaves as
    before. The type parameters of `CellValues` have changed (internal, but may affect
    code dispatching on them). ([#XXXX])
+ - `FacetValues` now supports multiple fields the same way as `CellValues`, e.g.
+   `FacetValues(fqr, (u = ipu, p = ipp))` with shape function queries on `fv.u` and
+   `fv.p`. The type parameters of `FacetValues` have changed (internal, but may affect
+   code dispatching on them). ([#XXXX])
 
 ### Fixes
  - Atomic assembly support for BlockAssembler. ([#1452])

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -1,5 +1,6 @@
 """
     FacetValues([::Type{T}], quad_rule::FacetQuadratureRule, func_interpol::Interpolation, [geom_interpol::Interpolation])
+    FacetValues([::Type{T}], quad_rule::FacetQuadratureRule, func_interpols::NamedTuple, [geom_interpol::Interpolation])
 
 A `FacetValues` object facilitates the process of evaluating values of shape functions, gradients of shape functions,
 values of nodal functions, gradients and divergences of nodal functions etc. on the facets of finite elements.
@@ -9,6 +10,8 @@ values of nodal functions, gradients and divergences of nodal functions etc. on 
 * `T`: an optional argument (default to `Float64`) to determine the type the internal data is stored as.
 * `quad_rule`: an instance of a [`FacetQuadratureRule`](@ref)
 * `func_interpol`: an instance of an [`Interpolation`](@ref) used to interpolate the approximated function
+* `func_interpols`: a named tuple with entries of type `Interpolation`, one for each field, see
+  *Multiple fields* below
 * `geom_interpol`: an optional instance of an [`Interpolation`](@ref) which is used to interpolate the geometry.
   By default linear Lagrange interpolation is used.
 
@@ -33,11 +36,20 @@ values of nodal functions, gradients and divergences of nodal functions etc. on 
 * [`function_symmetric_gradient`](@ref)
 * [`function_divergence`](@ref)
 * [`spatial_coordinate`](@ref)
+
+# Multiple fields
+
+Constructed with a `NamedTuple` of interpolations, `fv::FacetValues` works like the multi-field
+mode of [`CellValues`](@ref): functions related to specific shape functions are called on
+`fv.<name>` (of type [`FunctionValues`](@ref Ferrite.FunctionValues)) while geometric queries
+(e.g. `getdetJdV`, `getnormal`, and `spatial_coordinate`) are called on `fv` itself. Fields
+with equal interpolations share the same `FunctionValues`.
 """
 FacetValues
 
-mutable struct FacetValues{FV, GM, FQR, detT, nT, V_FV <: AbstractVector{FV}, V_GM <: AbstractVector{GM}} <: AbstractFacetValues
-    const fun_values::V_FV  # AbstractVector{FunctionValues}
+mutable struct FacetValues{NT, FV, GM, FQR, detT, nT, V_FV <: AbstractVector{FV}, V_GM <: AbstractVector{GM}} <: AbstractFacetValues
+    const fun_values_nt::NT # NamedTuple mapping field names to Val-indices into the fun_values tuples, or Nothing (single-field mode)
+    const fun_values::V_FV  # AbstractVector{<:Tuple}, one tuple of unique FunctionValues per facet
     const geo_mapping::V_GM # AbstractVector{GeometryMapping}
     const fqr::FQR          # FacetQuadratureRule
     # FacetValues are only functional for the types in the comments for the fields below.
@@ -48,6 +60,9 @@ mutable struct FacetValues{FV, GM, FQR, detT, nT, V_FV <: AbstractVector{FV}, V_
     current_facet::Int
 end
 
+const SingleFieldFacetValues = FacetValues{Nothing}
+const MultiFieldFacetValues = FacetValues{<:NamedTuple}
+
 function FacetValues(
         ::Type{T}, fqr::FacetQuadratureRule, ip_fun::Interpolation, ip_geo::VectorizedInterpolation{sdim},
         ::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder}
@@ -55,54 +70,79 @@ function FacetValues(
 
     # max(GeoDiffOrder, 1) ensures that we get the jacobian needed to calculate the normal.
     geo_mapping = map(qr -> GeometryMapping{max(GeoDiffOrder, 1)}(T, ip_geo.ip, qr), fqr.facet_rules)
-    fun_values = map(qr -> FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo), fqr.facet_rules)
+    fun_values = map(qr -> (FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo),), fqr.facet_rules)
     max_nquadpoints = maximum(qr -> length(getweights(qr)), fqr.facet_rules)
     # detJdV always calculated, since we needed to calculate the jacobian anyways for the normal.
     detJdV = fill(T(NaN), max_nquadpoints)
     normals = fill(zero(Vec{sdim, T}) * T(NaN), max_nquadpoints)
-    return FacetValues(fun_values, geo_mapping, fqr, detJdV, normals, 1)
+    return FacetValues(nothing, fun_values, geo_mapping, fqr, detJdV, normals, 1)
 end
 
-FacetValues(qr::FacetQuadratureRule, ip::Interpolation, args...; kwargs...) = FacetValues(Float64, qr, ip, args...; kwargs...)
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::ScalarInterpolation; kwargs...) where {T}
+function FacetValues(
+        ::Type{T}, fqr::FacetQuadratureRule, ip_funs::NamedTuple, ip_geo::VectorizedInterpolation{sdim},
+        ::ValuesUpdateFlags{FunDiffOrder, GeoDiffOrder}
+    ) where {T, sdim, FunDiffOrder, GeoDiffOrder}
+
+    geo_mapping = map(qr -> GeometryMapping{max(GeoDiffOrder, 1)}(T, ip_geo.ip, qr), fqr.facet_rules)
+    unique_ips = unique(values(ip_funs)) # Not type-stable, but ok for advanced users this should be constructed outside...
+    fun_values = map(qr -> tuple((FunctionValues{FunDiffOrder}(T, ip_fun, qr, ip_geo) for ip_fun in unique_ips)...), fqr.facet_rules)
+    fun_values_nt = NamedTuple((key => Val(findfirst(unique_ip -> ip == unique_ip, unique_ips)) for (key, ip) in pairs(ip_funs)))
+    max_nquadpoints = maximum(qr -> length(getweights(qr)), fqr.facet_rules)
+    detJdV = fill(T(NaN), max_nquadpoints)
+    normals = fill(zero(Vec{sdim, T}) * T(NaN), max_nquadpoints)
+    return FacetValues(fun_values_nt, fun_values, geo_mapping, fqr, detJdV, normals, 1)
+end
+
+FacetValues(qr::FacetQuadratureRule, ip::Union{Interpolation, NamedTuple}, args...; kwargs...) = FacetValues(Float64, qr, ip, args...; kwargs...)
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Union{Interpolation, NamedTuple}, ip_geo::ScalarInterpolation; kwargs...) where {T}
     return FacetValues(T, qr, ip, VectorizedInterpolation(ip_geo); kwargs...)
 end
-function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Interpolation, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip); kwargs...) where {T}
+function FacetValues(::Type{T}, qr::FacetQuadratureRule, ip::Union{Interpolation, NamedTuple}, ip_geo::VectorizedInterpolation = default_geometric_interpolation(ip); kwargs...) where {T}
     return FacetValues(T, qr, ip, ip_geo, ValuesUpdateFlags(ip; kwargs...))
 end
 
 function Base.copy(fv::FacetValues)
-    fun_values = map(copy, fv.fun_values)
-    geo_mapping = map(copy, fv.geo_mapping)
-    return FacetValues(fun_values, geo_mapping, copy(fv.fqr), copy(fv.detJdV), copy(fv.normals), fv.current_facet)
+    fun_values = map(fvals -> map(copy, fvals), getfield(fv, :fun_values))
+    geo_mapping = map(copy, getfield(fv, :geo_mapping))
+    return FacetValues(
+        getfield(fv, :fun_values_nt), fun_values, geo_mapping,
+        copy(getfield(fv, :fqr)), copy(getfield(fv, :detJdV)), copy(getfield(fv, :normals)), getcurrentfacet(fv)
+    )
 end
 
 getngeobasefunctions(fv::FacetValues) = getngeobasefunctions(get_geo_mapping(fv))
-getnbasefunctions(fv::FacetValues) = getnbasefunctions(get_fun_values(fv))
-getnquadpoints(fv::FacetValues) = @inbounds getnquadpoints(fv.fqr, getcurrentfacet(fv))
-@propagate_inbounds getdetJdV(fv::FacetValues, q_point) = fv.detJdV[q_point]
+getnquadpoints(fv::FacetValues) = @inbounds getnquadpoints(getfield(fv, :fqr), getcurrentfacet(fv))
+@propagate_inbounds getdetJdV(fv::FacetValues, q_point) = getfield(fv, :detJdV)[q_point]
 
-shape_value_type(fv::FacetValues) = shape_value_type(get_fun_values(fv))
-shape_gradient_type(fv::FacetValues) = shape_gradient_type(get_fun_values(fv))
-function_interpolation(fv::FacetValues) = function_interpolation(get_fun_values(fv))
-function_difforder(fv::FacetValues) = function_difforder(get_fun_values(fv))
 geometric_interpolation(fv::FacetValues) = geometric_interpolation(get_geo_mapping(fv))
 
-get_geo_mapping(fv::FacetValues) = @inbounds fv.geo_mapping[getcurrentfacet(fv)]
+get_geo_mapping(fv::FacetValues) = @inbounds getfield(fv, :geo_mapping)[getcurrentfacet(fv)]
 @propagate_inbounds geometric_value(fv::FacetValues, args...) = geometric_value(get_geo_mapping(fv), args...)
 
-get_fun_values(fv::FacetValues) = @inbounds fv.fun_values[getcurrentfacet(fv)]
+get_fun_values(fv::FacetValues) = @inbounds getfield(fv, :fun_values)[getcurrentfacet(fv)]
+@inline _single_fun_values(fv::SingleFieldFacetValues) = get_fun_values(fv)[1]
 
-@propagate_inbounds shape_value(fv::FacetValues, q_point::Int, i::Int) = shape_value(get_fun_values(fv), q_point, i)
-@propagate_inbounds shape_gradient(fv::FacetValues, q_point::Int, i::Int) = shape_gradient(get_fun_values(fv), q_point, i)
-@propagate_inbounds shape_hessian(fv::FacetValues, q_point::Int, i::Int) = shape_hessian(get_fun_values(fv), q_point, i)
+getnbasefunctions(fv::SingleFieldFacetValues) = getnbasefunctions(_single_fun_values(fv))
+shape_value_type(fv::SingleFieldFacetValues) = shape_value_type(_single_fun_values(fv))
+shape_gradient_type(fv::SingleFieldFacetValues) = shape_gradient_type(_single_fun_values(fv))
+function_interpolation(fv::SingleFieldFacetValues) = function_interpolation(_single_fun_values(fv))
+function_difforder(fv::SingleFieldFacetValues) = function_difforder(_single_fun_values(fv))
+
+@propagate_inbounds shape_value(fv::SingleFieldFacetValues, q_point::Int, i::Int) = shape_value(_single_fun_values(fv), q_point, i)
+@propagate_inbounds shape_gradient(fv::SingleFieldFacetValues, q_point::Int, i::Int) = shape_gradient(_single_fun_values(fv), q_point, i)
+@propagate_inbounds shape_hessian(fv::SingleFieldFacetValues, q_point::Int, i::Int) = shape_hessian(_single_fun_values(fv), q_point, i)
+
+# In multi-field mode, properties expose (only) the named FunctionValues of the current
+# facet, e.g. `fv.u`. Single-field mode keeps the default `getproperty`.
+@inline Base.getproperty(fv::MultiFieldFacetValues, key::Symbol) = _tuple_index(get_fun_values(fv), getproperty(getfield(fv, :fun_values_nt), key))
+Base.propertynames(fv::MultiFieldFacetValues) = propertynames(getfield(fv, :fun_values_nt))
 
 """
     getcurrentfacet(fv::FacetValues)
 
 Return the current active facet of the `FacetValues` object (from last `reinit!`).
 """
-getcurrentfacet(fv::FacetValues) = fv.current_facet[]
+getcurrentfacet(fv::FacetValues) = getfield(fv, :current_facet)
 
 """
     getnormal(fv::FacetValues, qp::Int)
@@ -110,15 +150,15 @@ getcurrentfacet(fv::FacetValues) = fv.current_facet[]
 Return the normal at the quadrature point `qp` for the active facet of the
 `FacetValues` object(from last `reinit!`).
 """
-getnormal(fv::FacetValues, qp::Int) = fv.normals[qp]
+getnormal(fv::FacetValues, qp::Int) = getfield(fv, :normals)[qp]
 
-nfacets(fv::FacetValues) = length(fv.geo_mapping)
+nfacets(fv::FacetValues) = length(getfield(fv, :geo_mapping))
 
 function set_current_facet!(fv::FacetValues, facet_nr::Int)
     # Checking facet_nr before setting current_facet allows us to use @inbounds
     # when indexing by getcurrentfacet(fv) in other places!
     checkbounds(Bool, 1:nfacets(fv), facet_nr) || throw(ArgumentError("Facet nr is out of range."))
-    fv.current_facet = facet_nr
+    setfield!(fv, :current_facet, facet_nr)
     return
 end
 
@@ -126,8 +166,16 @@ end
     return reinit!(fv, nothing, x, facet_nr)
 end
 
+@inline function reinit_needs_cell(fv::FacetValues)
+    return any(map(fvals -> !isa(mapping_type(fvals), IdentityMapping), get_fun_values(fv)))
+end
+
+function check_reinit_sdim_consistency(fv::FacetValues, ::AbstractVector{VT}) where {VT}
+    return map(fvals -> check_reinit_sdim_consistency(:FacetValues, shape_gradient_type(fvals), VT), get_fun_values(fv))
+end
+
 function reinit!(fv::FacetValues, cell::Union{AbstractCell, Nothing}, x::AbstractVector{Vec{dim, T}}, facet_nr::Int) where {dim, T}
-    check_reinit_sdim_consistency(:FacetValues, shape_gradient_type(fv), eltype(x))
+    check_reinit_sdim_consistency(fv, x)
     set_current_facet!(fv, facet_nr)
     n_geom_basefuncs = getngeobasefunctions(fv)
     if !checkbounds(Bool, x, 1:n_geom_basefuncs) || length(x) != n_geom_basefuncs
@@ -141,21 +189,33 @@ function reinit!(fv::FacetValues, cell::Union{AbstractCell, Nothing}, x::Abstrac
         throw(ArgumentError("The cell::AbstractCell input is required to reinit! non-identity function mappings"))
     end
 
-    @inbounds for (q_point, w) in pairs(getweights(fv.fqr, facet_nr))
+    detJdV = getfield(fv, :detJdV)
+    normals = getfield(fv, :normals)
+    @inbounds for (q_point, w) in pairs(getweights(getfield(fv, :fqr), facet_nr))
         mapping = calculate_mapping(geo_mapping, q_point, x)
         J = getjacobian(mapping)
         # See the `Ferrite.embedding_det` docstring for more background
         weight_norm = weighted_normal(J, getrefshape(geo_mapping.ip), facet_nr)
         detJ = norm(weight_norm)
         detJ > 0.0 || throw_detJ_not_pos(detJ)
-        @inbounds fv.detJdV[q_point] = detJ * w
-        @inbounds fv.normals[q_point] = weight_norm / norm(weight_norm)
+        @inbounds detJdV[q_point] = detJ * w
+        @inbounds normals[q_point] = weight_norm / norm(weight_norm)
         apply_mapping!(fun_values, q_point, mapping, cell)
     end
     return
 end
 
-function Base.show(io::IO, d::MIME"text/plain", fv::FacetValues)
+function _show_nqp_per_facet(io::IO, fv::FacetValues)
+    nqp = getnquadpoints.(getfield(fv, :fqr).facet_rules)
+    if all(n == first(nqp) for n in nqp)
+        println(io, first(nqp), " quadrature points per facet")
+    else
+        println(io, tuple(nqp...), " quadrature points on each facet")
+    end
+    return
+end
+
+function Base.show(io::IO, d::MIME"text/plain", fv::SingleFieldFacetValues)
     ip_geo = geometric_interpolation(fv)
     rdim = getrefdim(ip_geo)
     vdim = isa(shape_value(fv, 1, 1), Vec) ? length(shape_value(fv, 1, 1)) : 0
@@ -163,17 +223,48 @@ function Base.show(io::IO, d::MIME"text/plain", fv::FacetValues)
     sdim = GradT === nothing ? nothing : sdim_from_gradtype(GradT)
     vstr = vdim == 0 ? "scalar" : "vdim=$vdim"
     print(io, "FacetValues(", vstr, ", rdim=$rdim, sdim=$sdim): ")
-    nqp = getnquadpoints.(fv.fqr.facet_rules)
-    if all(n == first(nqp) for n in nqp)
-        println(io, first(nqp), " quadrature points per facet")
-    else
-        println(io, tuple(nqp...), " quadrature points on each facet")
-    end
+    _show_nqp_per_facet(io, fv)
     print(io, " Function interpolation: "); show(io, d, function_interpolation(fv))
     print(io, "\nGeometric interpolation: ")
-    return sdim === nothing ? show(io, d, ip_geo) : show(io, d, ip_geo^sdim)
     sdim === nothing ? show(io, d, ip_geo) : show(io, d, ip_geo^sdim)
     return
+end
+
+function Base.show(io::IO, d::MIME"text/plain", fv::MultiFieldFacetValues)
+    ip_geo = geometric_interpolation(fv)
+    GradT = shape_gradient_type(first(get_fun_values(fv)))
+    sdim = GradT === nothing ? nothing : sdim_from_gradtype(GradT)
+    print(io, "FacetValues with ")
+    _show_nqp_per_facet(io, fv)
+    print(io, "Geometric interpolation: ")
+    sdim === nothing ? show(io, d, ip_geo) : show(io, d, ip_geo^sdim)
+    print(io, "\nFunction interpolations")
+    for key in propertynames(fv)
+        ip = function_interpolation(getproperty(fv, key))
+        print(io, "\n  ", key, ": "); show(io, d, ip)
+    end
+    return
+end
+
+# Error messages for functions that should be called on individual `FunctionValues` to help users
+function getnbasefunctions(fv::MultiFieldFacetValues)
+    k = first(propertynames(fv)) # Pick the first function values to use in example
+    throw(ArgumentError("getnbasefunctions isn't applicable to a multi-field FacetValues. Use on `FunctionValues` for the specific field, e.g. getnbasefunctions(fv.$k)"))
+end
+
+for f in (:shape_value, :shape_gradient, :shape_symmetric_gradient, :shape_divergence)
+    @eval function $f(fv::MultiFieldFacetValues, ::Int, ::Int)
+        k = first(propertynames(fv)) # Pick the first function values to use in example
+        fun = $f                       # Make the function name available to use in the error message
+        throw(ArgumentError("$fun isn't applicable to a multi-field FacetValues. Use on `FunctionValues` for the specific field, e.g. $fun(fv.$k, q_point, shapenr)"))
+    end
+end
+for f in (:function_value, :function_gradient, :function_symmetric_gradient, :function_divergence)
+    @eval function $f(fv::MultiFieldFacetValues, ::Int, ::AbstractVector, args...)
+        k = first(propertynames(fv)) # Pick the first function values to use in example
+        fun = $f                       # Make the function name available to use in the error message
+        throw(ArgumentError("$fun isn't applicable to a multi-field FacetValues. Use on `FunctionValues` for the specific field, e.g. $fun(fv.$k, q_point, ae, [dofrange])"))
+    end
 end
 
 """

--- a/src/FEValues/InterfaceValues.jl
+++ b/src/FEValues/InterfaceValues.jl
@@ -162,7 +162,7 @@ function reinit!(
     @assert length(quad_points_a) <= length(quad_points_b)
 
     # Re-evaluate shape functions in the transformed quadrature points
-    precompute_values!(get_fun_values(iv.there), quad_points_b)
+    foreach(fun_values -> precompute_values!(fun_values, quad_points_b), get_fun_values(iv.there))
     precompute_values!(get_geo_mapping(iv.there), quad_points_b)
 
     # reinit! the "there" side

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -217,7 +217,7 @@ end
 
 # TODO: Are these needed to be deprecated - harder? with the new parameterization
 # (Cell|Face)Values with vector dofs
-const _VectorValues = Union{CellValues{Nothing, Tuple{FV}}, FacetValues{<:FV}} where {FV <: FunctionValues{<:Any, <:VectorInterpolation}}
+const _VectorValues = Union{CellValues{Nothing, Tuple{FV}}, FacetValues{Nothing, Tuple{FV}}} where {FV <: FunctionValues{<:Any, <:VectorInterpolation}}
 function function_value(::_VectorValues, ::Int, ::AbstractVector{Vec{dim, T}}) where {dim, T}
     throw(DeprecationError("function_value(fe_v::VectorValues, q_point::Int, u::AbstractVector{Vec{dim,T}})" => "function_value(fe_v, q_point, reinterpret(T, u))"))
 end

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -47,6 +47,9 @@ include("test_utils.jl")
         @test_call reinit!(cmv, coords)
         @test_call reinit!(cmv_u, coords)
         @test_call reinit!(cmv3, coords)
+
+        fmv = FacetValues(FacetQuadratureRule{RefQuadrilateral}(2), (u = ipu, p = ipp, T = ipT))
+        @test_call reinit!(fmv, coords, 1)
     end
     @testset "Embedded elements" begin
         @testset "Scalar/vector on curves (vdim = $vdim)" for vdim in (0, 1, 2, 3)

--- a/test/test_facevalues.jl
+++ b/test/test_facevalues.jl
@@ -2,6 +2,18 @@
 using LinearAlgebra
 include(joinpath(@__DIR__, "test_utils.jl"))
 
+# Test that all values in the struct are equal,
+# but that bits-types are not aliased to eachother.
+function test_equal_but_unaliased(a::T, b::T) where {T}
+    for fname in fieldnames(T)
+        a_val = getfield(a, fname)
+        b_val = getfield(b, fname)
+        isbits(a_val) || @test a_val !== b_val
+        @test a_val == b_val
+    end
+    return
+end
+
 @testset "FacetValues" begin
     for (scalar_interpol, quad_rule) in (
             (Lagrange{RefLine, 1}(), FacetQuadratureRule{RefLine}(2)),
@@ -156,17 +168,11 @@ include(joinpath(@__DIR__, "test_utils.jl"))
                 @test typeof(fv) == typeof(fvc)
 
                 # Test that all mutable types in FunctionValues and GeometryMapping have been copied
-                for key in (:fun_values, :geo_mapping)
-                    for i in eachindex(getfield(fv, key))
-                        val = getfield(fv, key)[i]
-                        valc = getfield(fvc, key)[i]
-                        for fname in fieldnames(typeof(val))
-                            v = getfield(val, fname)
-                            vc = getfield(valc, fname)
-                            isbits(v) || @test v !== vc
-                            @test v == vc
-                        end
+                for i in eachindex(getfield(fv, :fun_values))
+                    for (v, vc) in zip(getfield(fv, :fun_values)[i], getfield(fvc, :fun_values)[i])
+                        test_equal_but_unaliased(v, vc)
                     end
+                    test_equal_but_unaliased(getfield(fv, :geo_mapping)[i], getfield(fvc, :geo_mapping)[i])
                 end
                 # Test that fqr, detJdV, and normals, are copied as expected.
                 # Note that qr remain aliased, as defined by `copy(qr)=qr`, see quadrature.jl.
@@ -200,6 +206,88 @@ include(joinpath(@__DIR__, "test_utils.jl"))
         push!(Ferrite.getweights(fv2.fqr.facet_rules[1]), 1)
         showstring = sprint(show, MIME"text/plain"(), fv2)
         @test startswith(showstring, "FacetValues(scalar, rdim=2, sdim=2): (3, 2, 2, 2) quadrature points on each face")
+    end
+
+    @testset "Multi-field FacetValues" begin
+        # Test that multi-field FacetValues give the same output as single-field FacetValues,
+        # as that output is thoroughly tested above
+        ipu = Lagrange{RefQuadrilateral, 2}()^2
+        ipp = Lagrange{RefQuadrilateral, 1}()
+        ipT = ipp
+
+        fqr = FacetQuadratureRule{RefQuadrilateral}(2)
+        fvu = FacetValues(fqr, ipu)
+        fvp = FacetValues(fqr, ipp)
+        fmv = FacetValues(fqr, (u = ipu, p = ipp, T = ipT))
+
+        @test fmv isa Ferrite.MultiFieldFacetValues
+        @test !(fvu isa Ferrite.MultiFieldFacetValues)
+        @test typeof(FacetValues(fqr, (u = ipu, p = ipp, T = ipT))) === typeof(fmv)
+        @test propertynames(fmv) == (:u, :p, :T)
+
+        @test fmv.p === fmv.T # Correct aliasing for identical interpolations
+        @test fmv.u !== fmv.p
+        @test Ferrite.geometric_interpolation(fmv) == Ferrite.geometric_interpolation(fvu)
+        @test Ferrite.function_interpolation(fmv.u) == ipu
+        @test Ferrite.function_interpolation(fmv.p) == ipp
+
+        # Test type-stable access by hard-coded key (relies on constant propagation)
+        _getufield(x) = x.u
+        @inferred _getufield(fmv)
+
+        ref_coords = Ferrite.reference_coordinates(Ferrite.geometric_interpolation(fmv))
+        x = map(xref -> xref + rand(typeof(xref)) / 5, ref_coords) # Random perturbation
+        ue = rand(getnbasefunctions(fmv.u))
+        for facet_nr in 1:Ferrite.nfacets(fmv)
+            reinit!.((fvu, fvp, fmv), (x,), facet_nr)
+            @test fmv.p === fmv.T # Aliasing holds for each facet
+            @test getnquadpoints(fmv) == getnquadpoints(fvu)
+            for q_point in 1:getnquadpoints(fmv)
+                @test getdetJdV(fmv, q_point) ≈ getdetJdV(fvu, q_point)
+                @test getnormal(fmv, q_point) ≈ getnormal(fvu, q_point)
+                @test spatial_coordinate(fmv, q_point, x) ≈ spatial_coordinate(fvu, q_point, x)
+                for i in 1:getnbasefunctions(fmv.u)
+                    @test shape_value(fmv.u, q_point, i) ≈ shape_value(fvu, q_point, i)
+                    @test shape_gradient(fmv.u, q_point, i) ≈ shape_gradient(fvu, q_point, i)
+                end
+                for i in 1:getnbasefunctions(fmv.p)
+                    @test shape_value(fmv.p, q_point, i) ≈ shape_value(fvp, q_point, i)
+                    @test shape_gradient(fmv.p, q_point, i) ≈ shape_gradient(fvp, q_point, i)
+                end
+                @test function_value(fmv.u, q_point, ue) ≈ function_value(fvu, q_point, ue)
+            end
+        end
+
+        @testset "copy(::MultiFieldFacetValues)" begin
+            fmv_copy = @inferred copy(fmv)
+            @test typeof(fmv_copy) === typeof(fmv)
+            @test fmv_copy.p === fmv_copy.T # Aliasing preserved
+            for i in eachindex(getfield(fmv, :fun_values))
+                for (v, vc) in zip(getfield(fmv, :fun_values)[i], getfield(fmv_copy, :fun_values)[i])
+                    test_equal_but_unaliased(v, vc)
+                end
+            end
+        end
+
+        @testset "Error paths specific to multi-field FacetValues" begin
+            @test_throws ArgumentError getnbasefunctions(fmv)
+            @test_throws "getnbasefunctions" getnbasefunctions(fmv)
+            for f in (shape_value, shape_gradient, shape_symmetric_gradient, shape_divergence)
+                @test_throws ArgumentError f(fmv, 1, 1)
+                @test_throws "$(nameof(f))" f(fmv, 1, 1)
+            end
+            for f in (function_value, function_gradient, function_symmetric_gradient, function_divergence)
+                @test_throws ArgumentError f(fmv, 1, ue)
+                @test_throws "$(nameof(f))" f(fmv, 1, ue)
+            end
+        end
+
+        @testset "show" begin
+            showstring = sprint(show, MIME"text/plain"(), fmv)
+            @test startswith(showstring, "FacetValues with 2 quadrature points per facet")
+            @test contains(showstring, "u: Lagrange{RefQuadrilateral, 2}()^2")
+            @test contains(showstring, "p: Lagrange{RefQuadrilateral, 1}()")
+        end
     end
 
 end # of testset


### PR DESCRIPTION
Stacked on #1469 — only the top commit is new here.

`FacetValues` now accepts a `NamedTuple` of interpolations, like `CellValues` after #1469:

```julia
fqr = FacetQuadratureRule{RefQuadrilateral}(2)
fv = FacetValues(fqr, (u = ipu, p = ipp))
reinit!(fv, x, facet_nr)
Nu = shape_value(fv.u, q_point, i)   # shape queries on fv.<name>
dΓ = getdetJdV(fv, q_point)          # geometric queries on fv
n = getnormal(fv, q_point)
```

Same design as multi-field `CellValues`: per facet, one tuple of unique `FunctionValues`, with field names mapped through a `NamedTuple` of `Val`-indices. Equal interpolations share their `FunctionValues`, and geometry (mapping, `detJdV`, normals) is computed once per facet regardless of the number of fields.

Additional changes:
- `InterfaceValues.reinit!` now re-evaluates each unique `FunctionValues` on the there side (tuple-aware `precompute_values!`).
- `FacetValues` `show` split into single-/multi-field variants (also removes a pre-existing unreachable duplicated line).
- `_VectorValues` in `deprecations.jl` updated for the new type parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
