### PR TITLE
Propagate atomics through constraint condensation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
  - Atomic assembly support for BlockAssembler. ([#1452])
+ - `apply_assemble!` now respects the assembler's atomic mode when non-local affine
+   constraints write directly to the global matrix and vector. ([#1465])
  - `add_sparsity_entries!` (and thereby `allocate_matrix`) now guarantees that passing
    `interface_coupling` adds the requested interface entries: the `topology` keyword
    argument is now optional and, when not passed, constructed from the grid (previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
  - Atomic assembly support for BlockAssembler. ([#1452])
+ - `apply_assemble!` now respects the assembler's atomic mode when non-local affine
+   constraints write directly to the global matrix and vector. ([#1465])
  - `add_interface_entries!` (and thereby `interface_coupling` builds) no longer errors for
    grids where some cells are not covered by any `SubDofHandler`: an uncovered cell has no
    dofs and contributes no interface entries, but the covered side of such an interface

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -93,6 +93,20 @@ end
     end
 end
 
+function Ferrite.addindex!(A::SparseMatrixCSR{Bi, Tv}, v::Tv, i::Int, j::Int, ::Val{atomic} = Val(false)) where {Bi, Tv, atomic}
+    @boundscheck checkbounds(A, i, j)
+    iszero(v) && return A
+    nzr = nzrange(A, i)
+    stored_j = j - (1 - Bi)
+    searchk = searchsortedfirst(A.colval, stored_j, first(nzr), last(nzr), Base.Order.Forward)
+    if searchk <= last(nzr) && A.colval[searchk] == stored_j
+        Ferrite.addindex!(A.nzval, v, searchk, Val{atomic}())
+        return A
+    else
+        throw(Ferrite.SparsityError())
+    end
+end
+
 function Ferrite.zero_out_rows!(K::SparseMatrixCSR, ch::ConstraintHandler)
     @debug @assert issorted(ch.prescribed_dofs)
     for row in ch.prescribed_dofs

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1762,7 +1762,7 @@ end
 function _apply_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_dofs::AbstractVector, ch::ConstraintHandler, apply_zero::Bool,
-        global_matrix, global_vector
+        global_matrix, global_vector, atomic::Val = Val(false)
     )
     @assert isclosed(ch)
     # TODO: With apply_zero it shouldn't be required to pass the vector.
@@ -1794,7 +1794,7 @@ function _apply_local!(
     # 3. Condense any affine constraints
     if has_nontrivial_affine_constraints
         # Condense this constraint locally if possible, and otherwise modifies the global arrays.
-        _condense_local!(local_matrix, local_vector, global_matrix, global_vector, global_dofs, ch.dofmapping, ch.dofcoefficients, ch.isconstrained)
+        _condense_local!(local_matrix, local_vector, global_matrix, global_vector, global_dofs, ch.dofmapping, ch.dofcoefficients, ch.isconstrained, atomic)
     end
     # 4. Zero out columns/rows of local matrix and replace diagonal entries with the mean
     if has_constraints
@@ -1825,7 +1825,7 @@ end
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_matrix #=::SparseMatrixCSC=#, global_vector #=::Vector=#,
         global_dofs::AbstractVector, dofmapping::Dict, dofcoefficients::Vector,
-        isconstrained::BitVector
+        isconstrained::BitVector, atomic::Val = Val(false)
     )
 
 Condensation of affine constraints on element level. If possible this function only
@@ -1835,7 +1835,7 @@ function _condense_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_matrix #=::SparseMatrixCSC=#, global_vector #=::Vector=#,
         global_dofs::AbstractVector, dofmapping::Dict, dofcoefficients::Vector,
-        isconstrained::BitVector,
+        isconstrained::BitVector, atomic::Val = Val(false),
     )
     @assert axes(local_matrix, 1) == axes(local_matrix, 2) ==
         axes(local_vector, 1) == axes(global_dofs, 1)
@@ -1856,7 +1856,7 @@ function _condense_local!(
                         # can't zero it out later like with the local matrix.
                         if !isconstrained[global_col] && !isconstrained[global_mrow]
                             has_global_arrays || missing_global()
-                            addindex!(global_matrix, mw, global_mrow, global_col)
+                            addindex!(global_matrix, mw, global_mrow, global_col, atomic)
                         end
                     else
                         local_matrix[local_mrow, local_col] += mw
@@ -1877,7 +1877,7 @@ function _condense_local!(
                             # can't zero it out later like with the local matrix.
                             if !haskey(dofmapping, global_row) && !haskey(dofmapping, global_mcol)
                                 has_global_arrays || missing_global()
-                                addindex!(global_matrix, mw, global_row, global_mcol)
+                                addindex!(global_matrix, mw, global_row, global_mcol, atomic)
                             end
                         else
                             local_matrix[local_row, local_mcol] += mw
@@ -1894,7 +1894,7 @@ function _condense_local!(
                                 # can't zero it out later like with the local matrix.
                                 if !haskey(dofmapping, global_mrow) && !haskey(dofmapping, global_mcol)
                                     has_global_arrays || missing_global()
-                                    addindex!(global_matrix, mww, global_mrow, global_mcol)
+                                    addindex!(global_matrix, mww, global_mrow, global_mcol, atomic)
                                 end
                             else
                                 local_matrix[local_mrow, local_mcol] += mww
@@ -1908,7 +1908,7 @@ function _condense_local!(
                 local_mcol = findfirst(==(global_mcol), global_dofs)
                 if local_mcol === nothing
                     has_global_arrays || missing_global()
-                    addindex!(global_vector, vw, global_mcol)
+                    addindex!(global_vector, vw, global_mcol, atomic)
                 else
                     local_vector[local_mcol] += vw
                 end

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1763,7 +1763,7 @@ end
 function _apply_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_dofs::AbstractVector, ch::ConstraintHandler, apply_zero::Bool,
-        global_matrix, global_vector
+        global_matrix, global_vector, atomic::Val = Val(false)
     )
     @assert isclosed(ch)
     # TODO: With apply_zero it shouldn't be required to pass the vector.
@@ -1795,7 +1795,7 @@ function _apply_local!(
     # 3. Condense any affine constraints
     if has_nontrivial_affine_constraints
         # Condense this constraint locally if possible, and otherwise modifies the global arrays.
-        _condense_local!(local_matrix, local_vector, global_matrix, global_vector, global_dofs, ch.dofmapping, ch.dofcoefficients, ch.isconstrained)
+        _condense_local!(local_matrix, local_vector, global_matrix, global_vector, global_dofs, ch.dofmapping, ch.dofcoefficients, ch.isconstrained, atomic)
     end
     # 4. Zero out columns/rows of local matrix and replace diagonal entries with the mean
     if has_constraints
@@ -1826,7 +1826,7 @@ end
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_matrix #=::SparseMatrixCSC=#, global_vector #=::Vector=#,
         global_dofs::AbstractVector, dofmapping::Dict, dofcoefficients::Vector,
-        isconstrained::BitVector
+        isconstrained::BitVector, atomic::Val = Val(false)
     )
 
 Condensation of affine constraints on element level. If possible this function only
@@ -1836,7 +1836,7 @@ function _condense_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_matrix #=::SparseMatrixCSC=#, global_vector #=::Vector=#,
         global_dofs::AbstractVector, dofmapping::Dict, dofcoefficients::Vector,
-        isconstrained::BitVector,
+        isconstrained::BitVector, atomic::Val = Val(false),
     )
     @assert axes(local_matrix, 1) == axes(local_matrix, 2) ==
         axes(local_vector, 1) == axes(global_dofs, 1)
@@ -1857,7 +1857,7 @@ function _condense_local!(
                         # can't zero it out later like with the local matrix.
                         if !isconstrained[global_col] && !isconstrained[global_mrow]
                             has_global_arrays || missing_global()
-                            addindex!(global_matrix, mw, global_mrow, global_col)
+                            addindex!(global_matrix, mw, global_mrow, global_col, atomic)
                         end
                     else
                         local_matrix[local_mrow, local_col] += mw
@@ -1878,7 +1878,7 @@ function _condense_local!(
                             # can't zero it out later like with the local matrix.
                             if !haskey(dofmapping, global_row) && !haskey(dofmapping, global_mcol)
                                 has_global_arrays || missing_global()
-                                addindex!(global_matrix, mw, global_row, global_mcol)
+                                addindex!(global_matrix, mw, global_row, global_mcol, atomic)
                             end
                         else
                             local_matrix[local_row, local_mcol] += mw
@@ -1895,7 +1895,7 @@ function _condense_local!(
                                 # can't zero it out later like with the local matrix.
                                 if !haskey(dofmapping, global_mrow) && !haskey(dofmapping, global_mcol)
                                     has_global_arrays || missing_global()
-                                    addindex!(global_matrix, mww, global_mrow, global_mcol)
+                                    addindex!(global_matrix, mww, global_mrow, global_mcol, atomic)
                                 end
                             else
                                 local_matrix[local_mrow, local_mcol] += mww
@@ -1909,7 +1909,7 @@ function _condense_local!(
                 local_mcol = findfirst(==(global_mcol), global_dofs)
                 if local_mcol === nothing
                     has_global_arrays || missing_global()
-                    addindex!(global_vector, vw, global_mcol)
+                    addindex!(global_vector, vw, global_mcol, atomic)
                 else
                     local_vector[local_mcol] += vw
                 end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -494,9 +494,10 @@ function apply_assemble!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector;
         apply_zero::Bool = false
     )
+    atomic = Val(_is_atomic(assembler))
     _apply_local!(
         local_matrix, local_vector, global_dofs, ch, apply_zero,
-        matrix_handle(assembler), vector_handle(assembler),
+        matrix_handle(assembler), vector_handle(assembler), atomic,
     )
     assemble!(assembler, global_dofs, local_matrix, local_vector)
     return

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -96,6 +96,22 @@ using SparseArrays, LinearAlgebra
         V = [-1.0, 1.0, 2.0, -2.0, 2.0, 1.0, -1.0]
         @test Ka == sparsecsr(I, J, V)
         @test fa == [1.0, 4.0, 1.0]
+
+        # Non-local affine constraint condensation also uses atomic accumulation
+        ch_affine = ConstraintHandler(dh)
+        add!(ch_affine, AffineConstraint(1, [3 => 1.0], 0.0))
+        close!(ch_affine)
+        K = allocate_matrix(SparseMatrixCSR, dh, ch_affine)
+        f = zeros(3)
+        Ka = copy(K)
+        fa = copy(f)
+        assembler = start_assemble(K, f)
+        atomic_assembler = start_assemble(Ka, fa; atomic = true)
+        apply_assemble!(assembler, ch_affine, [1, 2], copy(ke), copy(fe))
+        apply_assemble!(atomic_assembler, ch_affine, [1, 2], copy(ke), copy(fe))
+        @test Ka == K
+        @test fa == f
+
         # Atomic accumulation is only supported for Float32/Float64 matrices
         Kint = sparsecsr([1, 2], [1, 2], zeros(Int, 2))
         @test_throws ArgumentError start_assemble(Kint; atomic = true)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1,6 +1,41 @@
 # Imports for parallel (isolated) test execution:
 using LinearAlgebra, SparseArrays, Logging
 
+# Minimal atomic assembler used to verify that `apply_assemble!` propagates its atomic
+# mode into the non-local constraint condensation before regular assembly.
+struct AtomicApplyAssembler{M, V} <: Ferrite.AbstractAssembler{Float64}
+    K::M
+    f::V
+end
+struct AtomicProbeArray{N} <: AbstractArray{Float64, N}
+    data::Array{Float64, N}
+    atomics::Vector{Bool}
+end
+AtomicProbeArray(data::Array{Float64, N}) where {N} = AtomicProbeArray{N}(data, Bool[])
+Base.size(A::AtomicProbeArray) = size(A.data)
+Base.getindex(A::AtomicProbeArray, I...) = getindex(A.data, I...)
+Base.setindex!(A::AtomicProbeArray, v, I...) = setindex!(A.data, v, I...)
+
+Ferrite.matrix_handle(a::AtomicApplyAssembler) = a.K
+Ferrite.vector_handle(a::AtomicApplyAssembler) = a.f
+Ferrite._is_atomic(::AtomicApplyAssembler) = true
+function Ferrite.assemble!(
+        ::AtomicApplyAssembler, ::AbstractVector{<:Integer}, ::AbstractMatrix,
+        ::AbstractVector
+    )
+    return
+end
+function Ferrite.addindex!(A::AtomicProbeArray{1}, v::Float64, i::Int, ::Val{atomic} = Val(false)) where {atomic}
+    push!(A.atomics, atomic)
+    A.data[i] += v
+    return A
+end
+function Ferrite.addindex!(A::AtomicProbeArray{2}, v::Float64, i::Int, j::Int, ::Val{atomic} = Val(false)) where {atomic}
+    push!(A.atomics, atomic)
+    A.data[i, j] += v
+    return A
+end
+
 # misc constraint tests
 
 @testset "constructors and error checking" begin
@@ -1619,6 +1654,27 @@ end # testset
         end
     end
 end # testset
+
+@testset "atomic local constraint condensation" begin
+    grid = generate_grid(Line, (2,))
+    dh = DofHandler(grid)
+    add!(dh, :u, Lagrange{RefLine, 1}())
+    close!(dh)
+    ch = ConstraintHandler(dh)
+    add!(ch, AffineConstraint(1, [3 => 1.0], 0.0))
+    close!(ch)
+
+    dofs = celldofs(dh, 1)
+    K = AtomicProbeArray(zeros(3, 3))
+    f = AtomicProbeArray(zeros(3))
+    assembler = AtomicApplyAssembler(K, f)
+    apply_assemble!(assembler, ch, dofs, ones(2, 2), ones(2))
+
+    @test !isempty(K.atomics)
+    @test !isempty(f.atomics)
+    @test all(K.atomics)
+    @test all(f.atomics)
+end
 
 @testset "Sparsity pattern without constrained dofs" begin
     grid = generate_grid(Triangle, (5, 5))


### PR DESCRIPTION
## Summary

- forward the assembler's atomic mode to non-local affine constraint writes
- add atomic `addindex!` support for `SparseMatrixCSR`
- add regression tests for matrix and vector accumulation

Closes #1465.
