### PR TITLE
Retire the generic branch: fast fill for pre-populated patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal changes
  - `SparsityPattern` has been rewritten: all rows are now stored in a single contiguous
-   buffer and filled by an exact-counting fast path with lazily sorted rows. The internal
+   buffer and filled by an exact-counting fast path with lazily sorted rows (also for builds
+   on patterns with pre-existing entries, which are kept and deduplicated). The internal
    `FastSparsityPattern` (from [#1302]) and the internal `Ferrite.PoolAllocator` module have
    been removed. ([#1397])
  - The documented contract of `Ferrite.eachrow(sp[, row])` for `AbstractSparsityPattern` now

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -76,7 +76,7 @@ documentation.
    column indices live as a slice. Backing all rows with a single growable buffer (plus an
    isbits metadata array) keeps GC pressure low.
  - `sorted::Bool`: whether each row's column indices are currently sorted. Rows are filled unsorted
-   by the fast path and sorted lazily on demand (see `eachrow`/`add_entry!`).
+   by the counting build in `add_sparsity_entries!` and sorted lazily on demand (see `eachrow`/`add_entry!`).
 
 !!! warning "Internal struct"
     The specific implementation of this struct, such as struct fields, type layout and type
@@ -214,17 +214,19 @@ function _sort_rows!(sp::SparsityPattern, rowrange::UnitRange{Int})
     return
 end
 
-# Fast path: count exact per-row sizes with a column marker, presize the buffer, then marker-dedup
+# The counting build behind add_sparsity_entries!: count exact per-row sizes with a column
+# marker, presize the buffer, then marker-dedup
 # fill each row UNSORTED (sorted lazily). Always includes the diagonal. Non-full `coupling` and
 # `keep_constrained = false` are handled by applying the expanded coupling masks and the
 # constrained-dof filter identically in the count and the fill pass (see _visit_row_candidates!).
-function _fast_fill_cells!(
+function _build_pattern!(
         sp::SparsityPattern, dh::DofHandler,
         couplings::Union{Nothing, Vector{Matrix{Bool}}} = nothing,
         isconstrained::Union{Nothing, Vector{Bool}} = nothing,
         neighbor_cells::Union{Nothing, ArrayOfVectorViews} = nothing,
         interface_couplings::Union{Nothing, Vector{Matrix{Bool}}} = nothing;
         fill_interfaces::Bool = false,
+        oldbuffer::Union{Nothing, ConstructionBuffer{Int, 1}} = nothing,
     )
     nrows = getnrows(sp)
     #...
@@ -239,14 +241,15 @@ function _fast_fill_cells!(
     cell_to_sdh = dh.cell_to_subdofhandler
     _visit_row_candidates!(
         rowlen, nothing, nothing, marker, row_to_cells, row_to_localidx, cell_dofs,
-        cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings
+        cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings, oldbuffer
     )
     buffer = _presize_buffer(rowlen, sp.buffer.sizehint)
     fill!(marker, 0)
     _visit_row_candidates!(
         rowlen, buffer.data, buffer.indices, marker, row_to_cells, row_to_localidx, cell_dofs,
         cell_to_sdh, couplings, isconstrained,
-        fill_interfaces ? neighbor_cells : nothing, fill_interfaces ? interface_couplings : nothing
+        fill_interfaces ? neighbor_cells : nothing, fill_interfaces ? interface_couplings : nothing,
+        oldbuffer
     )
     sp.buffer = buffer
     sp.sorted = false
@@ -354,11 +357,13 @@ function add_sparsity_entries!(
     return sp
 end
 
-# SparsityPattern takes a fast path whenever it is empty: cell entries (including the diagonal,
-# and respecting `coupling` and `keep_constrained`) are exactly counted, the buffer is presized in
-# one allocation, and rows are filled with a marker-dedup append. A non-empty pattern falls back
-# to the generic per-entry path. Interface entries (interface_coupling) and constraints always
-# layer on afterwards, so they are compatible with the fast path.
+# Specialized method for the concrete SparsityPattern.
+# This builds the pattern in bulk: cell entries (including the diagonal, respecting
+# `coupling` and `keep_constrained`) and any pre-existing entries are exactly counted, the
+# buffer is presized in one allocation, and rows are filled with a marker-dedup append.
+# Interface entries (interface_coupling) are reserved for (and, when the enumeration is
+# exact, filled by) the same passes; otherwise they and the constraints layer on afterwards
+# through add_entry!.
 function add_sparsity_entries!(
         sp::SparsityPattern, dh::DofHandler, ch::Union{ConstraintHandler, Nothing} = nothing;
         keep_constrained::Bool = true,
@@ -371,31 +376,27 @@ function add_sparsity_entries!(
         error("number of rows ($(getnrows(sp))) or columns ($(getncols(sp))) in the sparsity pattern is smaller than number of dofs ($(ndofs(dh)))")
     end
     interfaces_filled = false
-    if isempty(sp.buffer.data)
-        keep_constrained || _check_keep_constrained_args(dh, ch)
-        couplings = _coupling_to_local_dof_coupling(dh, coupling)
-        isconstrained = keep_constrained ? nothing : _isconstrained_by_dof(ch, getnrows(sp))
-        # With interface entries coming (added below), reserve row space for them up front so
-        # they land in place instead of relocating rows. When the reservation enumeration is
-        # provably exact it doubles as the insertion itself (see _visit_row_candidates!).
-        if interface_coupling === nothing
-            neighbor_cells = interface_couplings = nothing
-        else
-            if topology === nothing
-                topology = ExclusiveTopology(get_grid(dh))
-            end
-            neighbor_cells = create_cell_to_neighbors(dh.grid, topology)
-            interface_couplings = _coupling_to_local_dof_coupling(dh, interface_coupling)
-            interfaces_filled = _can_fill_interfaces_directly(dh)
-        end
-        _fast_fill_cells!(
-            sp, dh, couplings, isconstrained, neighbor_cells, interface_couplings;
-            fill_interfaces = interfaces_filled
-        )
+    keep_constrained || _check_keep_constrained_args(dh, ch)
+    couplings = _coupling_to_local_dof_coupling(dh, coupling)
+    isconstrained = keep_constrained ? nothing : _isconstrained_by_dof(ch, getnrows(sp))
+    # With interface entries coming (added below), reserve row space for them up front so
+    # they land in place instead of relocating rows. When the reservation enumeration is
+    # provably exact it doubles as the insertion itself (see _visit_row_candidates!).
+    if interface_coupling === nothing
+        neighbor_cells = interface_couplings = nothing
     else
-        add_diagonal_entries!(sp)
-        add_cell_entries!(sp, dh, ch; keep_constrained, coupling)
+        if topology === nothing
+            topology = ExclusiveTopology(get_grid(dh))
+        end
+        neighbor_cells = create_cell_to_neighbors(dh.grid, topology)
+        interface_couplings = _coupling_to_local_dof_coupling(dh, interface_coupling)
+        interfaces_filled = _can_fill_interfaces_directly(dh)
     end
+    oldbuffer = isempty(sp.buffer.data) ? nothing : sp.buffer
+    _build_pattern!(
+        sp, dh, couplings, isconstrained, neighbor_cells, interface_couplings;
+        fill_interfaces = interfaces_filled, oldbuffer
+    )
     interface_coupling !== nothing && !interfaces_filled && add_interface_entries!(sp, dh, ch; topology, keep_constrained, interface_coupling)
     ch !== nothing && add_constraint_entries!(sp, ch; keep_constrained)
     return sp
@@ -444,7 +445,7 @@ function _check_keep_constrained_args(dh::DofHandler, ch::Union{ConstraintHandle
     return
 end
 
-# For now interfaces can not be fast-filled with multiple SubDofHandlers (the expanded
+# For now the counting passes cannot fill interface entries directly with multiple SubDofHandlers (the expanded
 # coupling masks are per-sdh and do not apply to a neighbor with a different dof layout);
 # the enumeration still (over)counts cross-sdh neighbors so the reservation covers what
 # add_interface_entries! inserts afterwards.
@@ -919,7 +920,7 @@ function create_celldofs(dh::DofHandler)
     return ArrayOfVectorViews(indices, cell_dofs, LinearIndices((ncells,)))
 end
 
-# For each cell, the cells sharing a facet with it (used by the fast path to reserve row
+# For each cell, the cells sharing a facet with it (used by the counting build to reserve row
 # space for interface entries).
 function create_cell_to_neighbors(grid::AbstractGrid, topology)
     ncells = getncells(grid)
@@ -1000,6 +1001,7 @@ function _visit_row_candidates!(
         couplings::Union{Nothing, Vector{Matrix{Bool}}}, isconstrained::Union{Nothing, Vector{Bool}},
         neighbor_cells::Union{Nothing, ArrayOfVectorViews} = nothing,
         interface_couplings::Union{Nothing, Vector{Matrix{Bool}}} = nothing,
+        oldbuffer::Union{Nothing, ConstructionBuffer{Int, 1}} = nothing,
     )
     counting = data === nothing
     ncols = length(marker) # marker has one slot per column
@@ -1012,6 +1014,20 @@ function _visit_row_candidates!(
             marker[row] = row
             counting || (data[start] = row)
             p = 1
+        end
+        # Entries already stored in the pattern are always kept, deduplicated against the new
+        # candidates by the marker (cf. the retired generic per-entry path, which only ever
+        # added)
+        if oldbuffer !== nothing
+            r_old = oldbuffer.indices[row]
+            for q in 0:(r_old.ncurrent - 1)
+                col = oldbuffer.data[r_old.start + q]
+                if marker[col] != row
+                    marker[col] = row
+                    counting || (data[start + p] = col)
+                    p += 1
+                end
+            end
         end
         # For keep_constrained = false a constrained row stores only the diagonal (included
         # in the pattern just above)

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -354,7 +354,7 @@ end
     compare_patterns(sp_ic, sp_ic_topo)
 end
 
-@testset "SparsityPattern fast path" begin
+@testset "SparsityPattern counting build" begin
     function fsp_test_create_dh(CT)
         RS = getrefshape(CT)
         dim = Ferrite.getrefdim(RS)
@@ -364,13 +364,19 @@ end
         add!(dh, :b, Lagrange{RS, 2}()^dim)
         return close!(dh)
     end
-    # The internal fast (count-presize marker fill) path is taken for any fresh pattern. Force
-    # the generic per-entry path for comparison by seeding one diagonal entry first (the
-    # diagonal is always part of the pattern, so the built patterns must be identical).
-    function fsp_test_build_generic(dh, args...; kwargs...)
-        sp = init_sparsity_pattern(dh)
-        Ferrite.add_entry!(sp, 1, 1)
-        return add_sparsity_entries!(sp, dh, args...; kwargs...)
+    # The counting (count-presize marker fill) build is used for every SparsityPattern, so
+    # the reference for comparison is the generic AbstractSparsityPattern method, invoked
+    # explicitly. `seed!` optionally pre-populates the pattern before the build.
+    function fsp_test_build_generic(
+            dh, ch = nothing; seed! = identity, sp = init_sparsity_pattern(dh),
+            keep_constrained = true, coupling = nothing, interface_coupling = nothing, topology = nothing,
+        )
+        seed!(sp)
+        Base.@invoke add_sparsity_entries!(
+            sp::Ferrite.AbstractSparsityPattern, dh::DofHandler, ch::Union{ConstraintHandler, Nothing};
+            keep_constrained, coupling, interface_coupling, topology
+        )
+        return sp
     end
     for CT in (Line, Quadrilateral, Tetrahedron)
         dh = fsp_test_create_dh(CT)
@@ -391,7 +397,8 @@ end
         @test K1_csr == K2_csr
         @test K1_csr == K3_csr
     end
-    # Coupling and keep_constrained are handled by the fast path (masked/filtered counting);
+    # Coupling and keep_constrained are handled during the counting build (masked/filtered
+    # candidate enumeration);
     # compare against the generic path for the same arguments.
     for CT in (Quadrilateral, Tetrahedron)
         dh = fsp_test_create_dh(CT)
@@ -409,7 +416,7 @@ end
             compare_matrices(allocate_matrix(sp_fast), allocate_matrix(sp_gen))
         end
     end
-    # Full masks are normalized away in the fast path but must still be validated
+    # Full masks are normalized away before the build but must still be validated
     # (dh has 2 fields, 3 components, 22 dofs/cell, so trues(4, 4) matches nothing)
     let dh = fsp_test_create_dh(Quadrilateral)
         sp() = init_sparsity_pattern(dh)
@@ -421,7 +428,7 @@ end
     # Interface entries (topology) are reserved up front, filtered by interface_coupling. For a
     # single-subdofhandler discretization the reservation is exact and doubles as the fill
     # itself, i.e. no row relocations and no layered interface insertion. (Multiple
-    # subdofhandlers still take the layered path: the fast fill's expanded masks are square
+    # subdofhandlers still take the layered path: the counting build's expanded masks are square
     # per-subdofhandler and do not apply to a neighbor with a different dof layout;
     # rectangular per-(sdh, sdh) masks in the walk would lift that, as a follow-up.)
     let
@@ -439,6 +446,12 @@ end
             # asymmetric masks included
             @test sum(r -> r.nmax, sp.buffer.indices) == sum(length, Ferrite.eachrow(sp))
         end
+        # Two-phase build: cells first, then a second call layering the interface entries on
+        # the pre-populated pattern, must equal the one-shot build
+        sp_twophase = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
+        add_sparsity_entries!(sp_twophase, dh; topology = topo, interface_coupling = trues(2, 2))
+        sp_oneshot = add_sparsity_entries!(init_sparsity_pattern(dh), dh; topology = topo, interface_coupling = trues(2, 2))
+        compare_matrices(allocate_matrix(sp_twophase), allocate_matrix(sp_oneshot))
         # Mixed continuous/discontinuous fields: with the self-sufficient interface semantics
         # the enumeration is exact for any continuity (single subdofhandler), so the direct
         # fill and exact reservation apply here too.
@@ -454,7 +467,7 @@ end
         end
         # Same-side interface blocks: with a restricted cell coupling the interface pass also
         # provides masked pairs within each interface cell, so the own-cell candidates in the
-        # fast fill must pass on the interface mask too.
+        # counting build must pass on the interface mask too.
         for (cc, ic) in (
                 ([true false; false true], [false true; false false]),
                 ([true false; false true], trues(2, 2)),
@@ -479,16 +492,28 @@ end
             compare_matrices(allocate_matrix(sp), allocate_matrix(sp_gen))
         end
     end
-    # Patterns allocated larger than ndofs(dh) work with the fast path (the extra rows and
-    # columns get diagonal-only entries)
+    # The counting build also covers pre-populated patterns (existing entries are kept verbatim and
+    # deduplicated against the new candidates) and patterns larger than ndofs(dh).
     let
         dh = fsp_test_create_dh(Quadrilateral)
+        seed! = function (sp)
+            Ferrite.add_entry!(sp, 3, Ferrite.getncols(sp)) # outside the cell pattern
+            Ferrite.add_entry!(sp, 7, 4) # inside the cell pattern (deduplicated)
+            return sp
+        end
+        for kwargs in ((;), (; coupling = [true true; false true]))
+            sp = add_sparsity_entries!(seed!(init_sparsity_pattern(dh)), dh; kwargs...)
+            sp_gen = fsp_test_build_generic(dh; seed!, kwargs...)
+            compare_matrices(allocate_matrix(sp), allocate_matrix(sp_gen))
+        end
+        # Repeated add_sparsity_entries! is idempotent
+        sp_rep = add_sparsity_entries!(add_sparsity_entries!(init_sparsity_pattern(dh), dh), dh)
+        compare_matrices(allocate_matrix(sp_rep), allocate_matrix(add_sparsity_entries!(init_sparsity_pattern(dh), dh)))
+        # Pattern larger than ndofs: the extra rows/columns get diagonal-only entries
         n = ndofs(dh) + 3
         sp_big = add_sparsity_entries!(SparsityPattern(n, n), dh)
+        sp_big_gen = fsp_test_build_generic(dh; sp = SparsityPattern(n, n))
         @test Ferrite.getnrows(sp_big) == n
-        sp_big_gen = SparsityPattern(n, n)
-        Ferrite.add_entry!(sp_big_gen, 1, 1) # forces the generic branch
-        add_sparsity_entries!(sp_big_gen, dh)
         compare_matrices(allocate_matrix(sp_big), allocate_matrix(sp_big_gen))
         # Test with keep_constrained = false
         ch = ConstraintHandler(dh)
@@ -526,7 +551,7 @@ end
     end
     # CSC/Symmetric instantiation reads rows without sorting (_eachrow_anyorder) and must
     # give the same matrix for unsorted and sorted rows. Order matters: the first call must
-    # run while rows are still unsorted from the fast fill.
+    # run while rows are still unsorted from the build.
     let dh = fsp_test_create_dh(Quadrilateral)
         sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh)
         @test !sp.sorted


### PR DESCRIPTION
Treat entries already stored in the pattern as one more candidate source in the count and fill passes: each row replays its existing slice (unconditionally -- the retired branch also only ever added) before the cell/interface candidates, with the row-major marker deduplicating the union for free. Counts stay exact, nothing ever relocates, and add_sparsity_entries! now takes the counting build for every SparsityPattern, so the generic
add_diagonal_entries!/add_cell_entries! branch is gone.

With only one build path left, the "fast path" vocabulary is retired too: the SparsityPattern method is now described as the specialized (bulk-counting) method in contrast to the generic per-entry AbstractSparsityPattern method, _fast_fill_cells! is renamed to _fill_cells!, and comments/docstrings/test names are reworded accordingly.

Tests: the generic reference is now the AbstractSparsityPattern method via Base.@invoke (seeding an entry no longer forces a different path); new cases cover seeded patterns (with and without coupling), repeated add_sparsity_entries! (idempotent), and two-phase cell-then-interface builds.