### PR TITLE
Parallelize the sparsity pattern pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    (e.g. DG), at roughly half the peak memory use. This applies to all entry points
    (`allocate_matrix`, `add_sparsity_entries!`, ...) and the resulting patterns and
    matrices are unchanged. ([#1397])
+ - Building a `SparsityPattern` and instantiating a `SparseMatrixCSC` or `SparseMatrixCSR`
+   from it is now multithreaded: the count and fill passes of the pattern build and the
+   matrix instantiations chunk their rows over tasks, like the lazy row sort already did.
+   The resulting patterns and matrices are independent of the number of threads. ([#1481])
 
 ### Internal changes
  - `SparsityPattern` has been rewritten: all rows are now stored in a single contiguous
@@ -1400,6 +1404,7 @@ poking into Ferrite internals:
 [#1426]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1426
 [#1428]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1428
 [#1397]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1397
+[#1481]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1481
 [#1432]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1432
 [#1434]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1434
 [#1468]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1468

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    (`allocate_matrix`, `add_sparsity_entries!`, ...) and the resulting patterns and
    matrices are unchanged. ([#1397])
  - Building a `SparsityPattern` and instantiating a `SparseMatrixCSC` or `SparseMatrixCSR`
-   from it is now multithreaded: the count and fill passes of the pattern build and the
-   matrix instantiations chunk their rows over tasks, like the lazy row sort already did.
-   The resulting patterns and matrices are independent of the number of threads. ([#1481])
+   from it is now multithreaded. ([#1481])
 
 ### Internal changes
  - `SparsityPattern` has been rewritten: all rows are now stored in a single contiguous

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -138,7 +138,8 @@ end
 
 # The pattern rows are exactly CSR's rows: `eachrow` hands out the sorted column indices
 # (for `SparsityPattern` this sorts the rows lazily, a no-op if already sorted), so `rowptr`
-# follows from the row lengths and each row is copied straight into `colval`.
+# follows from the row lengths and each row is copied straight into `colval`. The copy,
+# the only part that depends on the pattern type, is dispatched through _fill_colval!.
 function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::AbstractSparsityPattern, sym::Bool) where {Tv, Ti}
     sym && throw(ArgumentError("Symmetric SparseMatrixCSR is not supported"))
     nrows = Ferrite.getnrows(sp)
@@ -148,44 +149,39 @@ function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::AbstractSparsi
     for (row, colidxs) in enumerate(Ferrite.eachrow(sp))
         rowptr[row + 1] = rowptr[row] + length(colidxs)
     end
-    nnz = rowptr[end] - 1
-    # 2. Allocate colval and nzval now that nnz is known
-    colval = Vector{Ti}(undef, nnz)
-    nzval = zeros(Tv, nnz)
-    # 3. Populate colval row by row
-    k = 1
-    for colidxs in Ferrite.eachrow(sp)
-        k = _copyto!(colval, k, colidxs)
-    end
-    return SparseMatrixCSR{1}(nrows, Ferrite.getncols(sp), rowptr, colval, nzval)
-end
-
-# SparsityPattern: the same construction, with the rows chunked over tasks: rowptr comes
-# straight from the row lengths, and each chunk copies its rows into disjoint slices of
-# colval (the one-time lazy sort behind _ensure_sorted! is itself parallel). Identical
-# bytes land at identical locations, so the result does not depend on the thread count.
-function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::Ferrite.SparsityPattern, sym::Bool) where {Tv, Ti}
-    sym && throw(ArgumentError("Symmetric SparseMatrixCSR is not supported"))
-    Ferrite._ensure_sorted!(sp)
-    nrows = Ferrite.getnrows(sp)
-    # 1. Setup rowptr
-    rowptr = Vector{Ti}(undef, nrows + 1)
-    rowptr[1] = 1
-    @inbounds for row in 1:nrows
-        rowptr[row + 1] = rowptr[row] + length(Ferrite._row_view(sp, row))
-    end
     nnz = Int(rowptr[end]) - 1
     # 2. Allocate colval and nzval now that nnz is known
     colval = Vector{Ti}(undef, nnz)
     nzval = zeros(Tv, nnz)
-    # 3. Populate colval chunk by chunk
-    @sync for rowrange in Ferrite._task_chunks(nrows)
-        Threads.@spawn _fill_csr_colval_chunk!(colval, rowptr, sp, rowrange)
-    end
+    # 3. Populate colval
+    _fill_colval!(colval, rowptr, sp)
     return SparseMatrixCSR{1}(nrows, Ferrite.getncols(sp), rowptr, colval, nzval)
 end
 
-function _fill_csr_colval_chunk!(colval::Vector{Ti}, rowptr::Vector{Ti}, sp::Ferrite.SparsityPattern, rowrange::UnitRange{Int}) where {Ti}
+# Generic AbstractSparsityPattern: the interface only promises whole-pattern row iteration
+# (rows may be lazy generators, and implementations need not support concurrent row
+# access), so the rows are copied serially in iteration order.
+function _fill_colval!(colval::Vector, rowptr::Vector, sp::AbstractSparsityPattern)
+    k = 1
+    for colidxs in Ferrite.eachrow(sp)
+        k = _copyto!(colval, k, colidxs)
+    end
+    return
+end
+
+# SparsityPattern: the rows are random-access views of disjoint slices (sorted by the
+# eachrow call that built rowptr; the _ensure_sorted! here is a free double check), so
+# each chunk of rows is copied concurrently into its disjoint slice of colval. Identical
+# bytes land at identical locations, so the result does not depend on the thread count.
+function _fill_colval!(colval::Vector{Ti}, rowptr::Vector{Ti}, sp::Ferrite.SparsityPattern) where {Ti}
+    Ferrite._ensure_sorted!(sp)
+    @sync for rowrange in Ferrite._task_chunks(Ferrite.getnrows(sp))
+        Threads.@spawn _fill_colval_chunk!(colval, rowptr, sp, rowrange)
+    end
+    return
+end
+
+function _fill_colval_chunk!(colval::Vector{Ti}, rowptr::Vector{Ti}, sp::Ferrite.SparsityPattern, rowrange::UnitRange{Int}) where {Ti}
     @inbounds for row in rowrange
         colidxs = Ferrite._row_view(sp, row)
         copyto!(colval, Int(rowptr[row]), colidxs, 1, length(colidxs))

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -165,16 +165,13 @@ function _fill_colval!(colval::Vector, rowptr::Vector, sp::AbstractSparsityPatte
     for colidxs in Ferrite.eachrow(sp)
         k = _copyto!(colval, k, colidxs)
     end
-    # The copy pass must consume exactly the row lengths that built rowptr, i.e. eachrow
-    # must enumerate identically in both passes
+    # The copy pass must consume exactly the row lengths that built rowptr
     @assert k == rowptr[end]
     return
 end
 
-# SparsityPattern: the rows are random-access views of disjoint slices (sorted by the
-# eachrow call that built rowptr; the _ensure_sorted! here is a free double check), so
-# each chunk of rows is copied concurrently into its disjoint slice of colval. Identical
-# bytes land at identical locations, so the result does not depend on the thread count.
+# SparsityPattern: the rows are random-access views of disjoint slices, so each chunk of
+# rows is copied concurrently into its disjoint slice of colval.
 function _fill_colval!(colval::Vector{Ti}, rowptr::Vector{Ti}, sp::Ferrite.SparsityPattern) where {Ti}
     Ferrite._ensure_sorted!(sp)
     @sync for rowrange in Ferrite._task_chunks(Ferrite.getnrows(sp))

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -160,4 +160,37 @@ function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::AbstractSparsi
     return SparseMatrixCSR{1}(nrows, Ferrite.getncols(sp), rowptr, colval, nzval)
 end
 
+# SparsityPattern: the same construction, with the rows chunked over tasks: rowptr comes
+# straight from the row lengths, and each chunk copies its rows into disjoint slices of
+# colval (the one-time lazy sort behind _ensure_sorted! is itself parallel). Identical
+# bytes land at identical locations, so the result does not depend on the thread count.
+function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::Ferrite.SparsityPattern, sym::Bool) where {Tv, Ti}
+    sym && throw(ArgumentError("Symmetric SparseMatrixCSR is not supported"))
+    Ferrite._ensure_sorted!(sp)
+    nrows = Ferrite.getnrows(sp)
+    # 1. Setup rowptr
+    rowptr = Vector{Ti}(undef, nrows + 1)
+    rowptr[1] = 1
+    @inbounds for row in 1:nrows
+        rowptr[row + 1] = rowptr[row] + length(Ferrite._row_view(sp, row))
+    end
+    nnz = Int(rowptr[end]) - 1
+    # 2. Allocate colval and nzval now that nnz is known
+    colval = Vector{Ti}(undef, nnz)
+    nzval = zeros(Tv, nnz)
+    # 3. Populate colval chunk by chunk
+    @sync for rowrange in Ferrite._task_chunks(nrows)
+        Threads.@spawn _fill_csr_colval_chunk!(colval, rowptr, sp, rowrange)
+    end
+    return SparseMatrixCSR{1}(nrows, Ferrite.getncols(sp), rowptr, colval, nzval)
+end
+
+function _fill_csr_colval_chunk!(colval::Vector{Ti}, rowptr::Vector{Ti}, sp::Ferrite.SparsityPattern, rowrange::UnitRange{Int}) where {Ti}
+    @inbounds for row in rowrange
+        colidxs = Ferrite._row_view(sp, row)
+        copyto!(colval, Int(rowptr[row]), colidxs, 1, length(colidxs))
+    end
+    return
+end
+
 end

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -138,8 +138,7 @@ end
 
 # The pattern rows are exactly CSR's rows: `eachrow` hands out the sorted column indices
 # (for `SparsityPattern` this sorts the rows lazily, a no-op if already sorted), so `rowptr`
-# follows from the row lengths and each row is copied straight into `colval`. The copy,
-# the only part that depends on the pattern type, is dispatched through _fill_colval!.
+# follows from the row lengths and each row is copied straight into `colval`.
 function _allocate_matrix(::Type{SparseMatrixCSR{1, Tv, Ti}}, sp::AbstractSparsityPattern, sym::Bool) where {Tv, Ti}
     sym && throw(ArgumentError("Symmetric SparseMatrixCSR is not supported"))
     nrows = Ferrite.getnrows(sp)
@@ -166,6 +165,9 @@ function _fill_colval!(colval::Vector, rowptr::Vector, sp::AbstractSparsityPatte
     for colidxs in Ferrite.eachrow(sp)
         k = _copyto!(colval, k, colidxs)
     end
+    # The copy pass must consume exactly the row lengths that built rowptr, i.e. eachrow
+    # must enumerate identically in both passes
+    @assert k == rowptr[end]
     return
 end
 

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -182,12 +182,7 @@ function _presize_buffer(rowlen::Vector{Int}, sizehint::Int)
     return ConstructionBuffer{Int, 1}(indices, data, sizehint)
 end
 
-# Split `1:n` into at most `nthreads()` contiguous chunks of at least `minchunk` items:
-# one chunk per thread since the chunked stages have uniform per-item cost (no load
-# balancing needed), with the minimum so that small problems degenerate to a single task
-# (serial-equivalent) instead of spawning useless tasks, and so that per-task scratch is
-# bounded by `nthreads()` copies. All stages parallelized with this helper produce results
-# that are bit-identical regardless of the number of threads.
+# Split `1:n` into at most `nthreads()` contiguous chunks of at least `minchunk` items.
 function _task_chunks(n::Int, minchunk::Int = 1000)
     return Iterators.partition(1:n, max(minchunk, cld(n, Threads.nthreads())))
 end
@@ -220,12 +215,9 @@ function _sort_rows!(sp::SparsityPattern, rowrange::UnitRange{Int})
     return
 end
 
-# Chunk the rows of a count/fill pass over tasks. The only shared mutable state in the row
-# visit is the column marker, so each task gets its own: rows are globally unique, so the
-# row-stamp dedup works unchanged with a fresh marker (a stale stamp from another row never
-# equals `row`), and every per-row result is identical to the serial enumeration no matter
-# how the rows are chunked. In particular the count/fill identity required by
-# _visit_row_candidates! is preserved.
+# Chunk the rows of a count/fill pass over tasks. Each task gets its own column marker
+# (the only shared mutable state); per-row results are independent of the chunking since
+# the row stamps are globally unique.
 function _visit_row_candidates_chunked!(
         rowlen::Vector{Int}, data::Union{Nothing, Vector{Int}}, indices::Union{Nothing, Vector{AdaptiveRange}},
         ncols::Int, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
@@ -929,20 +921,15 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::AbstractSparsityP
     return S
 end
 
-# SparsityPattern: the same counting transpose, parallelized by chunking the rows (read
-# through _row_view, order-free just like _eachrow_anyorder). Each chunk counts its rows'
-# columns into a private histogram; the serial combine then converts the histograms in
-# place into per-(chunk, column) write cursors, where a chunk's cursor for a column starts
-# exactly where the previous chunk's ended. Every entry therefore lands at the index the
-# serial ascending row loop would give it, so rowval is bit-identical (in particular
-# per-column sorted) regardless of the number of threads.
+# SparsityPattern: the counting transpose parallelized by chunking the rows: each chunk
+# counts its rows' columns into a private histogram, and the serial combine converts the
+# histograms in place into per-(chunk, column) write cursors so that the chunks scatter
+# into disjoint slots in serial (ascending row) order, keeping each column sorted.
 function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, sym::Bool) where {Tv, Ti}
     nrows, ncols = getnrows(sp), getncols(sp)
-    # The serial cursor conversion below costs O(nchunks * ncols) while the parallel count
-    # and scatter phases gain ~ nstored / nchunks, so the optimal chunk count is about
-    # sqrt(nstored / ncols), the square root of the average column length -- beyond that
-    # more chunks make the transpose slower (measured: at 64 threads an uncapped chunk
-    # count nearly cancelled the parallel gain).
+    # The serial cursor conversion costs O(nchunks * ncols) while the parallel phases gain
+    # ~ nstored / nchunks, so cap the chunk count at the optimum, ~ sqrt(average column
+    # length) -- more chunks than that make the transpose slower.
     nstored = 0
     @inbounds for row in 1:nrows
         nstored += sp.buffer.indices[row].ncurrent
@@ -956,8 +943,7 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, 
             hists[$ci] = _count_csc_columns_chunk(Ti, sp, $rowrange, sym)
         end
     end
-    # 2. Setup colptr, converting each histogram in place into the chunk's first write
-    #    index for every column (exclusive running sum in chunk = ascending row order)
+    # 2. Setup colptr and convert each histogram in place into the chunk's write cursors
     colptr = Vector{Ti}(undef, ncols + 1)
     nzptr = one(Ti)
     @inbounds for col in 1:ncols
@@ -970,15 +956,13 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, 
     end
     colptr[ncols + 1] = nzptr
     nnz = Int(nzptr) - 1
-    # 3. Allocate rowval and nzval now that nnz is known and populate rowval, each chunk
-    #    advancing its own cursors
+    # 3. Allocate rowval and nzval now that nnz is known and populate rowval
     rowval = Vector{Ti}(undef, nnz)
     nzval = zeros(Tv, nnz)
     @sync for (ci, rowrange) in enumerate(chunks)
         Threads.@spawn _fill_csc_rowval_chunk!(rowval, hists[$ci], sp, $rowrange, sym)
     end
-    # The last chunk's cursors must have ended at the start of the next column (earlier
-    # chunks' final cursors are the later chunks' start cursors and already consumed)
+    # The last chunk's cursors must have ended at the start of the next column
     @assert isempty(hists) || all(col -> hists[end][col] == colptr[col + 1], 1:ncols)
     return SparseMatrixCSC(nrows, ncols, colptr, rowval, nzval)
 end

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -220,6 +220,33 @@ function _sort_rows!(sp::SparsityPattern, rowrange::UnitRange{Int})
     return
 end
 
+# Chunk the rows of a count/fill pass over tasks. The only shared mutable state in the row
+# visit is the column marker, so each task gets its own: rows are globally unique, so the
+# row-stamp dedup works unchanged with a fresh marker (a stale stamp from another row never
+# equals `row`), and every per-row result is identical to the serial enumeration no matter
+# how the rows are chunked. In particular the count/fill identity required by
+# _visit_row_candidates! is preserved.
+function _visit_row_candidates_chunked!(
+        rowlen::Vector{Int}, data::Union{Nothing, Vector{Int}}, indices::Union{Nothing, Vector{AdaptiveRange}},
+        ncols::Int, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
+        cell_dofs::ArrayOfVectorViews, cell_to_sdh::Vector{Int},
+        couplings::Union{Nothing, Vector{Matrix{Bool}}}, isconstrained::Union{Nothing, Vector{Bool}},
+        neighbor_cells::Union{Nothing, ArrayOfVectorViews}, interface_couplings::Union{Nothing, Vector{Matrix{Bool}}},
+        oldbuffer::Union{Nothing, ConstructionBuffer{Int, 1}} = nothing,
+    )
+    @sync for rowrange in _task_chunks(length(rowlen))
+        Threads.@spawn begin
+            marker = zeros(Int, ncols) # per-task scratch
+            _visit_row_candidates!(
+                rowlen, data, indices, marker, $rowrange, row_to_cells, row_to_localidx,
+                cell_dofs, cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings,
+                oldbuffer
+            )
+        end
+    end
+    return
+end
+
 # The counting build behind add_sparsity_entries!: count exact per-row sizes with a column
 # marker, presize the buffer, then marker-dedup
 # fill each row UNSORTED (sorted lazily). Always includes the diagonal. Non-full `coupling` and
@@ -243,16 +270,14 @@ function _build_pattern!(
         cell_dofs, nrows, couplings !== nothing || interface_couplings !== nothing
     )
     rowlen = zeros(Int, nrows)
-    marker = zeros(Int, getncols(sp))
     cell_to_sdh = dh.cell_to_subdofhandler
-    _visit_row_candidates!(
-        rowlen, nothing, nothing, marker, row_to_cells, row_to_localidx, cell_dofs,
+    _visit_row_candidates_chunked!(
+        rowlen, nothing, nothing, getncols(sp), row_to_cells, row_to_localidx, cell_dofs,
         cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings, oldbuffer
     )
     buffer = _presize_buffer(rowlen, sp.buffer.sizehint)
-    fill!(marker, 0)
-    _visit_row_candidates!(
-        rowlen, buffer.data, buffer.indices, marker, row_to_cells, row_to_localidx, cell_dofs,
+    _visit_row_candidates_chunked!(
+        rowlen, buffer.data, buffer.indices, getncols(sp), row_to_cells, row_to_localidx, cell_dofs,
         cell_to_sdh, couplings, isconstrained,
         fill_interfaces ? neighbor_cells : nothing, fill_interfaces ? interface_couplings : nothing,
         oldbuffer
@@ -1002,7 +1027,7 @@ end
 # identically; both go through this function to guarantee that.
 function _visit_row_candidates!(
         rowlen::Vector{Int}, data::Union{Nothing, Vector{Int}}, indices::Union{Nothing, Vector{AdaptiveRange}},
-        marker::Vector{Int}, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
+        marker::Vector{Int}, rowrange::UnitRange{Int}, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
         cell_dofs::ArrayOfVectorViews, cell_to_sdh::Vector{Int},
         couplings::Union{Nothing, Vector{Matrix{Bool}}}, isconstrained::Union{Nothing, Vector{Bool}},
         neighbor_cells::Union{Nothing, ArrayOfVectorViews} = nothing,
@@ -1011,7 +1036,7 @@ function _visit_row_candidates!(
     )
     counting = data === nothing
     ncols = length(marker) # marker has one slot per column
-    @inbounds for row in 1:length(rowlen)
+    @inbounds for row in rowrange
         start = counting ? 0 : indices[row].start
         p = 0
         # The diagonal is always stored when the column exists (the pattern may have more

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -929,6 +929,73 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::AbstractSparsityP
     return S
 end
 
+# SparsityPattern: the same counting transpose, parallelized by chunking the rows (read
+# through _row_view, order-free just like _eachrow_anyorder). Each chunk counts its rows'
+# columns into a private histogram; the serial combine then converts the histograms in
+# place into per-(chunk, column) write cursors, where a chunk's cursor for a column starts
+# exactly where the previous chunk's ended. Every entry therefore lands at the index the
+# serial ascending row loop would give it, so rowval is bit-identical (in particular
+# per-column sorted) regardless of the number of threads.
+function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, sym::Bool) where {Tv, Ti}
+    nrows, ncols = getnrows(sp), getncols(sp)
+    chunks = collect(_task_chunks(nrows))
+    # 1. Count the columns of each chunk's rows into a chunk-private histogram
+    hists = Vector{Vector{Ti}}(undef, length(chunks))
+    @sync for (ci, rowrange) in enumerate(chunks)
+        Threads.@spawn begin
+            hists[$ci] = _count_csc_columns_chunk(Ti, sp, $rowrange, sym)
+        end
+    end
+    # 2. Setup colptr, converting each histogram in place into the chunk's first write
+    #    index for every column (exclusive running sum in chunk = ascending row order)
+    colptr = Vector{Ti}(undef, ncols + 1)
+    nzptr = one(Ti)
+    @inbounds for col in 1:ncols
+        colptr[col] = nzptr
+        for hist in hists
+            count = hist[col]
+            hist[col] = nzptr
+            nzptr += count
+        end
+    end
+    colptr[ncols + 1] = nzptr
+    nnz = Int(nzptr) - 1
+    # 3. Allocate rowval and nzval now that nnz is known and populate rowval, each chunk
+    #    advancing its own cursors
+    rowval = Vector{Ti}(undef, nnz)
+    nzval = zeros(Tv, nnz)
+    @sync for (ci, rowrange) in enumerate(chunks)
+        Threads.@spawn _fill_csc_rowval_chunk!(rowval, hists[$ci], sp, $rowrange, sym)
+    end
+    # The last chunk's cursors must have ended at the start of the next column (earlier
+    # chunks' final cursors are the later chunks' start cursors and already consumed)
+    @assert isempty(hists) || all(col -> hists[end][col] == colptr[col + 1], 1:ncols)
+    return SparseMatrixCSC(nrows, ncols, colptr, rowval, nzval)
+end
+
+function _count_csc_columns_chunk(::Type{Ti}, sp::SparsityPattern, rowrange::UnitRange{Int}, sym::Bool) where {Ti}
+    hist = zeros(Ti, getncols(sp))
+    @inbounds for row in rowrange
+        for col in _row_view(sp, row)
+            sym && row > col && continue
+            hist[col] += one(Ti)
+        end
+    end
+    return hist
+end
+
+function _fill_csc_rowval_chunk!(rowval::Vector{Ti}, hist::Vector{Ti}, sp::SparsityPattern, rowrange::UnitRange{Int}, sym::Bool) where {Ti}
+    @inbounds for row in rowrange
+        for col in _row_view(sp, row)
+            sym && row > col && continue
+            k = hist[col]
+            rowval[k] = row
+            hist[col] = k + one(Ti)
+        end
+    end
+    return
+end
+
 # Build the cell -> global dofs map as an ArrayOfVectorViews (a compact copy of the
 # DofHandler's cell dof storage).
 function create_celldofs(dh::DofHandler)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -938,7 +938,17 @@ end
 # per-column sorted) regardless of the number of threads.
 function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, sym::Bool) where {Tv, Ti}
     nrows, ncols = getnrows(sp), getncols(sp)
-    chunks = collect(_task_chunks(nrows))
+    # The serial cursor conversion below costs O(nchunks * ncols) while the parallel count
+    # and scatter phases gain ~ nstored / nchunks, so the optimal chunk count is about
+    # sqrt(nstored / ncols), the square root of the average column length -- beyond that
+    # more chunks make the transpose slower (measured: at 64 threads an uncapped chunk
+    # count nearly cancelled the parallel gain).
+    nstored = 0
+    @inbounds for row in 1:nrows
+        nstored += sp.buffer.indices[row].ncurrent
+    end
+    maxchunks = max(1, isqrt(cld(nstored, max(ncols, 1))))
+    chunks = collect(_task_chunks(nrows, max(1000, cld(nrows, maxchunks))))
     # 1. Count the columns of each chunk's rows into a chunk-private histogram
     hists = Vector{Vector{Ti}}(undef, length(chunks))
     @sync for (ci, rowrange) in enumerate(chunks)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -215,30 +215,6 @@ function _sort_rows!(sp::SparsityPattern, rowrange::UnitRange{Int})
     return
 end
 
-# Chunk the rows of a count/fill pass over tasks. Each task gets its own column marker
-# (the only shared mutable state); per-row results are independent of the chunking since
-# the row stamps are globally unique.
-function _visit_row_candidates_chunked!(
-        rowlen::Vector{Int}, data::Union{Nothing, Vector{Int}}, indices::Union{Nothing, Vector{AdaptiveRange}},
-        ncols::Int, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
-        cell_dofs::ArrayOfVectorViews, cell_to_sdh::Vector{Int},
-        couplings::Union{Nothing, Vector{Matrix{Bool}}}, isconstrained::Union{Nothing, Vector{Bool}},
-        neighbor_cells::Union{Nothing, ArrayOfVectorViews}, interface_couplings::Union{Nothing, Vector{Matrix{Bool}}},
-        oldbuffer::Union{Nothing, ConstructionBuffer{Int, 1}} = nothing,
-    )
-    @sync for rowrange in _task_chunks(length(rowlen))
-        Threads.@spawn begin
-            marker = zeros(Int, ncols) # per-task scratch
-            _visit_row_candidates!(
-                rowlen, data, indices, marker, $rowrange, row_to_cells, row_to_localidx,
-                cell_dofs, cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings,
-                oldbuffer
-            )
-        end
-    end
-    return
-end
-
 # The counting build behind add_sparsity_entries!: count exact per-row sizes with a column
 # marker, presize the buffer, then marker-dedup
 # fill each row UNSORTED (sorted lazily). Always includes the diagonal. Non-full `coupling` and
@@ -1079,6 +1055,30 @@ function create_row_to_cells(cell_dofs::ArrayOfVectorViews, nrows::Int, build_lo
     row_to_cells = ArrayOfVectorViews(indices, cells, lin)
     row_to_localidx = localidx === nothing ? nothing : ArrayOfVectorViews(indices, localidx, lin)
     return row_to_cells, row_to_localidx
+end
+
+# Chunk the rows of a count/fill pass over tasks. Each task gets its own column marker
+# (the only shared mutable state); per-row results are independent of the chunking since
+# the row stamps are globally unique.
+function _visit_row_candidates_chunked!(
+        rowlen::Vector{Int}, data::Union{Nothing, Vector{Int}}, indices::Union{Nothing, Vector{AdaptiveRange}},
+        ncols::Int, row_to_cells::ArrayOfVectorViews, row_to_localidx::Union{Nothing, ArrayOfVectorViews},
+        cell_dofs::ArrayOfVectorViews, cell_to_sdh::Vector{Int},
+        couplings::Union{Nothing, Vector{Matrix{Bool}}}, isconstrained::Union{Nothing, Vector{Bool}},
+        neighbor_cells::Union{Nothing, ArrayOfVectorViews}, interface_couplings::Union{Nothing, Vector{Matrix{Bool}}},
+        oldbuffer::Union{Nothing, ConstructionBuffer{Int, 1}} = nothing,
+    )
+    @sync for rowrange in _task_chunks(length(rowlen))
+        Threads.@spawn begin
+            marker = zeros(Int, ncols) # per-task scratch
+            _visit_row_candidates!(
+                rowlen, data, indices, marker, $rowrange, row_to_cells, row_to_localidx,
+                cell_dofs, cell_to_sdh, couplings, isconstrained, neighbor_cells, interface_couplings,
+                oldbuffer
+            )
+        end
+    end
+    return
 end
 
 # Count (data === nothing) or fill (data/indices from the presized buffer) the per-row

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -936,7 +936,7 @@ function _allocate_matrix(::Type{SparseMatrixCSC{Tv, Ti}}, sp::SparsityPattern, 
     rowval = Vector{Ti}(undef, nnz)
     nzval = zeros(Tv, nnz)
     @sync for (ci, rowrange) in enumerate(chunks)
-        Threads.@spawn _fill_csc_rowval_chunk!(rowval, hists[$ci], sp, $rowrange, sym)
+        Threads.@spawn _fill_csc_rowval_chunk!(rowval, hists[ci], sp, rowrange, sym)
     end
     # The last chunk's cursors must have ended at the start of the next column
     @assert isempty(hists) || all(col -> hists[end][col] == colptr[col + 1], 1:ncols)

--- a/src/Dofs/sparsity_pattern.jl
+++ b/src/Dofs/sparsity_pattern.jl
@@ -182,6 +182,16 @@ function _presize_buffer(rowlen::Vector{Int}, sizehint::Int)
     return ConstructionBuffer{Int, 1}(indices, data, sizehint)
 end
 
+# Split `1:n` into at most `nthreads()` contiguous chunks of at least `minchunk` items:
+# one chunk per thread since the chunked stages have uniform per-item cost (no load
+# balancing needed), with the minimum so that small problems degenerate to a single task
+# (serial-equivalent) instead of spawning useless tasks, and so that per-task scratch is
+# bounded by `nthreads()` copies. All stages parallelized with this helper produce results
+# that are bit-identical regardless of the number of threads.
+function _task_chunks(n::Int, minchunk::Int = 1000)
+    return Iterators.partition(1:n, max(minchunk, cld(n, Threads.nthreads())))
+end
+
 # Hot-path guard: kept tiny so that it inlines into callers; the actual sorting is out of
 # line in _sort_pattern! and only runs when the pattern is unsorted.
 @inline function _ensure_sorted!(sp::SparsityPattern)
@@ -192,11 +202,7 @@ end
 # Sort each row's slice in place (rows are already deduplicated). Rows are disjoint slices of
 # `data`, so they can be sorted in parallel by chunking the rows over tasks.
 @noinline function _sort_pattern!(sp::SparsityPattern)
-    nrows = getnrows(sp)
-    # One chunk per thread (rows have similar cost so no load balancing is needed), but at
-    # least 1000 rows per chunk so that small patterns don't spawn useless tasks.
-    chunksize = max(1000, cld(nrows, Threads.nthreads()))
-    @sync for rowrange in Iterators.partition(1:nrows, chunksize)
+    @sync for rowrange in _task_chunks(getnrows(sp))
         Threads.@spawn _sort_rows!(sp, rowrange)
     end
     sp.sorted = true

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -525,6 +525,49 @@ end
         add_sparsity_entries!(sp_big_kc_gen, dh, ch; keep_constrained = false)
         compare_matrices(allocate_matrix(sp_big_kc), allocate_matrix(sp_big_kc_gen))
     end
+    # Multi-chunk builds: enough rows (> 1000, the minimum chunk size) that the chunked
+    # count/fill passes (and the chunked matrix instantiations) span several tasks when the
+    # test runs with threads. Every combination must match the generic per-entry path
+    # exactly, and repeated builds must be identical (the parallel stages are deterministic
+    # regardless of thread count).
+    let
+        grid = generate_grid(Hexahedron, (6, 6, 6))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefHexahedron, 2}())
+        add!(dh, :v, Lagrange{RefHexahedron, 1}()^3)
+        close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, Dirichlet(:u, getfacetset(grid, "left"), x -> 0.0))
+        close!(ch)
+        topo = ExclusiveTopology(grid)
+        for kwargs in (
+                (;),
+                (; coupling = [true true; false true]),
+                (; keep_constrained = false),
+                (; interface_coupling = trues(2, 2), topology = topo),
+                (; coupling = [true true; false true], interface_coupling = [true false; true true], topology = topo, keep_constrained = false),
+            )
+            sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh, ch; kwargs...)
+            sp_gen = init_sparsity_pattern(dh)
+            Ferrite.add_entry!(sp_gen, 1, 1) # forces the generic branch
+            add_sparsity_entries!(sp_gen, dh, ch; kwargs...)
+            sp_again = add_sparsity_entries!(init_sparsity_pattern(dh), dh, ch; kwargs...)
+            compare_patterns(sp, sp_gen, sp_again)
+            compare_matrices(allocate_matrix(sp), allocate_matrix(sp_gen))
+            compare_matrices_csr(
+                allocate_matrix(SparseMatrixCSR{1, Float64, Int}, sp),
+                allocate_matrix(SparseMatrixCSR{1, Float64, Int}, sp_gen),
+            )
+        end
+        # Oversized pattern at multi-chunk scale (extra rows are diagonal-only and never
+        # constrained)
+        n = ndofs(dh) + 3
+        sp_big = add_sparsity_entries!(SparsityPattern(n, n), dh, ch; keep_constrained = false)
+        sp_big_gen = SparsityPattern(n, n)
+        Ferrite.add_entry!(sp_big_gen, 1, 1) # forces the generic branch
+        add_sparsity_entries!(sp_big_gen, dh, ch; keep_constrained = false)
+        compare_matrices(allocate_matrix(sp_big), allocate_matrix(sp_big_gen))
+    end
     # Test different number types (Int32, Float32)
     for Tv in (Float32, Float64)
         for Ti in (Int32, Int64)

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -520,9 +520,7 @@ end
         add!(ch, Dirichlet(:a, getfacetset(dh.grid, "left"), x -> 0.0))
         close!(ch)
         sp_big_kc = add_sparsity_entries!(SparsityPattern(n, n), dh, ch; keep_constrained = false)
-        sp_big_kc_gen = SparsityPattern(n, n)
-        Ferrite.add_entry!(sp_big_kc_gen, 1, 1) # forces the generic branch
-        add_sparsity_entries!(sp_big_kc_gen, dh, ch; keep_constrained = false)
+        sp_big_kc_gen = fsp_test_build_generic(dh, ch; sp = SparsityPattern(n, n), keep_constrained = false)
         compare_matrices(allocate_matrix(sp_big_kc), allocate_matrix(sp_big_kc_gen))
     end
     # Multi-chunk builds: enough rows (> 1000, the minimum chunk size) that the chunked
@@ -546,9 +544,7 @@ end
                 (; coupling = [true true; false true], interface_coupling = [true false; true true], topology = topo, keep_constrained = false),
             )
             sp = add_sparsity_entries!(init_sparsity_pattern(dh), dh, ch; kwargs...)
-            sp_gen = init_sparsity_pattern(dh)
-            Ferrite.add_entry!(sp_gen, 1, 1) # forces the generic branch
-            add_sparsity_entries!(sp_gen, dh, ch; kwargs...)
+            sp_gen = fsp_test_build_generic(dh, ch; kwargs...)
             sp_again = add_sparsity_entries!(init_sparsity_pattern(dh), dh, ch; kwargs...)
             compare_patterns(sp, sp_gen, sp_again)
             compare_matrices(allocate_matrix(sp), allocate_matrix(sp_gen))
@@ -561,9 +557,7 @@ end
         # constrained)
         n = ndofs(dh) + 3
         sp_big = add_sparsity_entries!(SparsityPattern(n, n), dh, ch; keep_constrained = false)
-        sp_big_gen = SparsityPattern(n, n)
-        Ferrite.add_entry!(sp_big_gen, 1, 1) # forces the generic branch
-        add_sparsity_entries!(sp_big_gen, dh, ch; keep_constrained = false)
+        sp_big_gen = fsp_test_build_generic(dh, ch; sp = SparsityPattern(n, n), keep_constrained = false)
         compare_matrices(allocate_matrix(sp_big), allocate_matrix(sp_big_gen))
     end
     # Test different number types (Int32, Float32)

--- a/test/test_sparsity_patterns.jl
+++ b/test/test_sparsity_patterns.jl
@@ -526,10 +526,8 @@ end
         compare_matrices(allocate_matrix(sp_big_kc), allocate_matrix(sp_big_kc_gen))
     end
     # Multi-chunk builds: enough rows (> 1000, the minimum chunk size) that the chunked
-    # count/fill passes (and the chunked matrix instantiations) span several tasks when the
-    # test runs with threads. Every combination must match the generic per-entry path
-    # exactly, and repeated builds must be identical (the parallel stages are deterministic
-    # regardless of thread count).
+    # passes and instantiations span several tasks when the test runs with threads. All
+    # combinations must match the generic path exactly, and repeated builds be identical.
     let
         grid = generate_grid(Hexahedron, (6, 6, 6))
         dh = DofHandler(grid)


### PR DESCRIPTION
## Summary

Follow-up to #1397 and #1480. The pattern pipeline's remaining serial stages are chunked
over tasks, the same way the lazy row sort already was (and following the threading style
of #1475): the count/fill passes of the counting build, the `SparseMatrixCSC` counting
transpose, and the `SparseMatrixCSR` row copy. All results are bit-identical to the
serial build regardless of the number of threads.

## Design

- A shared `_task_chunks` helper encodes the chunking policy from `_sort_pattern!`: at
  most `nthreads()` contiguous chunks of at least 1000 rows, so small problems stay
  serial-equivalent and per-task scratch is bounded.
- **Count/fill passes**: rows are chunked; the only shared mutable state was the column
  marker, which becomes per-task scratch. The row-stamp dedup works unchanged (rows are
  globally unique), and each row's enumeration — cell and interface candidates as well as
  the replay of pre-existing entries from #1480 — depends only on that row's data, so the
  pattern is identical for any chunking.
- **CSC transpose** (`SparsityPattern`-specialized; the generic method is unchanged for
  `BlockSparsityPattern` etc.): each chunk counts its rows' columns into a private
  histogram; a serial pass converts the histograms in place into per-(chunk, column)
  write cursors (each chunk's cursor starts where the previous chunk's ends); the chunks
  then scatter concurrently. Every entry lands at the index the serial ascending row
  loop would give it, so `rowval` stays per-column sorted. The chunk count is capped at
  ~sqrt(average column length): the serial cursor conversion costs
  O(nchunks × ncols), so more chunks than that make the transpose slower.
- **CSR copy**: `rowptr` from the row lengths, then chunks copy rows into disjoint
  slices of `colval`.

Deliberately left serial (measured ≤ 1.5 % of the build combined): `create_celldofs`,
`create_row_to_cells`, `create_cell_to_neighbors`, `_presize_buffer`. The per-entry
consumers (`add_constraint_entries!` and the multi-`SubDofHandler`
`add_interface_entries!` fallback) mutate a shared growable buffer and stay serial.

## Benchmarks

N³ hexahedra, quadratic scalar + linear vector field (same discretization as the
Tachometer suite), 1.27M dofs (N = 48), min of 3:

| stage | 1 thread | best threaded | speedup |
|---|---|---|---|
| pattern build (cells) | 1.27 s | 0.14 s (32t) | 8.9x |
| pattern build (full `interface_coupling`) | 5.97 s | 0.40 s (64t) | 15.1x |
| lazy row sort | 1.25 s | 0.07 s (32t) | 16.9x |
| CSC instantiation | 2.51 s | 1.13 s (8t) | 2.2x |
| CSR instantiation (after sort) | 1.75 s | 0.82 s (16t) | 2.1x |

Serial (1-thread) times are at parity with the base branch for every stage. The
cell-only build and the CSC/CSR instantiations saturate memory bandwidth; the
interface build and the sort are compute-richer and scale further. With the
chunk-count cap the CSC time is flat from 8 threads up (within 6% across 8-64
threads at both 0.74M and 1.27M dofs) instead of degrading back toward serial.

Per-commit attribution (same machine, 0.74M dofs, walking the stack commit by
commit at 8 threads): the marker-pass commit takes the build 792 -> 154 ms, the
CSC commit 1436 -> 648 ms (and is ~8% faster even serially), the CSR commit
1016 -> 545 ms, and the chunk-cap commit recovers the CSC anti-scaling at 32
threads (851 -> 682 ms) while being a no-op at 8. Every stage moves exactly at
its commit; the serial walk shows no regression anywhere.

## Determinism

Every parallel stage produces byte-identical output independent of thread count
(arguments per stage in the code comments). The test suite compares the counting build
against the generic `AbstractSparsityPattern` method exactly, and a dedicated multi-chunk
case (> 1000 rows, all kwarg combinations, oversized patterns, CSC/CSR storage equality)
runs with several chunks whenever the suite runs threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)