### PR TITLE
Speed up and parallelize grid coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `Complex` of `Float16`/`Float32`/`Float64` as value types, in addition to `Float32`
    and `Float64`. ([#1474])
 
+### Performance
+ - `create_coloring` is significantly faster: the incidence matrix construction and the
+   zone coloring of the workstream algorithm are now multithreaded, and remaining serial
+   parts use flat arrays instead of `Dict`/`Set` based bookkeeping. Representative
+   speedups for 200k-400k cell grids: 3-10x serial, and another 2-3x with 8 threads. The
+   resulting coloring is unchanged and independent of the number of threads. ([#1475])
+
 ## [v1.6.0] - 2026-08-02
 
 ### Added
@@ -1381,3 +1388,4 @@ poking into Ferrite internals:
 [#1438]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1438
 [#1452]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1452
 [#1474]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1474
+[#1475]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1475

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    zone coloring of the workstream algorithm are now multithreaded, and remaining serial
    parts use flat arrays instead of `Dict`/`Set` based bookkeeping. Representative
    speedups for 200k-400k cell grids: 3-10x serial, and another 2-3x with 8 threads. The
-   resulting coloring is unchanged and independent of the number of threads. ([#1475])
+   resulting coloring is independent of the number of threads, and unchanged for cellsets
+   that iterate in ascending order. For unordered cellsets (e.g. `Set`) the coloring is
+   now deterministic and may differ from previous releases. ([#1475])
 
 ## [v1.6.0] - 2026-08-02
 

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -1,55 +1,116 @@
-# Incidence matrix for element connections in the grid
-function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
-    cell_containing_node = Dict{Int, Set{Int}}()
-    for cellid in cellset
-        cell = getcells(g, cellid)
-        for v in get_node_ids(cell)
-            _set = get!(Set{Int}, cell_containing_node, v)
-            push!(_set, cellid)
-        end
-    end
+# Split `1:n` into at most `maxchunks` contiguous ranges of similar size.
+function _color_chunks(n::Int, maxchunks::Int)
+    return Iterators.partition(1:n, cld(n, min(n, maxchunks)))
+end
 
-    I, J = Int[], Int[]
-    for (_, cells) in cell_containing_node
-        for cell1 in cells # All these cells have a neighboring node
-            for cell2 in cells
-                # if true # cell1 != cell2
-                if cell1 != cell2
-                    push!(I, cell1)
-                    push!(J, cell2)
-                end
+function _gather_neighbor_chunk!(colcount, g, cellvec, chunk, nodeptr, nodecells)
+    buf = Int[]
+    candidates = Int[]
+    for i in chunk
+        cellid = cellvec[i]
+        empty!(candidates)
+        for v in get_node_ids(getcells(g, cellid))
+            for r in nodeptr[v]:(nodeptr[v + 1] - 1)
+                cell_neighbour = nodecells[r]
+                cell_neighbour == cellid || push!(candidates, cell_neighbour)
+            end
+        end
+        sort!(candidates)
+        prev = 0
+        for cell_neighbour in candidates
+            if cell_neighbour != prev
+                push!(buf, cell_neighbour)
+                colcount[cellid] += 1
+                prev = cell_neighbour
             end
         end
     end
-
-    incidence_matrix = SparseArrays.spzeros!(Bool, I, J, getncells(g), getncells(g))
-    fill!(incidence_matrix.nzval, true)
-    return incidence_matrix
+    return buf
 end
 
-# Greedy algorithm for coloring a grid such that no two cells with the same node
-# have the same color
-function greedy_coloring(incidence_matrix, cells = 1:size(incidence_matrix, 1))
-    cell_colors = Dict{Int, Int}(i => 0 for i in cells) # Zero represents no color set yet
-    occupied_colors = Set{Int}()
+# Incidence matrix for element connections in the grid
+function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
+    ncells = getncells(g)
+    cellvec = sort!(collect(Int, cellset))
+    if isempty(cellvec)
+        return SparseArrays.spzeros(Bool, Int, ncells, ncells)
+    end
+
+    # Map from node id to the cells in the cellset containing it, in CSR-like form.
+    # Since cells are visited in ascending order each per-node cell list is sorted.
+    nnodes = getnnodes(g)
+    nodeptr = zeros(Int, nnodes + 1)
+    nodeptr[1] = 1
+    for cellid in cellvec
+        for v in get_node_ids(getcells(g, cellid))
+            nodeptr[v + 1] += 1
+        end
+    end
+    for i in 2:(nnodes + 1)
+        nodeptr[i] += nodeptr[i - 1]
+    end
+    nodecells = Vector{Int}(undef, nodeptr[end] - 1)
+    cursor = copy(nodeptr)
+    for cellid in cellvec
+        for v in get_node_ids(getcells(g, cellid))
+            nodecells[cursor[v]] = cellid
+            cursor[v] += 1
+        end
+    end
+
+    # For each cell, gather the unique cells sharing at least one node with it.
+    # Since `cellvec` is sorted, each chunk corresponds to a contiguous range of
+    # columns in the CSC structure, so the chunk buffers can be computed in
+    # parallel and copied over without synchronization.
+    chunks = collect(_color_chunks(length(cellvec), Threads.nthreads()))
+    colcount = zeros(Int, ncells)
+    buffers = Vector{Vector{Int}}(undef, length(chunks))
+    @sync for (ci, chunk) in enumerate(chunks)
+        Threads.@spawn begin
+            buffers[$ci] = _gather_neighbor_chunk!(colcount, g, cellvec, $chunk, nodeptr, nodecells)
+        end
+    end
+
+    colptr = Vector{Int}(undef, ncells + 1)
+    colptr[1] = 1
+    for c in 1:ncells
+        colptr[c + 1] = colptr[c] + colcount[c]
+    end
+    rowval = Vector{Int}(undef, colptr[end] - 1)
+    @sync for (ci, chunk) in enumerate(chunks)
+        Threads.@spawn begin
+            buf = buffers[$ci]
+            copyto!(rowval, colptr[cellvec[first($chunk)]], buf, 1, length(buf))
+        end
+    end
+    nzval = fill(true, length(rowval))
+    return SparseMatrixCSC(ncells, ncells, colptr, rowval, nzval)
+end
+
+# Greedy coloring of the cells in `cells` such that no two connected cells (for which
+# `is_member` returns `true` for both) have the same color. `cell_colors` (indexed by cell
+# id, zeroed for the cells to color) and `occupied` are scratch data.
+function _greedy_coloring!(cell_colors::Vector{Int}, occupied::Vector{Bool}, incidence_matrix, cells, is_member::F) where {F}
     final_colors = Vector{Int}[]
     total_colors = 0
     for cellid in cells
-        empty!(occupied_colors)
+        for i in 1:total_colors
+            occupied[i] = false
+        end
         # loop over neighbors
         for r in nzrange(incidence_matrix, cellid)
             cell_neighbour = incidence_matrix.rowval[r]
-            cell_neighbour in cells || continue # Only care about the subset given in cells
+            is_member(cell_neighbour) || continue # Only care about the given subset
             color = cell_colors[cell_neighbour]
             if color != 0
-                push!(occupied_colors, color)
+                occupied[color] = true
             end
         end
 
-        # occupied colors now contains all the colors we are not allowed to use
+        # occupied now contains all the colors we are not allowed to use
         free_color = 0
         for attempt_color in 1:total_colors
-            if attempt_color ∉ occupied_colors
+            if !occupied[attempt_color]
                 free_color = attempt_color
                 break
             end
@@ -57,13 +118,38 @@ function greedy_coloring(incidence_matrix, cells = 1:size(incidence_matrix, 1))
         if free_color == 0 # no free color found, need to bump max colors
             total_colors += 1
             free_color = total_colors
+            total_colors > length(occupied) && push!(occupied, false)
             push!(final_colors, Int[])
         end
-        @assert free_color != 0
         cell_colors[cellid] = free_color
         push!(final_colors[free_color], cellid)
     end
     return final_colors
+end
+
+# Greedy algorithm for coloring a grid such that no two cells with the same node
+# have the same color
+function greedy_coloring(incidence_matrix, cells = 1:size(incidence_matrix, 1))
+    ncells = size(incidence_matrix, 1)
+    cell_colors = zeros(Int, ncells)
+    occupied = Bool[]
+    if cells isa AbstractUnitRange{Int}
+        return _greedy_coloring!(cell_colors, occupied, incidence_matrix, cells, c -> c in cells)
+    else
+        mask = zeros(Bool, ncells)
+        for c in cells
+            mask[c] = true
+        end
+        return _greedy_coloring!(cell_colors, occupied, incidence_matrix, cells, c -> mask[c])
+    end
+end
+
+function _color_zone_chunk!(zone_colors, chunk, zones, zone_of, cell_colors, incidence_matrix)
+    occupied = Bool[]
+    for zi in chunk
+        zone_colors[zi] = _greedy_coloring!(cell_colors, occupied, incidence_matrix, zones[zi], c -> zone_of[c] == zi)
+    end
+    return
 end
 
 # See Appendix A in https://www.math.colostate.edu/%7Ebangerth/publications/2013-pattern.pdf
@@ -74,43 +160,44 @@ function workstream_coloring(incidence_matrix, cellset)
     elseif length(cellset) == 1
         return Vector{Int}[Int[first(cellset)]]
     end
+    ncells = size(incidence_matrix, 1)
 
     ###################
     # 1. Partitioning #
     ###################
-    zones = OrderedSet{Int}[]
+    # Note: the incidence matrix is assumed to be created with the same cellset, so all
+    # neighbors found through it are members of the cellset.
+    cellvec = sort!(collect(Int, cellset))
+    zone_of = zeros(Int, ncells) # Zero represents no zone assigned yet
+    zones = Vector{Int}[]
     n_visited = 0
-    Z = 1
-    Z0 = OrderedSet{Int}() # Dummy zone
-    remaining_cells = OrderedSet{Int}(cellset)
-    while n_visited < length(cellset)
-        setdiff!(remaining_cells, zones...)
-        ## Zone 1: Just the first element
-        @assert length(remaining_cells) > 0
-        push!(zones, OrderedSet{Int}((first(remaining_cells),)))
-        Z += 1
+    seed_idx = 1
+    while n_visited < length(cellvec)
+        ## Zone 1: Just the first unvisited element (starts a new part of the cellset,
+        ## disconnected from the already zoned cells)
+        while zone_of[cellvec[seed_idx]] != 0
+            seed_idx += 1
+        end
+        seed = cellvec[seed_idx]
+        push!(zones, Int[seed])
+        zone_of[seed] = length(zones)
         n_visited += 1
         ## Zone N: All elements with connection to elements in Zone N-1
         while true
-            s = OrderedSet{Int}()
-            # Loop over all elements in previous zone and add their neighbouring elements
-            # unless they are in any of the previous 2 zones.
-            empty_zone = true
-            for c in get(zones, Z - 1, Z0)
-                c ∈ cellset || continue # technically not needed as long as incidence matrix is created with cellset
+            s = Int[]
+            Z = length(zones) + 1
+            for c in zones[end]
                 for r in nzrange(incidence_matrix, c)
                     cell_neighbour = incidence_matrix.rowval[r]
-                    if !(cell_neighbour in get(zones, Z - 2, Z0) || cell_neighbour in get(zones, Z - 1, Z0))
+                    if zone_of[cell_neighbour] == 0
+                        zone_of[cell_neighbour] = Z
                         push!(s, cell_neighbour)
-                        empty_zone = false
                     end
                 end
             end
-            empty_zone && break # no more cells connected to previous zone
-
+            isempty(s) && break # no more cells connected to previous zone
             push!(zones, s)
             n_visited += length(s)
-            Z += 1
         end
     end
 
@@ -118,8 +205,13 @@ function workstream_coloring(incidence_matrix, cellset)
     # 2. Coloring #
     ###############
     # TODO: The reference uses DSATUR algorithm instead of greedy
-    # TODO: Zones can be colorized in parallel
-    zone_colors = Vector{Vector{Int}}[greedy_coloring(incidence_matrix, z) for z in zones]
+    # Zones are colored in parallel: cells in a zone only ever compare colors with cells
+    # in the same zone, so each task reads and writes a disjoint part of `cell_colors`.
+    zone_colors = Vector{Vector{Vector{Int}}}(undef, length(zones))
+    cell_colors = zeros(Int, ncells)
+    @sync for chunk in _color_chunks(length(zones), 4 * Threads.nthreads())
+        Threads.@spawn _color_zone_chunk!(zone_colors, $chunk, zones, zone_of, cell_colors, incidence_matrix)
+    end
 
     ################
     # 3. Gathering #
@@ -142,7 +234,7 @@ function workstream_coloring(incidence_matrix, cellset)
             _, global_color = findmin(x -> (cond(x) && x ∉ used_for_zone) ? color_sizes[x] : typemax(Int), 1:N)
             push!(used_for_zone, global_color)
             append!(final_colors[global_color], zone_color_vectors[local_color])
-            map!(length, color_sizes, final_colors)
+            color_sizes[global_color] = length(final_colors[global_color])
         end
     end
 

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -3,26 +3,34 @@ function _color_chunks(n::Int, maxchunks::Int)
     return Iterators.partition(1:n, max(1, cld(n, maxchunks)))
 end
 
-# Normalize a cellset to a sorted vector of unique cell ids: 1-based indexable, sorted
-# ascending, no duplicates, `Int` elements. Unit ranges already fulfill these
-# requirements and are used as-is. Note that `unique!` on the sorted vector is a cheap
-# allocation-free linear scan.
+# We need a sorted collection without duplicates. The default case (`cells = 1:ncells`)
+# fulfills this already.
 _sorted_cellvec(cellset::AbstractUnitRange{Int}) = cellset
 _sorted_cellvec(cellset) = unique!(sort!(collect(Int, cellset)))
 
-function _gather_neighbor_chunk!(colcount, g, cellvec, chunk, nodeptr, nodecells)
+function _gather_neighbor_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodecells)
     buf = Int[]
     candidates = Int[]
+    # Loop over cells in the chunk
     for i in chunk
         cellid = cellvec[i]
         empty!(candidates)
-        for v in get_node_ids(getcells(g, cellid))
+        # Loop over nodes of the cell
+        for v in get_node_ids(getcells(grid, cellid))
+            # Loop over the cells connected to this node
             for r in nodeptr[v]:(nodeptr[v + 1] - 1)
                 cell_neighbour = nodecells[r]
                 cell_neighbour == cellid || push!(candidates, cell_neighbour)
             end
         end
-        sort!(candidates)
+        # QuickSort sorts in-place without allocations. The default algorithm dispatches
+        # to counting/radix sort which allocates a workspace on each call so we use QuickSort
+        # which performs better here.
+        sort!(candidates; alg = QuickSort)
+        # Each per-node cell list in nodecells is duplicate-free, but candidates
+        # concatenates the lists of all nodes of this cell, so a neighbor sharing k nodes
+        # with the cell occurs k times. After sorting, duplicates are adjacent and can be
+        # skipped by comparing with the previous entry (a unique! fused with the counting).
         prev = 0
         for cell_neighbour in candidates
             if cell_neighbour != prev
@@ -36,19 +44,19 @@ function _gather_neighbor_chunk!(colcount, g, cellvec, chunk, nodeptr, nodecells
 end
 
 # Incidence matrix for element connections in the grid
-function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
-    ncells = getncells(g)
+function create_incidence_matrix(grid::AbstractGrid, cellset = 1:getncells(grid))
+    ncells = getncells(grid)
     cellvec = _sorted_cellvec(cellset)
     if isempty(cellvec)
         return SparseArrays.spzeros(Bool, Int, ncells, ncells)
     end
 
     # Map from node id to the cells in the cellset containing it, in CSR-like form.
-    nnodes = getnnodes(g)
+    nnodes = getnnodes(grid)
     nodeptr = zeros(Int, nnodes + 1)
     nodeptr[1] = 1
     for cellid in cellvec
-        for v in get_node_ids(getcells(g, cellid))
+        for v in get_node_ids(getcells(grid, cellid))
             nodeptr[v + 1] += 1
         end
     end
@@ -58,7 +66,7 @@ function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
     nodecells = Vector{Int}(undef, nodeptr[end] - 1)
     cursor = copy(nodeptr)
     for cellid in cellvec
-        for v in get_node_ids(getcells(g, cellid))
+        for v in get_node_ids(getcells(grid, cellid))
             nodecells[cursor[v]] = cellid
             cursor[v] += 1
         end
@@ -67,13 +75,13 @@ function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
     # For each cell, gather the unique cells sharing at least one node with it.
     # Since `cellvec` is sorted, each chunk corresponds to a contiguous range of
     # columns in the CSC structure, so the chunk buffers can be computed in
-    # parallel and copied over without synchronization.
+    # parallel and afterwards concatenated to form rowval.
     chunks = collect(_color_chunks(length(cellvec), Threads.nthreads()))
     colcount = zeros(Int, ncells)
     buffers = Vector{Vector{Int}}(undef, length(chunks))
     @sync for (ci, chunk) in enumerate(chunks)
         Threads.@spawn begin
-            buffers[$ci] = _gather_neighbor_chunk!(colcount, g, cellvec, $chunk, nodeptr, nodecells)
+            buffers[$ci] = _gather_neighbor_chunk!(colcount, grid, cellvec, $chunk, nodeptr, nodecells)
         end
     end
 
@@ -83,11 +91,12 @@ function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
         colptr[c + 1] = colptr[c] + colcount[c]
     end
     rowval = Vector{Int}(undef, colptr[end] - 1)
-    @sync for (ci, chunk) in enumerate(chunks)
-        Threads.@spawn begin
-            buf = buffers[$ci]
-            copyto!(rowval, colptr[cellvec[first($chunk)]], buf, 1, length(buf))
-        end
+    @assert length(rowval) == sum(length, buffers; init = 0)
+    # This loop is trivially parallelizable but it is just a memcpy so there is no
+    # measurable speedup from doing so.
+    for (ci, chunk) in enumerate(chunks)
+        buf = buffers[ci]
+        copyto!(rowval, colptr[cellvec[first(chunk)]], buf, 1, length(buf))
     end
     nzval = fill(true, length(rowval))
     return SparseMatrixCSC(ncells, ncells, colptr, rowval, nzval)
@@ -213,6 +222,9 @@ function workstream_coloring(incidence_matrix, cellset)
     # TODO: The reference uses DSATUR algorithm instead of greedy
     # Zones are colored in parallel: cells in a zone only ever compare colors with cells
     # in the same zone, so each task reads and writes a disjoint part of `cell_colors`.
+    # Zone sizes vary wildly (they are levels of a breadth-first traversal), so
+    # oversubscribe with 4x more tasks than threads to get some load balancing from the
+    # scheduler.
     zone_colors = Vector{Vector{Vector{Int}}}(undef, length(zones))
     cell_colors = zeros(Int, ncells)
     @sync for chunk in _color_chunks(length(zones), 4 * Threads.nthreads())

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -1,7 +1,14 @@
 # Split `1:n` into at most `maxchunks` contiguous ranges of similar size.
 function _color_chunks(n::Int, maxchunks::Int)
-    return Iterators.partition(1:n, cld(n, min(n, maxchunks)))
+    return Iterators.partition(1:n, max(1, cld(n, maxchunks)))
 end
+
+# Normalize a cellset to a sorted vector of unique cell ids: 1-based indexable, sorted
+# ascending, no duplicates, `Int` elements. Unit ranges already fulfill these
+# requirements and are used as-is. Note that `unique!` on the sorted vector is a cheap
+# allocation-free linear scan.
+_sorted_cellvec(cellset::AbstractUnitRange{Int}) = cellset
+_sorted_cellvec(cellset) = unique!(sort!(collect(Int, cellset)))
 
 function _gather_neighbor_chunk!(colcount, g, cellvec, chunk, nodeptr, nodecells)
     buf = Int[]
@@ -31,13 +38,12 @@ end
 # Incidence matrix for element connections in the grid
 function create_incidence_matrix(g::AbstractGrid, cellset = 1:getncells(g))
     ncells = getncells(g)
-    cellvec = sort!(collect(Int, cellset))
+    cellvec = _sorted_cellvec(cellset)
     if isempty(cellvec)
         return SparseArrays.spzeros(Bool, Int, ncells, ncells)
     end
 
     # Map from node id to the cells in the cellset containing it, in CSR-like form.
-    # Since cells are visited in ascending order each per-node cell list is sorted.
     nnodes = getnnodes(g)
     nodeptr = zeros(Int, nnodes + 1)
     nodeptr[1] = 1
@@ -155,10 +161,11 @@ end
 # See Appendix A in https://www.math.colostate.edu/%7Ebangerth/publications/2013-pattern.pdf
 function workstream_coloring(incidence_matrix, cellset)
 
-    if length(cellset) == 0
+    cellvec = _sorted_cellvec(cellset)
+    if length(cellvec) == 0
         return Vector{Int}[]
-    elseif length(cellset) == 1
-        return Vector{Int}[Int[first(cellset)]]
+    elseif length(cellvec) == 1
+        return Vector{Int}[Int[first(cellvec)]]
     end
     ncells = size(incidence_matrix, 1)
 
@@ -167,7 +174,6 @@ function workstream_coloring(incidence_matrix, cellset)
     ###################
     # Note: the incidence matrix is assumed to be created with the same cellset, so all
     # neighbors found through it are members of the cellset.
-    cellvec = sort!(collect(Int, cellset))
     zone_of = zeros(Int, ncells) # Zero represents no zone assigned yet
     zones = Vector{Int}[]
     n_visited = 0

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -751,6 +751,12 @@ end
     #Special case with one and zero elements in the sets
     test_coloring(generate_grid(Quadrilateral, (2, 2)), [1])
     test_coloring(generate_grid(Quadrilateral, (2, 2)), [])
+
+    # duplicate entries in the cellset are ignored
+    let grid = generate_grid(Quadrilateral, (3, 3))
+        @test create_coloring(grid, [2, 2, 4]) == create_coloring(grid, [2, 4])
+        @test create_coloring(grid, [5, 5]) == create_coloring(grid, [5])
+    end
 end
 
 @testset "High order dof distribution" begin


### PR DESCRIPTION
This rewrites `src/Grid/coloring.jl` for performance. The coloring is a serial preprocessing step for threaded assembly, so its cost directly limits the achievable speedup (Amdahl's law).

- **`create_incidence_matrix`** (was ~80% of the total cost): the `Dict{Int, Set{Int}}` node map and the all-pairs `I`/`J` buffers (every neighbor pair pushed once per shared node) are replaced by a counting-sort node→cell map in CSR-like form, followed by a per-cell unique-neighbor gather that runs on `Threads.@spawn`ed chunks and writes the `SparseMatrixCSC` structure directly. Since the cellset is processed in sorted order, each chunk owns a contiguous, disjoint range of columns, so no synchronization is needed and the result is independent of the number of threads.
- **`workstream_coloring`**: the `OrderedSet` zones and the `setdiff!(remaining_cells, zones...)` splat (which rescanned all zones on every outer iteration) are replaced by a flat `zone_of` array doing a plain level-BFS. The zones are then colored in parallel (resolving the old TODO), which is safe because a zone's greedy coloring only reads and writes its own cells' entries in the shared color array.
- **`greedy_coloring`**: `Dict`/`Set` bookkeeping replaced with flat arrays; both algorithms share one core parameterized on a membership predicate.

The public API and the returned incidence matrix format are unchanged, and the produced colorings are deterministic: 1-thread and 8-thread runs give identical results.

Timings for `create_coloring` (best of 5, M-series CPU, julia 1.12.6):

| Grid | Before | After (8 threads) | After (1 thread) |
|---|---|---|---|
| Hexahedron 60³ (216k cells) | 469 ms | 50 ms | 164 ms |
| Tetrahedron 40³ (384k cells) | 1342 ms | 138 ms | 509 ms |
| Quadrilateral 500² (250k cells) | 196 ms | 7 ms | 17 ms |

A 1M-cell hexahedron grid now colors in ~0.4 s (8 threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)