### PR TITLE
Get rid of `NonConformingGrid` as the intermediate datastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Atomic assembly (`start_assemble(K, f; atomic = true)`) now supports `Float16` and
    `Complex` of `Float16`/`Float32`/`Float64` as value types, in addition to `Float32`
    and `Float64`. ([#1474])
+ - AMR: a `ForestBWG` is now used directly as the grid ("the forest is the grid"): it
+   answers all `AbstractGrid` queries (`getcells`, `getnodes`, `getfacetset`,
+   `getcoordinates`, ...) for its current refinement state through an epoch-guarded, lazily
+   materialized snapshot, so the explicit `grid = creategrid(forest)` step disappears from
+   user code. Every mutator (`refine!`, `coarsen!`, `refine_and_coarsen!`, `refine_all!`,
+   `balanceforest!`) bumps the forest's epoch; a `DofHandler` records the epoch at `close!`
+   and errors on use after a later mutation instead of silently assembling against a stale
+   dof distribution. The new exported `reclose!(dh)` re-distributes the dofs against the
+   current grid state (currently for a single whole-domain `SubDofHandler`). New
+   internal-but-stable accessors: `Ferrite.grid_epoch(grid)` (cache-invalidation key for
+   downstream packages), `Ferrite.has_hanging_nodes(grid)` (trait replacing dispatch on
+   `NonConformingGrid`) and `Ferrite.AMR.conformity_info(grid)` (hanging node -> masters
+   mapping). ([#1413])
+
+### Changed
+ - AMR: `getcells(forest::ForestBWG)` now returns the materialized
+   `Quadrilateral`/`Hexahedron` cells of the current refinement state (matching the
+   `AbstractGrid` interface) instead of the internal leaf octants, and
+   `getcells(forest, i)` returns cell `i` instead of throwing. The octant-returning
+   behaviour moved to `Ferrite.AMR.getleaves(forest)`. `getcelltype(forest)` now returns
+   the materialized cell type instead of leaking the octree type, and
+   `getnodesets`/`getvertexsets` on a forest now return empty sets (set reconstruction on
+   the refined grid is a known gap) instead of the macro grid's sets with wrong ids.
+   `ExclusiveTopology(forest)` and `transform_coordinates!(forest, f)` now throw
+   descriptive errors instead of silently operating on octree internals. ([#1413])
+
+### Deprecated
+ - AMR: `NonConformingGrid` (and with it the `grid = creategrid(forest)` workflow) is
+   deprecated in favour of using the `ForestBWG` directly as the grid together with
+   `reclose!`. Both keep working during the transition. ([#1413])
 
 ## [v1.6.0] - 2026-08-02
 
@@ -1380,4 +1410,5 @@ poking into Ferrite internals:
 [#1468]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1468
 [#1438]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1438
 [#1452]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1452
+[#1413]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1413
 [#1474]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1474

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    dof distribution. The new exported `reclose!(dh)` re-distributes the dofs against the
    current grid state (currently for a single whole-domain `SubDofHandler`). New
    internal-but-stable accessors: `Ferrite.grid_epoch(grid)` (cache-invalidation key for
-   downstream packages), `Ferrite.has_hanging_nodes(grid)` (trait replacing dispatch on
+   downstream packages), `Ferrite.is_nonconforming(grid)` (trait replacing dispatch on
    `NonConformingGrid`) and `Ferrite.AMR.conformity_info(grid)` (hanging node -> masters
    mapping). ([#1413])
 

--- a/docs/src/devdocs/AMR.md
+++ b/docs/src/devdocs/AMR.md
@@ -252,13 +252,43 @@ Ferrite.AMR.inside
 Ferrite.AMR._maximum_size
 ```
 
-## From a forest to a `NonConformingGrid`
+## From a forest to a grid: the materialization facade
 
 The operations above manipulate the forest of octrees (refine, coarsen, balance, neighbour
-lookups). To actually solve a finite element problem we must turn that forest into a concrete
-grid — this is [`creategrid`](@ref Ferrite.AMR.creategrid), which produces a
-`NonConformingGrid`: an ordinary grid plus the *hanging-node constraints* (`conformity_info`)
-that make a conforming finite element field possible.
+lookups). To actually solve a finite element problem the forest must answer *grid* queries —
+cells, nodes, sets — for its current refinement state. The `ForestBWG` does this itself: it
+subtypes `AbstractGrid` and overrides the accessor interface (`getcells`, `getnodes`,
+`getfacetset`, …) to forward to a lazily materialized snapshot
+(`Ferrite.AMR.ForestSnapshot`) kept in an internal cache box
+(`Ferrite.AMR.MaterializedForest`). Every mutator (`refine!`, `coarsen!`,
+`refine_and_coarsen!`, `refine_all!`, `balanceforest!`) bumps the cache's *epoch*
+([`Ferrite.grid_epoch`](@ref)) and drops the snapshot; the next grid query rebuilds it. A
+`DofHandler` records the epoch at `close!` and every per-loop entry point
+(`CellIterator`/`ConstraintHandler` construction, `ndofs`, VTK export) errors on a mismatch,
+pointing to [`reclose!`](@ref), which re-distributes the dofs against the current state:
+
+```julia
+forest = ForestBWG(grid0, b)
+dh = DofHandler(forest); add!(dh, :u, ip); close!(dh)
+while adapting
+    ch = ConstraintHandler(dh); add!(ch, ConformityConstraint(:u)); add!(ch, dbc); close!(ch)
+    # assemble / solve / estimate (facetskeleton(forest)) / mark
+    refine!(forest, marked); balanceforest!(forest)
+    reclose!(dh)
+end
+```
+
+The snapshot is produced by the [`creategrid`](@ref Ferrite.AMR.creategrid) pipeline
+described below. `creategrid` itself remains as a thin transitional wrapper producing a
+detached `NonConformingGrid` (deprecated): an ordinary grid plus the *hanging-node
+constraints* (`conformity_info`, read it through the accessor
+[`Ferrite.AMR.conformity_info`](@ref)) that make a conforming finite element field possible.
+
+Known facade gaps, shared with `creategrid`: node/vertex sets are not reconstructed onto the
+refined grid (the accessors report them empty), `ExclusiveTopology(forest)` errors (use
+[`facetskeleton`](@ref) instead — the
+fine-grid topology is ill-defined on hanging meshes), and `transform_coordinates!(forest, f)`
+errors (the transform would be lost on rematerialization; transform the base grid instead).
 
 !!! warning "`conformity_info` is subject to change"
     `conformity_info` currently stores hanging *vertices* and their master vertices — exactly

--- a/docs/src/reference/amr.md
+++ b/docs/src/reference/amr.md
@@ -30,6 +30,21 @@ refine_and_coarsen!
 balanceforest!
 ```
 
+## The grid facade
+
+A `ForestBWG` answers all `AbstractGrid` queries for its current refinement state through an
+epoch-guarded materialization cache; a `DofHandler` built on it detects staleness after
+refinement and is re-distributed with [`reclose!`](@ref).
+
+```@docs
+Ferrite.grid_epoch
+Ferrite.has_hanging_nodes
+Ferrite.AMR.conformity_info
+Ferrite.AMR.MaterializedForest
+Ferrite.AMR.ForestSnapshot
+Ferrite.AMR.getleaves
+```
+
 ## Materialization
 
 ```@docs

--- a/docs/src/reference/amr.md
+++ b/docs/src/reference/amr.md
@@ -38,7 +38,7 @@ refinement and is re-distributed with [`reclose!`](@ref).
 
 ```@docs
 Ferrite.grid_epoch
-Ferrite.has_hanging_nodes
+Ferrite.is_nonconforming
 Ferrite.AMR.conformity_info
 Ferrite.AMR.MaterializedForest
 Ferrite.AMR.ForestSnapshot

--- a/docs/src/reference/dofhandler.md
+++ b/docs/src/reference/dofhandler.md
@@ -14,6 +14,7 @@ SubDofHandler
 add!(::DofHandler, ::Symbol, ::Interpolation)
 add!(::SubDofHandler, ::Symbol, ::Interpolation)
 close!(::DofHandler)
+reclose!(::DofHandler)
 ```
 
 ## DoF renumbering

--- a/docs/src/topics/grid.md
+++ b/docs/src/topics/grid.md
@@ -104,6 +104,29 @@ It can be very useful to use a grid type for a certain special case, e.g. mixed 
 In order to define your own `<: AbstractGrid` you need to fulfill the `AbstractGrid` interface.
 In case that certain structures are preserved from the `Ferrite.Grid` type, you don't need to dispatch on your own type, but rather rely on the fallback `AbstractGrid` dispatch.
 
+### Required methods
+
+Ferrite's internals (`DofHandler` dof distribution, `CellIterator`/`CellCache`,
+`getcoordinates`, constraint handling, VTK export) reach a grid only through the accessor
+functions below — never through the `cells`/`nodes` fields directly. The field-based
+`AbstractGrid` fallbacks make all of them work automatically for any grid that stores
+`cells::Vector{<:AbstractCell}` and `nodes::Vector{<:Node}` plus the usual set dictionaries;
+a grid with a different internal representation must override them. For a conforming grid
+the required set is:
+
+- cells: `getcells(grid)`, `getcells(grid, i::Int)`, `getcells(grid, v::AbstractVector{Int})`,
+  `getncells(grid)`, `getcelltype(grid)`, `getcelltype(grid, i::Int)`
+- nodes/coordinates: `getnodes(grid)`, `getnodes(grid, i)`, `getnnodes(grid)`,
+  `get_node_coordinate(grid, n)`, `get_coordinate_type(grid)`, `get_coordinate_eltype(grid)`
+- sets (needed for boundary conditions and subdomains): `getcellset(s)`, `getfacetset(s)`,
+  `getnodeset(s)`, `getvertexset(s)`
+
+Optional traits with fallbacks: `has_hanging_nodes(grid)` (default `false`; return `true`
+for non-conforming grids so the `DofHandler` retains the entity → dof maps needed for
+conformity constraints) and `grid_epoch(grid)` (default `0`, i.e. not epoch-tracked; adaptive
+grids return a counter incremented on every mutation so that stale `DofHandler` use errors,
+see `reclose!`).
+
 ### Example
 
 As a starting point, we choose a minimal working example from the test suite:

--- a/docs/src/topics/grid.md
+++ b/docs/src/topics/grid.md
@@ -121,7 +121,7 @@ the required set is:
 - sets (needed for boundary conditions and subdomains): `getcellset(s)`, `getfacetset(s)`,
   `getnodeset(s)`, `getvertexset(s)`
 
-Optional traits with fallbacks: `has_hanging_nodes(grid)` (default `false`; return `true`
+Optional traits with fallbacks: `is_nonconforming(grid)` (default `false`; return `true`
 for non-conforming grids so the `DofHandler` retains the entity → dof maps needed for
 conformity constraints) and `grid_epoch(grid)` (default `0`, i.e. not epoch-tracked; adaptive
 grids return a counter incremented on every mutation so that stale `DofHandler` use errors,

--- a/ext/FerriteVTKHDF.jl
+++ b/ext/FerriteVTKHDF.jl
@@ -10,6 +10,7 @@ import Ferrite: write_solution, write_projection, write_cell_data, write_node_da
 using VTKHDF: VTKHDF, vtkhdf_grid, VTKPointData, VTKCellData
 
 function Ferrite.VTKHDFGridFile(filename::String, dh::DofHandler; kwargs...)
+    Ferrite._check_epoch(dh)
     for sdh in dh.subdofhandlers
         for ip in sdh.field_interpolations
             if !isa(conformity(ip), H1Conformity)

--- a/ext/FerriteVTKHDF.jl
+++ b/ext/FerriteVTKHDF.jl
@@ -10,15 +10,7 @@ import Ferrite: write_solution, write_projection, write_cell_data, write_node_da
 using VTKHDF: VTKHDF, vtkhdf_grid, VTKPointData, VTKCellData
 
 function Ferrite.VTKHDFGridFile(filename::String, dh::DofHandler; kwargs...)
-    Ferrite._check_epoch(dh)
-    for sdh in dh.subdofhandlers
-        for ip in sdh.field_interpolations
-            if !isa(conformity(ip), H1Conformity)
-                return VTKHDFGridFile(filename, get_grid(dh); write_discontinuous = true, kwargs...)
-            end
-        end
-    end
-    return VTKHDFGridFile(filename, get_grid(dh); kwargs...)
+    return VTKHDFGridFile(filename, get_grid(dh); write_discontinuous = Ferrite._vtk_discontinuous(dh), kwargs...)
 end
 
 function Ferrite.VTKHDFGridFile(filename::String, grid::AbstractGrid; write_discontinuous = false, kwargs...)

--- a/src/Adaptivity/constraints.jl
+++ b/src/Adaptivity/constraints.jl
@@ -16,16 +16,19 @@ struct ConformityConstraint
     field_name::Symbol
 end
 
-# Redispatch on the grid type instead of constraining the `ConstraintHandler` type parameters.
+# Redispatch on the grid's hanging-node trait instead of its concrete type, so both the
+# `ForestBWG` facade and the (deprecated) `NonConformingGrid` take the same path.
 function Ferrite.add!(ch::ConstraintHandler{<:DofHandler}, cc::ConformityConstraint)
-    return _add_conformity_constraints!(ch, Ferrite.get_grid(ch.dh), cc)
+    grid = Ferrite.get_grid(ch.dh)
+    if Ferrite.has_hanging_nodes(grid)
+        _add_conformity_constraints!(ch, grid, cc)
+    else
+        @warn "Trying to add conformity constraint to $(cc.field_name) on a conforming grid. Skipping."
+    end
+    return
 end
 
-function _add_conformity_constraints!(ch::ConstraintHandler, ::Ferrite.AbstractGrid, cc::ConformityConstraint)
-    return @warn "Trying to add conformity constraint to $(cc.field_name) on a conforming grid. Skipping."
-end
-
-function _add_conformity_constraints!(ch::ConstraintHandler, grid::NonConformingGrid, cc::ConformityConstraint)
+function _add_conformity_constraints!(ch::ConstraintHandler, grid::Ferrite.AbstractGrid, cc::ConformityConstraint)
     dh = ch.dh
     cc.field_name ∈ dh.field_names || throw(ArgumentError("Field $(cc.field_name) not found in provided dof handler. Available fields are $(dh.field_names)."))
     # The entity maps (vertexdicts) are indexed by the *global* field position, so the
@@ -48,7 +51,7 @@ function _add_conformity_constraints!(ch::ConstraintHandler, grid::NonConforming
     # to dof 0). Two ways to violate this: a cell belonging to no SubDofHandler at all
     # (`cell_to_subdofhandler == 0`), or the field itself living on only part of the grid.
     vertices = (dh.entitymaps::Ferrite.EntityMaps).vertices[global_fidx]
-    if any(iszero, dh.cell_to_subdofhandler) || _has_uncovered_hanging_vertex(grid.conformity_info, vertices)
+    if any(iszero, dh.cell_to_subdofhandler) || _has_uncovered_hanging_vertex(conformity_info(grid), vertices)
         throw(ArgumentError("ConformityConstraint requires the field :$(cc.field_name) on every cell of the non-conforming grid, but it covers only part of it. Subdomains (e.g. `L2Projector(...; set = ...)`) are not supported on non-conforming grids yet."))
     end
     # One set of linear constraints per hanging node
@@ -71,9 +74,9 @@ end
 end
 
 function _add_conformity_constraint(ch::ConstraintHandler, field_index::Int, interpolation::Lagrange{<:Any, 1})
-    # Reached only for a NonConformingGrid, so the entity maps are guaranteed to be present.
+    # Reached only for grids with hanging nodes, so the entity maps are guaranteed to be present.
     vertices = (ch.dh.entitymaps::Ferrite.EntityMaps).vertices[field_index]
-    for (hdof, mdof) in ch.dh.grid.conformity_info
+    for (hdof, mdof) in conformity_info(Ferrite.get_grid(ch.dh))
         # A hanging node is the average of its masters: an edge midpoint of its 2 endpoints
         # (weight 1/2), a 3D face center of its 4 face corners (weight 1/4).
         @debug @assert length(mdof) ∈ (2, 4)
@@ -85,9 +88,9 @@ function _add_conformity_constraint(ch::ConstraintHandler, field_index::Int, int
 end
 
 function _add_conformity_constraint(ch::ConstraintHandler, field_index::Int, interpolation::VectorizedInterpolation{vdim, <:Any, <:Any, <:Lagrange{<:Any, 1}}) where {vdim}
-    # Reached only for a NonConformingGrid, so the entity maps are guaranteed to be present.
+    # Reached only for grids with hanging nodes, so the entity maps are guaranteed to be present.
     vertices = (ch.dh.entitymaps::Ferrite.EntityMaps).vertices[field_index]
-    for (hdof, mdof) in ch.dh.grid.conformity_info
+    for (hdof, mdof) in conformity_info(Ferrite.get_grid(ch.dh))
         @debug @assert length(mdof) ∈ (2, 4)
         weight = 1 / length(mdof)
         # One constraint per component

--- a/src/Adaptivity/constraints.jl
+++ b/src/Adaptivity/constraints.jl
@@ -20,7 +20,7 @@ end
 # `ForestBWG` facade and the (deprecated) `NonConformingGrid` take the same path.
 function Ferrite.add!(ch::ConstraintHandler{<:DofHandler}, cc::ConformityConstraint)
     grid = Ferrite.get_grid(ch.dh)
-    if Ferrite.has_hanging_nodes(grid)
+    if Ferrite.is_nonconforming(grid)
         _add_conformity_constraints!(ch, grid, cc)
     else
         @warn "Trying to add conformity constraint to $(cc.field_name) on a conforming grid. Skipping."

--- a/src/Adaptivity/forest.jl
+++ b/src/Adaptivity/forest.jl
@@ -357,7 +357,6 @@ function coarsen!(forest::ForestBWG, cellids::AbstractVector{<:Integer}; require
     isempty(cellids) && return
     cmarked = issorted(cellids) ? cellids : sort(cellids)
     _apply_refine_coarsen!(forest, cmarked, eltype(cmarked)[], require_all_siblings)
-    _invalidate!(forest)
     return
 end
 
@@ -390,7 +389,6 @@ function refine_and_coarsen!(
         cmarked = issorted(coarsen_ids) ? coarsen_ids : sort(coarsen_ids)
         rmarked = issorted(refine_ids) ? refine_ids : sort(refine_ids)
         _apply_refine_coarsen!(forest, cmarked, rmarked, require_all_siblings)
-        _invalidate!(forest)
     end
     balance && balanceforest!(forest)
     return
@@ -419,6 +417,8 @@ function _apply_refine_coarsen!(forest::ForestBWG, cmarked::AbstractVector{<:Int
         end
         offset += n
     end
+    # one bump for the whole logical mutation, however many trees it rewrote
+    _invalidate!(forest)
     return
 end
 
@@ -583,17 +583,16 @@ end
 # and must not materialize).
 Ferrite.getcells(forest::ForestBWG) = _materialized(forest).cells
 Ferrite.getcells(forest::ForestBWG, v::Union{Integer, AbstractVector{<:Integer}}) = _materialized(forest).cells[v]
-Ferrite.getcells(forest::ForestBWG, setname::String) = _materialized(forest).cells[collect(getcellset(forest, setname))]
+# getcells(forest, setname), getnnodes and get_node_coordinate(forest, n) are the generic
+# AbstractGrid fallbacks, which compose through the overrides above.
 # All trees materialize into one concrete cell type (`MC`), independent of `i`.
 Ferrite.getcelltype(::ForestBWG{<:Any, <:Any, <:Any, MC}) where {MC} = MC
 Ferrite.getcelltype(::ForestBWG{<:Any, <:Any, <:Any, MC}, i::Integer) where {MC} = MC
 
 Ferrite.getnodes(forest::ForestBWG) = _materialized(forest).nodes
 Ferrite.getnodes(forest::ForestBWG, v::Union{Integer, AbstractVector{<:Integer}}) = _materialized(forest).nodes[v]
-Ferrite.getnnodes(forest::ForestBWG) = length(_materialized(forest).nodes)
 Ferrite.get_coordinate_type(::ForestBWG{dim, <:Any, T}) where {dim, T} = Vec{dim, T}
 Ferrite.get_coordinate_eltype(::ForestBWG{<:Any, <:Any, T}) where {T} = T
-Ferrite.get_node_coordinate(forest::ForestBWG, n::Integer) = get_node_coordinate(_materialized(forest).nodes[n])
 
 Ferrite.getcellset(forest::ForestBWG, setname::String) = _materialized(forest).cellsets[setname]
 Ferrite.getcellsets(forest::ForestBWG) = _materialized(forest).cellsets
@@ -2548,7 +2547,7 @@ end
 # the facade.
 function _materialize_snapshot(forest::ForestBWG{dim, C, T}) where {dim, C, T}
     node_map = dim == 2 ? node_map₂ : node_map₃
-    celltype = dim == 2 ? Quadrilateral : Hexahedron
+    celltype = _materialized_celltype(Val(dim))
     NV = 2^dim
     ncells = getncells(forest)
     ntrees = length(forest.cells)

--- a/src/Adaptivity/forest.jl
+++ b/src/Adaptivity/forest.jl
@@ -10,9 +10,52 @@
 #   materialization                `creategrid` (Lnodes numbering) and `facetskeleton`
 
 """
-    ForestBWG{dim, C <: OctreeBWG, T <: Real} <: Ferrite.AbstractGrid{dim}
+    ForestSnapshot{dim, C <: AbstractCell, T}
+
+The materialized (fine) grid of a [`ForestBWG`](@ref) at one refinement state: the cells and
+nodes produced by the [`creategrid`](@ref Ferrite.AMR.creategrid) pipeline, the hanging-node
+constraints (`conformity_info`, see [`conformity_info`](@ref Ferrite.AMR.conformity_info)) and
+the reconstructed `facetsets`/`cellsets`. Owned by the forest's [`MaterializedForest`](@ref)
+cache box — never read its fields from downstream code; go through the `AbstractGrid`
+accessors on the forest (`getcells`, `getnodes`, `getfacetset`, …) and
+[`conformity_info`](@ref Ferrite.AMR.conformity_info) instead.
+"""
+struct ForestSnapshot{dim, C <: Ferrite.AbstractCell, T}
+    cells::Vector{C}
+    nodes::Vector{Node{dim, T}}
+    conformity_info::Dict{Int, Vector{Int}}   # hanging node -> masters (until Phase 2)
+    facetsets::Dict{String, OrderedSet{Ferrite.FacetIndex}}
+    cellsets::Dict{String, OrderedSet{Int}}
+end
+
+"""
+    MaterializedForest{dim, C <: AbstractCell, T}
+
+The mutable cache box inside the (immutable) [`ForestBWG`](@ref): the current `epoch` (bumped
+by every mutator — `refine!`, `coarsen!`, `refine_and_coarsen!`, `refine_all!`,
+`balanceforest!`) and the lazily materialized [`ForestSnapshot`](@ref) of that epoch
+(`nothing` while stale/empty; filled on demand by `_materialized`).
+"""
+mutable struct MaterializedForest{dim, C <: Ferrite.AbstractCell, T}
+    epoch::Int
+    state::Union{Nothing, ForestSnapshot{dim, C, T}}
+end
+
+MaterializedForest{dim, C, T}() where {dim, C <: Ferrite.AbstractCell, T} =
+    MaterializedForest{dim, C, T}(1, nothing)
+
+"""
+    ForestBWG{dim, C <: OctreeBWG, T <: Real, MC <: AbstractCell} <: Ferrite.AbstractGrid{dim}
 `p4est` adaptive grid implementation based on [BWG2011](@citet)
 and [IBWG2015](@citet).
+
+The forest *is* the grid: it subtypes `AbstractGrid` and answers all grid queries
+(`getcells`, `getnodes`, `getfacetset`, `getcoordinates`, …) for its **current** refinement
+state through a lazily materialized, epoch-guarded snapshot (see [`MaterializedForest`](@ref)).
+Pass the forest directly to `DofHandler`, `ConstraintHandler` and VTK export; after
+`refine!`/`coarsen!`/`balanceforest!` a closed `DofHandler` errors on use until
+[`reclose!`](@ref) is called. `MC` is the materialized cell type (`Quadrilateral` in 2D,
+`Hexahedron` in 3D).
 
 ## Constructor
     ForestBWG(grid::AbstractGrid{dim}, b) where dim
@@ -26,7 +69,7 @@ that [`creategrid`](@ref Ferrite.AMR.creategrid) uses to identify nodes across t
 An out-of-range `b` therefore throws a `DomainError` rather than silently producing a grid with
 wrongly merged nodes.
 """
-struct ForestBWG{dim, C <: OctreeBWG, T <: Real} <: Ferrite.AbstractGrid{dim}
+struct ForestBWG{dim, C <: OctreeBWG, T <: Real, MC <: Ferrite.AbstractCell} <: Ferrite.AbstractGrid{dim}
     cells::Vector{C}
     nodes::Vector{Node{dim, T}}
     # Sets
@@ -36,6 +79,23 @@ struct ForestBWG{dim, C <: OctreeBWG, T <: Real} <: Ferrite.AbstractGrid{dim}
     vertexsets::Dict{String, OrderedSet{Ferrite.VertexIndex}}
     #Topology
     topology::ExclusiveTopology
+    # Epoch-guarded materialization cache (the facade state, see MaterializedForest)
+    mcache::MaterializedForest{dim, MC, T}
+end
+
+# The materialized cell type is a pure function of the dimension.
+_materialized_celltype(::Val{2}) = Quadrilateral
+_materialized_celltype(::Val{3}) = Hexahedron
+
+function ForestBWG(
+        cells::Vector{C}, nodes::Vector{Node{dim, T}}, cellsets, nodesets, facetsets,
+        vertexsets, topology::ExclusiveTopology
+    ) where {dim, C <: OctreeBWG, T}
+    MC = _materialized_celltype(Val(dim))
+    return ForestBWG{dim, C, T, MC}(
+        cells, nodes, cellsets, nodesets, facetsets, vertexsets, topology,
+        MaterializedForest{dim, MC, T}()
+    )
 end
 
 function ForestBWG(grid::Ferrite.AbstractGrid{dim}, b = DEFAULT_MAXLEVEL[dim]) where {dim}
@@ -44,7 +104,7 @@ function ForestBWG(grid::Ferrite.AbstractGrid{dim}, b = DEFAULT_MAXLEVEL[dim]) w
     @assert isconcretetype(C)
     @assert (C == Quadrilateral && dim == 2) || (C == Hexahedron && dim == 3)
     topology = ExclusiveTopology(grid)
-    cells = OctreeBWG.(grid.cells, b)
+    cells = OctreeBWG.(cells, b)
     nodes = getnodes(grid)
     cellsets = Ferrite.getcellsets(grid)
     nodesets = Ferrite.getnodesets(grid)
@@ -52,6 +112,67 @@ function ForestBWG(grid::Ferrite.AbstractGrid{dim}, b = DEFAULT_MAXLEVEL[dim]) w
     vertexsets = Ferrite.getvertexsets(grid)
     return ForestBWG(cells, nodes, cellsets, nodesets, facetsets, vertexsets, topology)
 end
+
+"""
+    grid_epoch(forest::ForestBWG) -> Int
+
+The forest's current refinement epoch — the **invalidation key** of the materialization
+facade. Every mutator ([`refine!`](@ref Ferrite.AMR.refine!), [`refine_all!`](@ref
+Ferrite.AMR.refine_all!), [`coarsen!`](@ref Ferrite.AMR.coarsen!),
+[`refine_and_coarsen!`](@ref Ferrite.AMR.refine_and_coarsen!), [`balanceforest!`](@ref
+Ferrite.AMR.balanceforest!)) increments it; pure grid queries never change it. Always `>= 1`
+(conforming grids return `0` from the [`Ferrite.grid_epoch`](@ref) fallback, meaning "not
+epoch-tracked").
+
+Downstream code may cache anything derived from the forest's grid state (cells, nodes,
+dof-distributions, plot data, …) keyed on this value: the cache is valid exactly as long as
+`grid_epoch(forest)` is unchanged. This accessor is internal-but-stable API — it will keep
+working across releases, but is deliberately not exported.
+"""
+Ferrite.grid_epoch(forest::ForestBWG) = forest.mcache.epoch
+
+# Invalidate the facade: bump the epoch and drop the snapshot. Called by every mutator.
+function _invalidate!(forest::ForestBWG)
+    mc = forest.mcache
+    mc.epoch += 1
+    mc.state = nothing
+    return
+end
+
+"""
+    _materialized(forest::ForestBWG) -> ForestSnapshot
+
+The materialized snapshot of the forest's current refinement state, building it on demand
+(the [`creategrid`](@ref Ferrite.AMR.creategrid) pipeline) and caching it in the forest's
+[`MaterializedForest`](@ref) box until the next mutator invalidates it. All `AbstractGrid`
+accessor overrides on `ForestBWG` go through this. Requires a 2:1-balanced forest, like
+`creategrid`.
+"""
+@inline function _materialized(forest::ForestBWG)
+    state = forest.mcache.state
+    if state === nothing
+        state = _materialize_snapshot(forest)
+        forest.mcache.state = state
+    end
+    return state
+end
+
+Ferrite.has_hanging_nodes(::ForestBWG) = true
+
+"""
+    conformity_info(forest::ForestBWG) -> Dict{Int, Vector{Int}}
+    conformity_info(grid::NonConformingGrid)
+
+The hanging-node constraints of the materialized grid: a mapping from each hanging (slave)
+node id to its 2 (edge midpoint) or 4 (3D face center) master node ids, in the node numbering
+of the materialized grid (`getnodes(forest)`). For the forest this materializes on demand and
+reflects the current refinement state. This accessor is the supported way for downstream code
+to read conformity information — never reach into snapshot or grid fields directly.
+
+The layout will change once hanging edges/faces are exposed as entities for higher-order
+fields — see the warning in the AMR devdocs.
+"""
+conformity_info(forest::ForestBWG) = _materialized(forest).conformity_info
 
 function Ferrite.get_facet_facet_neighborhood(g::ForestBWG{dim}) where {dim}
     return Ferrite._get_facet_facet_neighborhood(g.topology, Val(dim))
@@ -108,6 +229,7 @@ function refine_all!(forest::ForestBWG, l)
         resize!(leaves, length(refined))
         copyto!(leaves, refined)
     end
+    _invalidate!(forest)
     return
 end
 
@@ -130,7 +252,9 @@ function refine!(forest::ForestBWG, cellid::Integer)
         prev_nleaves_k = nleaves_k
         nleaves_k += length(forest.cells[k].leaves)
     end
-    return refine_octant!(forest.cells[k], forest.cells[k].leaves[cellid - prev_nleaves_k])
+    refine_octant!(forest.cells[k], forest.cells[k].leaves[cellid - prev_nleaves_k])
+    _invalidate!(forest)
+    return
 end
 
 """
@@ -199,6 +323,7 @@ function refine!(forest::ForestBWG, cellids::AbstractVector{<:Integer})
         end
         offset += n
     end
+    _invalidate!(forest)
     return
 end
 
@@ -232,6 +357,7 @@ function coarsen!(forest::ForestBWG, cellids::AbstractVector{<:Integer}; require
     isempty(cellids) && return
     cmarked = issorted(cellids) ? cellids : sort(cellids)
     _apply_refine_coarsen!(forest, cmarked, eltype(cmarked)[], require_all_siblings)
+    _invalidate!(forest)
     return
 end
 
@@ -264,6 +390,7 @@ function refine_and_coarsen!(
         cmarked = issorted(coarsen_ids) ? coarsen_ids : sort(coarsen_ids)
         rmarked = issorted(refine_ids) ? refine_ids : sort(refine_ids)
         _apply_refine_coarsen!(forest, cmarked, rmarked, require_all_siblings)
+        _invalidate!(forest)
     end
     balance && balanceforest!(forest)
     return
@@ -401,6 +528,7 @@ function _coarsen_all!(forest::ForestBWG)
             end
         end
     end
+    _invalidate!(forest)
     return
 end
 
@@ -415,23 +543,22 @@ function Ferrite.getncells(grid::ForestBWG)
 end
 
 """
-    getcells(forest::ForestBWG) -> Vector{OctantBWG}
+    getleaves(forest::ForestBWG) -> Vector{OctantBWG}
 
 Collect the leaf octants of all trees of `forest` into a single vector, in ascending cell id
-order (tree by tree, Morton order within each tree) — i.e. the octant `getcells(forest)[i]`
-materializes into cell `i` of [`creategrid`](@ref Ferrite.AMR.creategrid)`(forest)`.
+order (tree by tree, Morton order within each tree) — i.e. the octant `getleaves(forest)[i]`
+materializes into cell `i` of the forest's grid facade (`getcells(forest)[i]`).
 
 !!! warning "Allocates on every call"
     This materializes a fresh vector of all leaves each time it is called — `O(n)` in the
     number of cells. Call it once and reuse the result instead of calling it inside loops.
 
-The returned octants live in the coordinate system of their respective tree, so the scalar
-`getcells(forest, cellid)` from the `AbstractGrid` interface is deliberately not supported
-(an octant is not interpretable without its tree) and throws instead of falling back to
-`forest.cells[cellid]`, which would inconsistently return a whole tree. Take
-`forest.cells[k].leaves` for tree-local work.
+The returned octants live in the coordinate system of their respective tree; take
+`forest.cells[k].leaves` for tree-local work. (This used to be `getcells(forest)`, which now
+returns the materialized `Quadrilateral`/`Hexahedron` cells per the `AbstractGrid`
+interface.)
 """
-function Ferrite.getcells(forest::ForestBWG{dim, C}) where {dim, C}
+function getleaves(forest::ForestBWG{dim, C}) where {dim, C}
     ncells = getncells(forest)
     nnodes = 2^dim
     cellvector = Vector{OctantBWG{dim, nnodes, eltype(C)}}(undef, ncells)
@@ -446,14 +573,60 @@ function Ferrite.getcells(forest::ForestBWG{dim, C}) where {dim, C}
     return cellvector
 end
 
-# Block the generic `getcells(grid, i) = grid.cells[i]` fallback: `forest.cells` are trees,
-# not cells, so it would silently return a whole tree while `getcells(forest)` returns leaves.
-function Ferrite.getcells(forest::ForestBWG, cellid::Union{Int, AbstractVector{Int}})
-    throw(ArgumentError("getcells(forest, cellid) is not supported: a leaf octant is not interpretable without its tree. Use getcells(forest) for all leaves, or forest.cells[k].leaves for tree-local work."))
+# --- AbstractGrid accessor overrides -------------------------------------------------------
+#
+# Ferrite's `AbstractGrid` fallbacks are field-based (`getcells(g) = g.cells`, …), and
+# `forest.cells` holds the *trees* (octrees), `forest.nodes` the *macro* nodes. Every
+# accessor that would touch those fields is therefore overridden to answer from the
+# materialized snapshot of the current refinement state instead. `getncells` stays the
+# cheap tree-sum (it is called inside `balanceforest!` while the forest is mid-mutation
+# and must not materialize).
+Ferrite.getcells(forest::ForestBWG) = _materialized(forest).cells
+Ferrite.getcells(forest::ForestBWG, v::Union{Integer, AbstractVector{<:Integer}}) = _materialized(forest).cells[v]
+Ferrite.getcells(forest::ForestBWG, setname::String) = _materialized(forest).cells[collect(getcellset(forest, setname))]
+# All trees materialize into one concrete cell type (`MC`), independent of `i`.
+Ferrite.getcelltype(::ForestBWG{<:Any, <:Any, <:Any, MC}) where {MC} = MC
+Ferrite.getcelltype(::ForestBWG{<:Any, <:Any, <:Any, MC}, i::Integer) where {MC} = MC
+
+Ferrite.getnodes(forest::ForestBWG) = _materialized(forest).nodes
+Ferrite.getnodes(forest::ForestBWG, v::Union{Integer, AbstractVector{<:Integer}}) = _materialized(forest).nodes[v]
+Ferrite.getnnodes(forest::ForestBWG) = length(_materialized(forest).nodes)
+Ferrite.get_coordinate_type(::ForestBWG{dim, <:Any, T}) where {dim, T} = Vec{dim, T}
+Ferrite.get_coordinate_eltype(::ForestBWG{<:Any, <:Any, T}) where {T} = T
+Ferrite.get_node_coordinate(forest::ForestBWG, n::Integer) = get_node_coordinate(_materialized(forest).nodes[n])
+
+Ferrite.getcellset(forest::ForestBWG, setname::String) = _materialized(forest).cellsets[setname]
+Ferrite.getcellsets(forest::ForestBWG) = _materialized(forest).cellsets
+Ferrite.getfacetset(forest::ForestBWG, setname::String) = _materialized(forest).facetsets[setname]
+Ferrite.getfacetsets(forest::ForestBWG) = _materialized(forest).facetsets
+# Node/vertex-set reconstruction is a known gap (as for `creategrid`): the macro sets kept
+# in `forest.nodesets`/`forest.vertexsets` are indexed against the *macro* grid and would be
+# wrong ids on the materialized grid, so the facade reports no node/vertex sets at all.
+Ferrite.getnodesets(::ForestBWG) = Dict{String, OrderedSet{Int}}()
+Ferrite.getnodeset(forest::ForestBWG, setname::String) = Ferrite.getnodesets(forest)[setname]
+Ferrite.getvertexsets(::ForestBWG) = Dict{String, OrderedSet{Ferrite.VertexIndex}}()
+Ferrite.getvertexset(forest::ForestBWG, setname::String) = Ferrite.getvertexsets(forest)[setname]
+
+# `ExclusiveTopology` of the materialized grid is wrong on hanging meshes (facet neighbours
+# across a hanging interface are not 1:1), and the field-based construction would read the
+# trees; error instead of silently producing a broken topology.
+function Ferrite.ExclusiveTopology(::ForestBWG)
+    error(
+        "ExclusiveTopology(forest::ForestBWG) is not supported: the topology of the " *
+            "materialized grid is ill-defined on non-conforming meshes. Use " *
+            "`Ferrite.AMR.facetskeleton(forest)` for facet-interface iteration instead."
+    )
 end
-# All trees share one octree type (the `ForestBWG` constructor requires a concrete,
-# uniform cell type), so the celltype does not depend on `i`.
-Ferrite.getcelltype(grid::ForestBWG, i::Int) = eltype(grid.cells)
+
+# The transform would mutate cached snapshot nodes in place and be silently lost on the next
+# rematerialization; transforming the tree corners instead is future work.
+function Ferrite.transform_coordinates!(::ForestBWG, ::Function)
+    error(
+        "transform_coordinates!(forest::ForestBWG, f) is not supported: the transform " *
+            "would be lost on the next rematerialization. Transform the base grid before " *
+            "constructing the ForestBWG instead."
+    )
+end
 
 """
     _treecorners(forest::ForestBWG{dim}, k::Integer) -> NTuple{2^dim, Vec{dim}}
@@ -1004,6 +1177,9 @@ function balanceforest!(forest::ForestBWG{dim}) where {dim}
             end
         end
     end
+    # Conservatively invalidate even when no cell was added: `balancetree` rebuilds the
+    # per-tree leaf lists, so "no count change" is not proof of "no change".
+    _invalidate!(forest)
     return
 end
 
@@ -2349,8 +2525,28 @@ Pipeline:
 Requires a 2:1-balanced forest (see [`balanceforest!`](@ref)) — balance is what guarantees
 hanging vertices are simple feature midpoints with non-hanging masters, and it is checked (an
 unbalanced forest leaves element vertices without node ids, which raises an error).
+
+!!! note "The facade makes this call unnecessary"
+    A `ForestBWG` now answers all `AbstractGrid` queries itself through an internal,
+    epoch-guarded materialization cache running this very pipeline — pass the forest
+    directly to `DofHandler`/`ConstraintHandler`/`VTKGridFile` and use [`reclose!`](@ref)
+    after refinement. `creategrid` remains as a thin wrapper for the transition; the
+    returned grid is a detached copy that does **not** track later refinements.
 """
-function creategrid(forest::ForestBWG{dim, C, T}) where {dim, C, T}
+function creategrid(forest::ForestBWG)
+    snap = _materialize_snapshot(forest)
+    return NonConformingGrid(
+        snap.cells, snap.nodes;
+        conformity_info = snap.conformity_info,
+        facetsets = snap.facetsets,
+        cellsets = snap.cellsets,
+    )
+end
+
+# The `creategrid` pipeline body, emitting the facade's cache entry. Built fresh on every
+# call (never returns the cached snapshot), so `creategrid`'s result shares no state with
+# the facade.
+function _materialize_snapshot(forest::ForestBWG{dim, C, T}) where {dim, C, T}
     node_map = dim == 2 ? node_map₂ : node_map₃
     celltype = dim == 2 ? Quadrilateral : Hexahedron
     NV = 2^dim
@@ -2402,11 +2598,10 @@ function creategrid(forest::ForestBWG{dim, C, T}) where {dim, C, T}
             final_of_prov[E[m3[2], m3[1]]], final_of_prov[E[m4[2], m4[1]]],
         ]
     end
-    return NonConformingGrid(
-        cells, Node.(nodecoords);
-        conformity_info = hnodes,
-        facetsets = reconstruct_facetsets(forest),
-        cellsets = reconstruct_cellsets(forest),
+    MC = _materialized_celltype(Val(dim))
+    return ForestSnapshot{dim, MC, T}(
+        cells, Node.(nodecoords), hnodes,
+        reconstruct_facetsets(forest), reconstruct_cellsets(forest),
     )
 end
 

--- a/src/Adaptivity/forest.jl
+++ b/src/Adaptivity/forest.jl
@@ -83,15 +83,15 @@ struct ForestBWG{dim, C <: OctreeBWG, T <: Real, MC <: Ferrite.AbstractCell} <: 
     mcache::MaterializedForest{dim, MC, T}
 end
 
-# The materialized cell type is a pure function of the dimension.
-_materialized_celltype(::Val{2}) = Quadrilateral
-_materialized_celltype(::Val{3}) = Hexahedron
+# The cell type a tree materializes into: the hypercube of the tree's dimension.
+_materialized_celltype(::Type{<:OctreeBWG{2}}) = Quadrilateral
+_materialized_celltype(::Type{<:OctreeBWG{3}}) = Hexahedron
 
 function ForestBWG(
         cells::Vector{C}, nodes::Vector{Node{dim, T}}, cellsets, nodesets, facetsets,
         vertexsets, topology::ExclusiveTopology
     ) where {dim, C <: OctreeBWG, T}
-    MC = _materialized_celltype(Val(dim))
+    MC = _materialized_celltype(C)
     return ForestBWG{dim, C, T, MC}(
         cells, nodes, cellsets, nodesets, facetsets, vertexsets, topology,
         MaterializedForest{dim, MC, T}()
@@ -157,7 +157,7 @@ accessor overrides on `ForestBWG` go through this. Requires a 2:1-balanced fores
     return state
 end
 
-Ferrite.has_hanging_nodes(::ForestBWG) = true
+Ferrite.is_nonconforming(::ForestBWG) = true
 
 """
     conformity_info(forest::ForestBWG) -> Dict{Int, Vector{Int}}
@@ -2547,7 +2547,7 @@ end
 # the facade.
 function _materialize_snapshot(forest::ForestBWG{dim, C, T}) where {dim, C, T}
     node_map = dim == 2 ? node_map₂ : node_map₃
-    celltype = _materialized_celltype(Val(dim))
+    celltype = _materialized_celltype(C)
     NV = 2^dim
     ncells = getncells(forest)
     ntrees = length(forest.cells)
@@ -2597,7 +2597,7 @@ function _materialize_snapshot(forest::ForestBWG{dim, C, T}) where {dim, C, T}
             final_of_prov[E[m3[2], m3[1]]], final_of_prov[E[m4[2], m4[1]]],
         ]
     end
-    MC = _materialized_celltype(Val(dim))
+    MC = _materialized_celltype(C)
     return ForestSnapshot{dim, MC, T}(
         cells, Node.(nodecoords), hnodes,
         reconstruct_facetsets(forest), reconstruct_cellsets(forest),

--- a/src/Adaptivity/ncgrid.jl
+++ b/src/Adaptivity/ncgrid.jl
@@ -20,6 +20,13 @@ This grid serves as an entry point for non-intrusive adaptive grid libraries.
 !!! note
     A grid produced by [`creategrid`](@ref Ferrite.AMR.creategrid) only carries the `cellsets`
     and `facetsets` of the base grid; its `nodesets` and `vertexsets` are empty.
+
+!!! warning "Deprecated"
+    `NonConformingGrid` is deprecated in favour of using the [`ForestBWG`](@ref) directly as
+    the grid: the forest answers all `AbstractGrid` queries for its current refinement state,
+    a `DofHandler` built on it detects staleness after refinement, and [`reclose!`](@ref)
+    re-distributes the dofs. `NonConformingGrid` (and [`creategrid`](@ref
+    Ferrite.AMR.creategrid)) keep working during the transition but will be removed.
 """
 mutable struct NonConformingGrid{dim, C <: Ferrite.AbstractCell, T <: Real, CIT} <: Ferrite.AbstractGrid{dim}
     cells::Vector{C}
@@ -50,6 +57,11 @@ end
 # Must be qualified: `get_coordinate_type` is not exported from Ferrite, so an unqualified
 # definition here would create a separate `AMR.get_coordinate_type` instead of extending it.
 Ferrite.get_coordinate_type(::NonConformingGrid{dim, C, T}) where {dim, C, T} = Vec{dim, T}
+
+Ferrite.has_hanging_nodes(::NonConformingGrid) = true
+
+# See the docstring at `conformity_info(::ForestBWG)` in forest.jl.
+conformity_info(g::NonConformingGrid) = g.conformity_info
 
 function Base.show(io::IO, ::MIME"text/plain", grid::NonConformingGrid)
     print(io, "$(typeof(grid)) with $(getncells(grid)) ")

--- a/src/Adaptivity/ncgrid.jl
+++ b/src/Adaptivity/ncgrid.jl
@@ -58,7 +58,7 @@ end
 # definition here would create a separate `AMR.get_coordinate_type` instead of extending it.
 Ferrite.get_coordinate_type(::NonConformingGrid{dim, C, T}) where {dim, C, T} = Vec{dim, T}
 
-Ferrite.has_hanging_nodes(::NonConformingGrid) = true
+Ferrite.is_nonconforming(::NonConformingGrid) = true
 
 # See the docstring at `conformity_info(::ForestBWG)` in forest.jl.
 conformity_info(g::NonConformingGrid) = g.conformity_info

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -177,6 +177,7 @@ ConstraintHandler(dh::AbstractDofHandler) = ConstraintHandler(Float64, dh)
 ConstraintHandler(::Type{Tv}, dh::AbstractDofHandler) where {Tv} = ConstraintHandler(Tv, Int, dh)
 function ConstraintHandler(::Type{Tv}, ::Type{Ti}, dh::AbstractDofHandler) where {Tv <: Number, Ti <: Integer}
     @assert isclosed(dh)
+    _check_epoch(dh)
     return ConstraintHandler(
         Dirichlet[], ProjectedDirichlet[], Ti[], Ti[], Tv[], Union{Nothing, Tv}[],
         Union{Nothing, DofCoefficients{Tv, Ti}}[], Dict{Ti, Ti}(), BitVector(), BCValues{Tv, Ti}[], dh, false,
@@ -1214,7 +1215,7 @@ function _add!(
         max_x = Tx(i -> typemin(eltype(Tx)))
         for facetpair in facet_map, facet_indices in (facetpair.mirror, facetpair.image)
             cellidx, facetidx = facet_indices
-            nodes = facets(grid.cells[cellidx])[facetidx]
+            nodes = facets(getcells(grid, cellidx))[facetidx]
             union!(all_node_idxs, nodes)
             for n in nodes
                 x = get_node_coordinate(grid, n)
@@ -1470,7 +1471,7 @@ __to_facetset(_, set::AbstractSet{FacetIndex}) = set
 __to_facetset(grid, set::String) = getfacetset(grid, set)
 function __collect_boundary_facets(grid::Grid)
     candidates = Dict{Tuple, FacetIndex}()
-    for (ci, c) in enumerate(grid.cells)
+    for (ci, c) in enumerate(getcells(grid))
         for (fi, fn) in enumerate(facets(c))
             facet = sortfacet_fast(fn)
             if haskey(candidates, facet)
@@ -1491,14 +1492,14 @@ function __collect_periodic_facets_tree!(facet_map::Vector{PeriodicFacetPair}, g
 
     mirror_mean_x = Tx[]
     for (c, f) in mset
-        fn = facets(grid.cells[c])[f]
+        fn = facets(getcells(grid, c))[f]
         push!(mirror_mean_x, sum(get_node_coordinate(grid, i) for i in fn) / length(fn))
     end
 
     # Same dance for the image
     image_mean_x = Tx[]
     for (c, f) in iset
-        fn = facets(grid.cells[c])[f]
+        fn = facets(getcells(grid, c))[f]
         # Apply transformation to all coordinates
         push!(image_mean_x, sum(transformation(get_node_coordinate(grid, i))::Tx for i in fn) / length(fn))
     end
@@ -1599,9 +1600,9 @@ end
 # have opposing normal vectors
 function __check_periodic_facets(grid::Grid, fi::FacetIndex, fj::FacetIndex, known_order::Bool, tol::Float64)
     cii, fii = fi
-    nodes_i = facets(grid.cells[cii])[fii]
+    nodes_i = facets(getcells(grid, cii))[fii]
     cij, fij = fj
-    nodes_j = facets(grid.cells[cij])[fij]
+    nodes_j = facets(getcells(grid, cij))[fij]
 
     # 1. Check that normals are opposite TODO: Should use FacetValues here
     ni = __outward_normal(grid, nodes_i)
@@ -1675,9 +1676,9 @@ end
 # vectors, and ii) compute the relative rotation.
 function __check_periodic_facets_f(grid::Grid, fi::FacetIndex, fj::FacetIndex, xmi, xmj, transformation::F, tol::Float64) where {F}
     cii, fii = fi
-    nodes_i = facets(grid.cells[cii])[fii]
+    nodes_i = facets(getcells(grid, cii))[fii]
     cij, fij = fj
-    nodes_j = facets(grid.cells[cij])[fij]
+    nodes_j = facets(getcells(grid, cij))[fij]
 
     # 1. Check if normals are aligned or opposite TODO: Should use FacetValues here
     ni = __outward_normal(grid, nodes_i)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -186,7 +186,9 @@ function Base.show(io::IO, mime::MIME"text/plain", dh::DofHandler)
     if !isclosed(dh)
         print(io, "  Not closed!")
     else
-        print(io, "  Total dofs: ", ndofs(dh))
+        # Deliberately not `ndofs(dh)`: printing a DofHandler that became stale through a
+        # grid mutation should describe it (last-closed state), not throw.
+        print(io, "  Total dofs: ", dh.ndofs)
     end
     return
 end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -161,9 +161,26 @@ close!(dh)
     nodes in the associated grid.
 """
 function DofHandler(grid::G) where {dim, G <: AbstractGrid{dim}}
-    ncells = getncells(grid)
     sdhs = SubDofHandler{DofHandler{dim, G}}[]
-    return DofHandler{dim, G}(sdhs, Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), false, grid, -1, nothing, 0)
+    dh = DofHandler{dim, G}(sdhs, Symbol[], Int[], Int[], Int[], false, grid, -1, nothing, 0)
+    return _reset_dof_state!(dh, getncells(grid))
+end
+
+# Every ncells-sized or close-derived field of a DofHandler, (re)set in one place. The
+# constructor and `reclose!` must agree on this list: a cache added to the struct and
+# initialized only in the constructor would survive `reclose!` at its stale
+# pre-refinement length — exactly the silent-staleness class the epoch guard exists to
+# rule out.
+function _reset_dof_state!(dh::DofHandler, ncells::Int)
+    resize!(dh.cell_to_subdofhandler, ncells)
+    fill!(dh.cell_to_subdofhandler, 0)
+    resize!(dh.cell_dofs_offset, ncells)
+    fill!(dh.cell_dofs_offset, 0)
+    empty!(dh.cell_dofs)
+    dh.ndofs = -1
+    dh.entitymaps = nothing
+    dh.closed = false
+    return dh
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", dh::DofHandler)
@@ -535,18 +552,12 @@ function reclose!(dh::DofHandler)
         )
     end
     # Re-resolve the (epoch-bound) whole-domain cellset against the current grid state and
-    # reset every ncells-sized structure fixed at construction/close time.
+    # reset every ncells-sized structure fixed at construction/close time (shared with the
+    # constructor, so the two lists cannot drift apart).
     ncells = getncells(get_grid(dh))
     empty!(sdh.cellset)
     union!(sdh.cellset, 1:ncells)
-    resize!(dh.cell_to_subdofhandler, ncells)
-    fill!(dh.cell_to_subdofhandler, 0)
-    resize!(dh.cell_dofs_offset, ncells)
-    fill!(dh.cell_dofs_offset, 0)
-    empty!(dh.cell_dofs)
-    dh.ndofs = -1
-    dh.entitymaps = nothing
-    dh.closed = false
+    _reset_dof_state!(dh, ncells)
     __close!(dh)
     return dh
 end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -100,8 +100,8 @@ end
 
 Maps from grid entities (vertices, edges, faces) to the first dof distributed on that entity,
 one entry per field. Produced as scratch storage while distributing dofs and retained by a
-[`DofHandler`](@ref) only when its grid is a `NonConformingGrid`, where it is needed to build
-the affine constraints that tie hanging nodes to their masters.
+[`DofHandler`](@ref) only when its grid has hanging nodes (see `has_hanging_nodes`), where it
+is needed to build the affine constraints that tie hanging nodes to their masters.
 
 - `vertices[f][v]` is the first dof on vertex `v` for field `f` (`0` if unvisited).
 - `edges[f][(a, b)]` is the first dof on the edge between global vertices `a < b`.
@@ -125,9 +125,13 @@ mutable struct DofHandler{dim, G <: AbstractGrid{dim}} <: AbstractDofHandler
     const grid::G
     ndofs::Int
     # Maps from entity to dofs. These are scratch structures during dof distribution and are
-    # only retained afterwards for a `NonConformingGrid` (to build conformity constraints for
-    # hanging nodes), otherwise this is `nothing`. See [`EntityMaps`](@ref).
+    # only retained afterwards for grids with hanging nodes (to build conformity constraints,
+    # see `has_hanging_nodes`), otherwise this is `nothing`. See [`EntityMaps`](@ref).
     entitymaps::Union{Nothing, EntityMaps}
+    # The grid's epoch (see `grid_epoch`) at the time of `close!`. `0` means the grid is not
+    # epoch-tracked; for epoch-tracked (adaptive) grids, `_check_epoch` compares this
+    # against the grid's current epoch and errors on mismatch (fix with `reclose!`).
+    grid_epoch::Int
 end
 
 """
@@ -159,7 +163,7 @@ close!(dh)
 function DofHandler(grid::G) where {dim, G <: AbstractGrid{dim}}
     ncells = getncells(grid)
     sdhs = SubDofHandler{DofHandler{dim, G}}[]
-    return DofHandler{dim, G}(sdhs, Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), false, grid, -1, nothing)
+    return DofHandler{dim, G}(sdhs, Symbol[], Int[], zeros(Int, ncells), zeros(Int, ncells), false, grid, -1, nothing, 0)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", dh::DofHandler)
@@ -196,6 +200,32 @@ get_grid(dh::DofHandler) = dh.grid
 Return the number of degrees of freedom in `dh`
 """
 ndofs(dh::AbstractDofHandler) = dh.ndofs
+ndofs(dh::DofHandler) = (_check_epoch(dh); dh.ndofs)
+
+"""
+    _check_epoch(dh::DofHandler)
+
+Guard against use of a `DofHandler` whose (epoch-tracked, adaptive) grid has been refined
+or coarsened since [`close!`](@ref): errors on an epoch mismatch, pointing to
+[`reclose!`](@ref). A no-op for grids that are not epoch-tracked (`grid_epoch(grid) == 0`).
+Called at per-loop entry points (`CellIterator` construction, `ConstraintHandler`
+construction, [`ndofs`](@ref), VTK export) — not per cell.
+"""
+@inline _check_epoch(dh::DofHandler) = _check_epoch(dh, get_grid(dh))
+@inline _check_epoch(::AbstractDofHandler) = nothing
+@inline function _check_epoch(dh::DofHandler, grid::AbstractGrid)
+    current = grid_epoch(grid)
+    dh.grid_epoch == current || _stale_dofhandler_error(dh.grid_epoch, current)
+    return nothing
+end
+@noinline function _stale_dofhandler_error(closed_epoch::Int, current_epoch::Int)
+    error(
+        "The DofHandler is stale: its grid has been mutated (refined/coarsened/balanced) " *
+            "since close! (grid epoch $current_epoch, DofHandler closed at epoch " *
+            "$closed_epoch). Call reclose!(dh) to re-distribute the dofs against the current " *
+            "grid state, then rebuild the ConstraintHandler."
+    )
+end
 
 """
     ndofs_per_cell(dh::AbstractDofHandler[, cell::Int=1])
@@ -442,14 +472,81 @@ function __close!(dh::DofHandler{dim}) where {dim}
     dh.ndofs = nextdof - 1
     dh.closed = true
 
-    # Retain the entity maps only for non-conforming grids, where they are needed to build
-    # the conformity (hanging-node) constraints. Conforming grids discard them.
-    if get_grid(dh) isa NonConformingGrid
+    # Retain the entity maps only for grids with hanging nodes, where they are needed to
+    # build the conformity constraints. Conforming grids discard them.
+    if has_hanging_nodes(get_grid(dh))
         dh.entitymaps = EntityMaps(vertexdicts, edgedicts, facedicts)
     end
 
+    # Record the grid's epoch (0 for grids that are not epoch-tracked): `_check_epoch`
+    # compares against it so that use after a later grid mutation errors (see `reclose!`).
+    dh.grid_epoch = grid_epoch(get_grid(dh))
+
     return dh, vertexdicts, edgedicts, facedicts
 
+end
+
+"""
+    reclose!(dh::DofHandler)
+
+Re-distribute the dofs of an already closed `dh` against the **current** state of its grid —
+the companion of grid mutation on adaptive grids (e.g. `Ferrite.AMR.ForestBWG`): after
+`refine!`/`coarsen!`/`balanceforest!` the old dof distribution is meaningless (cell ids and
+node numbering change) and every use of `dh` errors, until `reclose!` re-runs the
+distribution and records the new grid epoch.
+
+Fields, interpolations and the internal dof-distribution order are kept; `ndofs(dh)`,
+`celldofs` and all dof ranges are recomputed from scratch. A `ConstraintHandler` built
+against the old distribution remains stale — rebuild it (re-`add!`ing the constraints), as
+in the adaptive loop:
+
+```julia
+dh = DofHandler(forest); add!(dh, :u, ip); close!(dh)
+while adapting
+    ch = ConstraintHandler(dh); add!(ch, ConformityConstraint(:u)); add!(ch, dbc); close!(ch)
+    # assemble / solve / estimate / mark
+    refine!(forest, marked); balanceforest!(forest)
+    reclose!(dh)
+end
+```
+
+Currently only a `DofHandler` with a single `SubDofHandler` covering the whole domain is
+supported (its cellset is regenerated as `1:getncells(grid)`); subdomains error since their
+cellsets are bound to the old cell numbering.
+"""
+function reclose!(dh::DofHandler)
+    isclosed(dh) || error("reclose! expects a closed DofHandler; call close!(dh) first.")
+    if length(dh.subdofhandlers) != 1
+        error(
+            "reclose! currently supports only a single SubDofHandler covering the whole " *
+                "domain, got $(length(dh.subdofhandlers)) SubDofHandlers. Rebuild the " *
+                "DofHandler instead."
+        )
+    end
+    sdh = dh.subdofhandlers[1]
+    old_ncells = length(dh.cell_to_subdofhandler)
+    if length(sdh.cellset) != old_ncells
+        error(
+            "reclose! currently supports only a SubDofHandler covering the whole domain, " *
+                "but the cellset covers $(length(sdh.cellset)) of $old_ncells cells. Rebuild " *
+                "the DofHandler instead."
+        )
+    end
+    # Re-resolve the (epoch-bound) whole-domain cellset against the current grid state and
+    # reset every ncells-sized structure fixed at construction/close time.
+    ncells = getncells(get_grid(dh))
+    empty!(sdh.cellset)
+    union!(sdh.cellset, 1:ncells)
+    resize!(dh.cell_to_subdofhandler, ncells)
+    fill!(dh.cell_to_subdofhandler, 0)
+    resize!(dh.cell_dofs_offset, ncells)
+    fill!(dh.cell_dofs_offset, 0)
+    empty!(dh.cell_dofs)
+    dh.ndofs = -1
+    dh.entitymaps = nothing
+    dh.closed = false
+    __close!(dh)
+    return dh
 end
 
 """

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -100,7 +100,7 @@ end
 
 Maps from grid entities (vertices, edges, faces) to the first dof distributed on that entity,
 one entry per field. Produced as scratch storage while distributing dofs and retained by a
-[`DofHandler`](@ref) only when its grid has hanging nodes (see `has_hanging_nodes`), where it
+[`DofHandler`](@ref) only when its grid is non-conforming (see `is_nonconforming`), where it
 is needed to build the affine constraints that tie hanging nodes to their masters.
 
 - `vertices[f][v]` is the first dof on vertex `v` for field `f` (`0` if unvisited).
@@ -125,8 +125,8 @@ mutable struct DofHandler{dim, G <: AbstractGrid{dim}} <: AbstractDofHandler
     const grid::G
     ndofs::Int
     # Maps from entity to dofs. These are scratch structures during dof distribution and are
-    # only retained afterwards for grids with hanging nodes (to build conformity constraints,
-    # see `has_hanging_nodes`), otherwise this is `nothing`. See [`EntityMaps`](@ref).
+    # only retained afterwards for non-conforming grids (to build conformity constraints,
+    # see `is_nonconforming`), otherwise this is `nothing`. See [`EntityMaps`](@ref).
     entitymaps::Union{Nothing, EntityMaps}
     # The grid's epoch (see `grid_epoch`) at the time of `close!`. `0` means the grid is not
     # epoch-tracked; for epoch-tracked (adaptive) grids, `_check_epoch` compares this
@@ -491,9 +491,9 @@ function __close!(dh::DofHandler{dim}) where {dim}
     dh.ndofs = nextdof - 1
     dh.closed = true
 
-    # Retain the entity maps only for grids with hanging nodes, where they are needed to
+    # Retain the entity maps only for non-conforming grids, where they are needed to
     # build the conformity constraints. Conforming grids discard them.
-    if has_hanging_nodes(get_grid(dh))
+    if is_nonconforming(get_grid(dh))
         dh.entitymaps = EntityMaps(vertexdicts, edgedicts, facedicts)
     end
 

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -31,16 +31,19 @@ struct VTKGridFile{VTK <: WriteVTK.DatasetFile}
     cellnodes::Union{Vector{UnitRange{Int}}, Nothing}
     node_mapping::Union{Vector{Int}, Nothing}
 end
-function VTKGridFile(filename::String, dh::DofHandler; kwargs...)
+# Shared by this entry point and the VTKHDF extension's counterpart: guard against a
+# stale (pre-`reclose!`) handler and decide whether any field forces discontinuous
+# output — one body, so a future conformity type or guard refinement lands in both.
+function _vtk_discontinuous(dh::DofHandler)
     _check_epoch(dh)
-    for sdh in dh.subdofhandlers
-        for ip in sdh.field_interpolations
-            if !isa(conformity(ip), H1Conformity)
-                return VTKGridFile(filename, get_grid(dh); write_discontinuous = true, kwargs...)
-            end
-        end
+    for sdh in dh.subdofhandlers, ip in sdh.field_interpolations
+        isa(conformity(ip), H1Conformity) || return true
     end
-    return VTKGridFile(filename, get_grid(dh); kwargs...)
+    return false
+end
+
+function VTKGridFile(filename::String, dh::DofHandler; kwargs...)
+    return VTKGridFile(filename, get_grid(dh); write_discontinuous = _vtk_discontinuous(dh), kwargs...)
 end
 function VTKGridFile(filename::String, grid::AbstractGrid; write_discontinuous = false, kwargs...)
     vtk, cellnodes, node_mapping = create_vtk_grid(filename, grid, write_discontinuous; kwargs...)

--- a/src/Export/VTK.jl
+++ b/src/Export/VTK.jl
@@ -32,6 +32,7 @@ struct VTKGridFile{VTK <: WriteVTK.DatasetFile}
     node_mapping::Union{Vector{Int}, Nothing}
 end
 function VTKGridFile(filename::String, dh::DofHandler; kwargs...)
+    _check_epoch(dh)
     for sdh in dh.subdofhandlers
         for ip in sdh.field_interpolations
             if !isa(conformity(ip), H1Conformity)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -451,6 +451,31 @@ Get the spatial dimension of the grid, corresponding to the vector dimension of 
 getspatialdim(::AbstractGrid{sdim}) where {sdim} = sdim
 
 """
+    grid_epoch(grid::AbstractGrid) -> Int
+
+The grid's current *epoch* — an integer identifying its refinement state. Static grids
+return `0`, meaning "not epoch-tracked". Mutable/adaptive grids (e.g.
+`Ferrite.AMR.ForestBWG`) return a value `>= 1` that is incremented by every mutating
+operation; a [`DofHandler`](@ref) records this value at [`close!`](@ref) and errors when
+used against a grid whose epoch has since changed (see [`reclose!`](@ref)).
+
+Downstream code may use this value as an invalidation key for caches derived from the grid
+state. Internal-but-stable API.
+"""
+grid_epoch(::AbstractGrid) = 0
+
+"""
+    has_hanging_nodes(grid::AbstractGrid) -> Bool
+
+Trait: whether the grid can contain hanging (constrained, non-conforming) nodes. `false`
+for conforming grids; `true` for non-conforming ones (e.g. `Ferrite.AMR.ForestBWG` and
+`Ferrite.AMR.NonConformingGrid`). A `DofHandler` retains its entity → dof maps after
+[`close!`](@ref) exactly when this holds, so that conformity (hanging-node) constraints can
+be built from them.
+"""
+has_hanging_nodes(::AbstractGrid) = false
+
+"""
     get_reference_dimension(grid::AbstractGrid) -> Union{Int, Symbol}
     get_reference_dimension(grid::AbstractGrid, cellid::Int) -> Int
 
@@ -487,11 +512,11 @@ Whereas the last option tries to call a `cellset` of the `grid`. `Collection` ca
 """
 @inline getcells(grid::AbstractGrid) = grid.cells
 @inline getcells(grid::AbstractGrid, v::Union{Integer, AbstractVector{<:Integer}}) = grid.cells[v]
-@inline getcells(grid::AbstractGrid, setname::String) = grid.cells[collect(getcellset(grid, setname))]
+@inline getcells(grid::AbstractGrid, setname::String) = getcells(grid)[collect(getcellset(grid, setname))]
 "Returns the number of cells in the `<:AbstractGrid`."
-@inline getncells(grid::AbstractGrid) = length(grid.cells)
+@inline getncells(grid::AbstractGrid) = length(getcells(grid))
 "Returns the celltype of the `<:AbstractGrid`."
-@inline getcelltype(grid::AbstractGrid) = eltype(grid.cells)
+@inline getcelltype(grid::AbstractGrid) = eltype(getcells(grid))
 @inline getcelltype(grid::AbstractGrid, i::Integer) = typeof(getcells(grid, i))
 
 """
@@ -505,15 +530,15 @@ to a Node.
 """
 @inline getnodes(grid::AbstractGrid) = grid.nodes
 @inline getnodes(grid::AbstractGrid, v::Union{Integer, AbstractVector{<:Integer}}) = grid.nodes[v]
-@inline getnodes(grid::AbstractGrid, setname::String) = grid.nodes[collect(getnodeset(grid, setname))]
+@inline getnodes(grid::AbstractGrid, setname::String) = getnodes(grid)[collect(getnodeset(grid, setname))]
 "Returns the number of nodes in the grid."
-@inline getnnodes(grid::AbstractGrid) = length(grid.nodes)
+@inline getnnodes(grid::AbstractGrid) = length(getnodes(grid))
 "Returns the number of nodes of the `i`-th cell."
 function nnodes_per_cell(grid::AbstractGrid)
     if !isconcretetype(getcelltype(grid))
         error("There are different celltypes in the `grid`. Use `nnodes_per_cell(grid, cellid::Integer)` instead")
     end
-    return nnodes(first(grid.cells))
+    return nnodes(first(getcells(grid)))
 end
 @inline nnodes_per_cell(grid::AbstractGrid, i::Integer) = nnodes(getcells(grid, i))
 

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -465,15 +465,16 @@ state. Internal-but-stable API.
 grid_epoch(::AbstractGrid) = 0
 
 """
-    has_hanging_nodes(grid::AbstractGrid) -> Bool
+    is_nonconforming(grid::AbstractGrid) -> Bool
 
-Trait: whether the grid can contain hanging (constrained, non-conforming) nodes. `false`
-for conforming grids; `true` for non-conforming ones (e.g. `Ferrite.AMR.ForestBWG` and
-`Ferrite.AMR.NonConformingGrid`). A `DofHandler` retains its entity → dof maps after
-[`close!`](@ref) exactly when this holds, so that conformity (hanging-node) constraints can
-be built from them.
+Trait: whether the grid can be non-conforming, i.e. contain interfaces where the
+discretization must be constrained to stay conforming (hanging nodes from h-refinement, but
+also e.g. degree mismatches from p-refinement). `false` for conforming grids; `true` for
+non-conforming ones (e.g. `Ferrite.AMR.ForestBWG` and `Ferrite.AMR.NonConformingGrid`). A
+`DofHandler` retains its entity → dof maps after [`close!`](@ref) exactly when this holds, so
+that conformity constraints can be built from them.
 """
-has_hanging_nodes(::AbstractGrid) = false
+is_nonconforming(::AbstractGrid) = false
 
 """
     get_reference_dimension(grid::AbstractGrid) -> Union{Int, Symbol}

--- a/src/Grid/topology.jl
+++ b/src/Grid/topology.jl
@@ -358,7 +358,7 @@ _getneighborhood(::Val{3}, top, grid, facetindex::FacetIndex, include_self) = ge
 Computes the stencils induced by the edge connectivity of the vertices.
 """
 function vertex_star_stencils(top::ExclusiveTopology, grid::Grid)
-    cells = grid.cells
+    cells = getcells(grid)
     stencil_table = ArrayOfVectorViews(VertexIndex[], (getnnodes(grid),); sizehint = 10) do buf
         # Vertex Connectivity
         for (global_vertexid, cellset) in enumerate(top.vertex_to_cell)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -130,12 +130,13 @@ end
     close!(proj::L2Projector)
 
 Close `proj` which assembles and calculates the left-hand-side of the projection equation, before doing a Cholesky factorization
-of the mass-matrix. For `NonConformingGrid`s, a [`ConformityConstraint`](@ref) is automatically added to ensure continuity across hanging nodes.
+of the mass-matrix. For grids with hanging nodes (see `has_hanging_nodes`), a
+[`ConformityConstraint`](@ref) is automatically added to ensure continuity across hanging nodes.
 """
 function close!(proj::L2Projector)
     close!(proj.dh)
     grid = get_grid(proj.dh)
-    if grid isa NonConformingGrid
+    if has_hanging_nodes(grid)
         ch = ConstraintHandler(proj.dh)
         add!(ch, ConformityConstraint(:_))
         close!(ch)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -130,13 +130,13 @@ end
     close!(proj::L2Projector)
 
 Close `proj` which assembles and calculates the left-hand-side of the projection equation, before doing a Cholesky factorization
-of the mass-matrix. For grids with hanging nodes (see `has_hanging_nodes`), a
+of the mass-matrix. For non-conforming grids (see `is_nonconforming`), a
 [`ConformityConstraint`](@ref) is automatically added to ensure continuity across hanging nodes.
 """
 function close!(proj::L2Projector)
     close!(proj.dh)
     grid = get_grid(proj.dh)
-    if has_hanging_nodes(grid)
+    if is_nonconforming(grid)
         ch = ConstraintHandler(proj.dh)
         add!(ch, ConformityConstraint(:_))
         close!(ch)

--- a/src/PointEvalHandler.jl
+++ b/src/PointEvalHandler.jl
@@ -501,7 +501,7 @@ function Base.iterate(p::PointIterator, state = 1)
         local_coord = (p.ph.local_coords[state])::Vec
         n = nnodes_per_cell(p.ph.grid, cid)
         getcoordinates!(resize!(p.coords, n), p.ph.grid, cid)
-        point = PointLocation(cid, p.ph.grid.cells[cid], local_coord, p.coords)
+        point = PointLocation(cid, getcells(p.ph.grid, cid), local_coord, p.coords)
         return (point, state + 1)
     end
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -125,6 +125,7 @@ export
     DofHandler,
     SubDofHandler,
     close!,
+    reclose!,
     ndofs,
     ndofs_per_cell,
     celldofs!,

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -260,6 +260,7 @@ function CellIterator(
         set = 1:getncells(grid)
     end
     if gridordh isa DofHandler
+        _check_epoch(gridordh)
         # TODO: Since the CellCache is resizeable this is not really necessary to check
         #       here, but might be useful to catch slow code paths?
         _check_same_celltype(get_grid(gridordh), set)
@@ -270,6 +271,7 @@ function CellIterator(gridordh::Union{Grid, DofHandler}, flags::UpdateFlags)
     return CellIterator(gridordh, nothing, flags)
 end
 function CellIterator(sdh::SubDofHandler, flags::UpdateFlags = UpdateFlags())
+    _check_epoch(sdh.dh)
     return CellIterator(CellCache(sdh, flags), sdh.cellset)
 end
 

--- a/test/test_p4est_facade.jl
+++ b/test/test_p4est_facade.jl
@@ -1,0 +1,256 @@
+# The ForestBWG grid facade (#1413): a `ForestBWG` is used directly as the grid of a
+# `DofHandler`/`ConstraintHandler`/VTK export. Grid accessors answer for the *current*
+# refinement state through an epoch-guarded materialization cache; mutators bump the
+# epoch, stale `DofHandler` use errors, and `reclose!` re-distributes dofs.
+using Ferrite, Test
+using LinearAlgebra, SparseArrays
+
+@testset "facade accessor overrides vs creategrid reference $dim D" for (dim, CT, RS) in
+    ((2, Quadrilateral, RefQuadrilateral), (3, Hexahedron, RefHexahedron))
+
+    grid = generate_grid(CT, ntuple(_ -> 2, dim))
+    addcellset!(grid, "left", x -> x[1] <= 0)
+    forest = ForestBWG(grid, 3)
+    Ferrite.AMR.refine!(forest, [1])
+    Ferrite.AMR.balanceforest!(forest)
+    ref = Ferrite.AMR.creategrid(forest)
+
+    # cells
+    @test getcells(forest) == getcells(ref)
+    @test getcells(forest, 3) == getcells(ref, 3)
+    @test getcells(forest, [1, 2]) == getcells(ref, [1, 2])
+    @test getcells(forest, "left") == getcells(ref, "left")
+    @test getncells(forest) == getncells(ref) == length(getcells(forest))
+    @test getcelltype(forest) === CT === getcelltype(forest, 1)
+    @test Ferrite.nnodes_per_cell(forest) == 2^dim == Ferrite.nnodes_per_cell(forest, 1)
+
+    # nodes and coordinates
+    @test getnodes(forest) == getnodes(ref)
+    @test getnodes(forest, 2) == getnodes(ref, 2)
+    @test getnodes(forest, [1, 2]) == getnodes(ref, [1, 2])
+    @test getnnodes(forest) == getnnodes(ref)
+    @test Ferrite.get_coordinate_type(forest) === Vec{dim, Float64}
+    @test Ferrite.get_coordinate_eltype(forest) === Float64
+    @test Ferrite.get_node_coordinate(forest, 5) == Ferrite.get_node_coordinate(ref, 5)
+    for cellid in (1, getncells(ref))
+        @test getcoordinates(forest, cellid) == getcoordinates(ref, cellid)
+    end
+
+    # sets: cellsets/facetsets are reconstructed, node/vertex sets are a documented gap
+    @test getcellset(forest, "left") == getcellset(ref, "left")
+    @test Ferrite.getcellsets(forest) == Ferrite.getcellsets(ref)
+    @test getfacetset(forest, "left") == getfacetset(ref, "left")
+    @test Ferrite.getfacetsets(forest) == Ferrite.getfacetsets(ref)
+    @test isempty(Ferrite.getnodesets(forest))
+    @test isempty(Ferrite.getvertexsets(forest))
+    @test_throws KeyError getnodeset(forest, "anything")
+    @test_throws KeyError getvertexset(forest, "anything")
+
+    # conformity information through the documented accessor, never via snapshot fields
+    @test Ferrite.AMR.conformity_info(forest) == ref.conformity_info
+    @test Ferrite.AMR.conformity_info(ref) == ref.conformity_info
+    @test Ferrite.has_hanging_nodes(forest)
+    @test Ferrite.has_hanging_nodes(ref)
+    @test !Ferrite.has_hanging_nodes(grid)
+end
+
+@testset "hard errors: ExclusiveTopology and transform_coordinates!" begin
+    forest = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    err = try
+        ExclusiveTopology(forest)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("facetskeleton", err.msg)
+    @test_throws ErrorException Ferrite.transform_coordinates!(forest, x -> 2 * x)
+end
+
+@testset "epoch semantics" begin
+    # plain grids are not epoch-tracked
+    @test Ferrite.grid_epoch(generate_grid(Quadrilateral, (1, 1))) == 0
+
+    forest = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    e = Ferrite.grid_epoch(forest)
+    @test e >= 1
+
+    # pure queries (including materialization) leave the epoch alone
+    getcells(forest)
+    getnnodes(forest)
+    getcoordinates(forest, 1)
+    Ferrite.AMR.facetskeleton(forest)
+    @test Ferrite.grid_epoch(forest) == e
+
+    # every mutator bumps
+    Ferrite.AMR.refine!(forest, [1])
+    @test Ferrite.grid_epoch(forest) > e
+    e = Ferrite.grid_epoch(forest)
+    Ferrite.AMR.balanceforest!(forest)
+    @test Ferrite.grid_epoch(forest) > e
+    e = Ferrite.grid_epoch(forest)
+    Ferrite.AMR.refine!(forest, 2) # scalar refine!
+    @test Ferrite.grid_epoch(forest) > e
+    e = Ferrite.grid_epoch(forest)
+    Ferrite.AMR.refine_all!(forest, 3)
+    @test Ferrite.grid_epoch(forest) > e
+    e = Ferrite.grid_epoch(forest)
+    Ferrite.AMR.coarsen!(forest, collect(1:4); require_all_siblings = false)
+    @test Ferrite.grid_epoch(forest) > e
+    e = Ferrite.grid_epoch(forest)
+    Ferrite.AMR.refine_and_coarsen!(forest, Int[], [1])
+    @test Ferrite.grid_epoch(forest) > e
+    # _coarsen_all! (internal) also invalidates
+    f3 = ForestBWG(generate_grid(Quadrilateral, (1, 1)), 1)
+    Ferrite.AMR.refine_all!(f3, 1)
+    e3 = Ferrite.grid_epoch(f3)
+    Ferrite.AMR._coarsen_all!(f3)
+    @test Ferrite.grid_epoch(f3) > e3
+
+    # the facade serves the refreshed state after a mutation
+    f2 = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    n = getncells(f2)
+    @test length(getcells(f2)) == n
+    Ferrite.AMR.refine!(f2, [1])
+    Ferrite.AMR.balanceforest!(f2)
+    @test length(getcells(f2)) == getncells(f2) > n
+end
+
+# Assemble the Laplace problem with unit load; returns the constrained solution.
+function _facade_solve(dh, ch, cv)
+    n = getnbasefunctions(cv)
+    Ke = zeros(n, n)
+    fe = zeros(n)
+    K = allocate_matrix(dh, ch)
+    f = zeros(ndofs(dh))
+    assembler = start_assemble(K, f)
+    for cell in CellIterator(dh)
+        reinit!(cv, cell)
+        fill!(Ke, 0)
+        fill!(fe, 0)
+        for qp in 1:getnquadpoints(cv)
+            dΩ = getdetJdV(cv, qp)
+            for i in 1:n
+                fe[i] += shape_value(cv, qp, i) * dΩ
+                for j in 1:n
+                    Ke[i, j] += (shape_gradient(cv, qp, i) ⋅ shape_gradient(cv, qp, j)) * dΩ
+                end
+            end
+        end
+        assemble!(assembler, celldofs(cell), Ke, fe)
+    end
+    apply!(K, f, ch)
+    u = K \ f
+    apply!(u, ch)
+    return u
+end
+
+@testset "tutorial-shaped adaptive loop $dim D" for (dim, CT, RS) in
+    ((2, Quadrilateral, RefQuadrilateral), (3, Hexahedron, RefHexahedron))
+
+    forest = ForestBWG(generate_grid(CT, ntuple(_ -> 2, dim)), 3)
+    ip = Lagrange{RS, 1}()
+    cv = CellValues(QuadratureRule{RS}(2), ip)
+
+    dh = DofHandler(forest)
+    add!(dh, :u, ip)
+    close!(dh)
+    @test ndofs(dh) == getnnodes(forest) == 3^dim
+
+    for _ in 1:2
+        ch = ConstraintHandler(dh)
+        add!(ch, ConformityConstraint(:u))
+        add!(ch, Dirichlet(:u, getfacetset(forest, "left"), x -> 0.0))
+        close!(ch)
+
+        u = _facade_solve(dh, ch, cv)
+        @test length(u) == ndofs(dh)
+        @test all(isfinite, u)
+        @test maximum(abs, u) > 0
+
+        # mark + refine; the DofHandler is now stale and must say so
+        Ferrite.AMR.refine!(forest, [1])
+        Ferrite.AMR.balanceforest!(forest)
+        stale = try
+            CellIterator(dh)
+            nothing
+        catch e
+            e
+        end
+        @test stale isa ErrorException
+        @test occursin("reclose!", stale.msg)
+        @test_throws ErrorException ndofs(dh)
+        @test_throws ErrorException ConstraintHandler(dh)
+        @test_throws ErrorException VTKGridFile(tempname(), dh)
+
+        # reclose! re-distributes dofs against the new epoch
+        reclose!(dh)
+        @test ndofs(dh) == getnnodes(forest)
+        @test Ferrite.isclosed(dh)
+    end
+
+    # after the loop, a full solve on the twice-refined forest still goes through,
+    # and VTK export accepts the recloseed handler
+    ch = ConstraintHandler(dh)
+    add!(ch, ConformityConstraint(:u))
+    add!(ch, Dirichlet(:u, getfacetset(forest, "left"), x -> 0.0))
+    close!(ch)
+    u = _facade_solve(dh, ch, cv)
+    @test all(isfinite, u)
+    mktempdir() do dir
+        VTKGridFile(joinpath(dir, "facade"), dh) do vtk
+            write_solution(vtk, dh, u)
+        end
+        @test isfile(joinpath(dir, "facade.vtu"))
+    end
+end
+
+@testset "reclose! guards" begin
+    # not closed
+    forest = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    dh = DofHandler(forest)
+    add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+    @test_throws ErrorException reclose!(dh)
+
+    # multiple SubDofHandlers are not supported in v1
+    dh2 = DofHandler(forest)
+    sdh_a = SubDofHandler(dh2, 1:2)
+    add!(sdh_a, :u, Lagrange{RefQuadrilateral, 1}())
+    sdh_b = SubDofHandler(dh2, 3:4)
+    add!(sdh_b, :u, Lagrange{RefQuadrilateral, 1}())
+    close!(dh2)
+    Ferrite.AMR.refine!(forest, [1])
+    Ferrite.AMR.balanceforest!(forest)
+    @test_throws ErrorException reclose!(dh2)
+
+    # a single SubDofHandler on a subdomain is not supported in v1 either
+    forest3 = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    dh3 = DofHandler(forest3)
+    sdh_c = SubDofHandler(dh3, 1:2)
+    add!(sdh_c, :u, Lagrange{RefQuadrilateral, 1}())
+    close!(dh3)
+    Ferrite.AMR.refine!(forest3, [1])
+    Ferrite.AMR.balanceforest!(forest3)
+    @test_throws ErrorException reclose!(dh3)
+
+    # reclose! on a conforming (non-epoch-tracked) grid is a valid re-distribution no-op
+    grid = generate_grid(Quadrilateral, (2, 2))
+    dh4 = DofHandler(grid)
+    add!(dh4, :u, Lagrange{RefQuadrilateral, 1}())
+    close!(dh4)
+    nd = ndofs(dh4)
+    reclose!(dh4)
+    @test ndofs(dh4) == nd
+end
+
+@testset "creategrid remains a thin working wrapper" begin
+    forest = ForestBWG(generate_grid(Quadrilateral, (2, 2)), 3)
+    Ferrite.AMR.refine!(forest, [1])
+    Ferrite.AMR.balanceforest!(forest)
+    g = Ferrite.AMR.creategrid(forest)
+    @test g isa Ferrite.AMR.NonConformingGrid
+    @test getncells(g) == getncells(forest)
+    # the returned grid does not alias the facade cache
+    @test getcells(g) !== getcells(forest)
+    @test getnodes(g) !== getnodes(forest)
+end

--- a/test/test_p4est_facade.jl
+++ b/test/test_p4est_facade.jl
@@ -49,9 +49,9 @@ using LinearAlgebra, SparseArrays
     # conformity information through the documented accessor, never via snapshot fields
     @test Ferrite.AMR.conformity_info(forest) == ref.conformity_info
     @test Ferrite.AMR.conformity_info(ref) == ref.conformity_info
-    @test Ferrite.has_hanging_nodes(forest)
-    @test Ferrite.has_hanging_nodes(ref)
-    @test !Ferrite.has_hanging_nodes(grid)
+    @test Ferrite.is_nonconforming(forest)
+    @test Ferrite.is_nonconforming(ref)
+    @test !Ferrite.is_nonconforming(grid)
 end
 
 @testset "hard errors: ExclusiveTopology and transform_coordinates!" begin

--- a/test/test_p4est_forest.jl
+++ b/test/test_p4est_forest.jl
@@ -874,11 +874,11 @@ end
     forest = ForestBWG(grid, 3)
     Ferrite.AMR.refine_all!(forest, 1)
 
-    # getcells collects the leaves of all trees in cell id order (tree by tree, Morton
-    # order within each tree); the scalar getcells(forest, cellid) deliberately throws
-    # instead of hitting the generic fallback, which would return a whole tree
-    @test_throws ArgumentError getcells(forest, 7)
-    @test_throws ArgumentError getcells(forest, [1, 2])
+    # the facade materializes the fine grid on demand: getcells returns the materialized
+    # Quadrilateral cells (never trees or octants), for all three accessor variants
+    @test getcells(forest, 7) isa Quadrilateral
+    @test getcells(forest, [1, 2]) == getcells(forest)[1:2]
+    @test eltype(getcells(forest)) === Quadrilateral
 
     # marking a cell already at the maximum level is a documented no-op — also when the
     # tree's *first* leaf is the max-level one (used to throw from the 2^dim size hint)
@@ -895,7 +895,8 @@ end
         g = Ferrite.AMR.creategrid(f)
         @test getncells(g) == n
     end
-    leaves = getcells(forest)
+    # getleaves collects the leaf octants in cell id order (formerly getcells(forest))
+    leaves = Ferrite.AMR.getleaves(forest)
     @test length(leaves) == getncells(forest)
     @test leaves[7] == forest.cells[2].leaves[3]
     @test leaves[1] == forest.cells[1].leaves[1]
@@ -919,9 +920,8 @@ end
         @test getnnodes(Ferrite.AMR.creategrid(f)) == 45
     end
 
-    # NOTE: getcelltype currently exposes the octree (tree) type; this will change
-    @test getcelltype(forest) === eltype(forest.cells) === getcelltype(forest, 1)
-    @test getcelltype(forest) <: Ferrite.AMR.OctreeBWG
+    # the facade reports the materialized cell type, never the octree (tree) type
+    @test getcelltype(forest) === Quadrilateral === getcelltype(forest, 1)
 
     # getneighborhood forwards to the macro topology
     top = ExclusiveTopology(grid)
@@ -977,11 +977,11 @@ end
     # (ids 1:nchild) recovers the original forest octant-for-octant
     forest = ForestBWG(generate_grid(CT, ntuple(_ -> 2, dim)), 4)
     Ferrite.AMR.refine_all!(forest, 1)
-    base = getcells(forest)
+    base = Ferrite.AMR.getleaves(forest)
     Ferrite.AMR.refine!(forest, [1])
     @test getncells(forest) == length(base) + (nchild - 1)
     Ferrite.AMR.coarsen!(forest, collect(1:nchild))
-    @test getcells(forest) == base
+    @test Ferrite.AMR.getleaves(forest) == base
     for tree in forest.cells
         @test issorted(tree.leaves)
     end
@@ -994,7 +994,7 @@ end
     f2 = deepcopy(f1)
     Ferrite.AMR._coarsen_all!(f1)
     Ferrite.AMR.coarsen!(f2, collect(1:getncells(f2)); require_all_siblings = true)
-    @test getcells(f1) == getcells(f2)
+    @test Ferrite.AMR.getleaves(f1) == Ferrite.AMR.getleaves(f2)
 
     # policy modularity: one marked sibling is a no-op under all-siblings, collapses the
     # family under any-sibling

--- a/test/test_p4est_grid.jl
+++ b/test/test_p4est_grid.jl
@@ -200,14 +200,19 @@ end
 
 @testset "vertex/node sets are not transferred $dim D" for (dim, CT) in ((2, Quadrilateral), (3, Hexahedron))
     # creategrid only carries cellsets and facetsets onto the refined grid. The forest keeps
-    # the macro vertex/node sets, but the materialized grid has both empty -- documented on
+    # the macro vertex/node sets in its fields (indexed against the *macro* grid), but both
+    # the facade accessors and the materialized grid report them empty -- documented on
     # `creategrid`/`NonConformingGrid`, pinned here so the behaviour cannot drift silently.
     grid = generate_grid(CT, ntuple(_ -> 2, dim))
     addvertexset!(grid, "vs", x -> x[1] ≈ -1.0)
     grid.nodesets["ns"] = Ferrite.OrderedSet([1, 2])
     forest = ForestBWG(grid, 3)
-    @test Ferrite.getvertexsets(forest) == Ferrite.getvertexsets(grid)
-    @test Ferrite.getnodesets(forest) == Ferrite.getnodesets(grid)
+    @test forest.vertexsets == Ferrite.getvertexsets(grid)
+    @test forest.nodesets == Ferrite.getnodesets(grid)
+    @test isempty(Ferrite.getvertexsets(forest))
+    @test isempty(Ferrite.getnodesets(forest))
+    @test_throws KeyError getvertexset(forest, "vs")
+    @test_throws KeyError getnodeset(forest, "ns")
 
     Ferrite.AMR.refine!(forest, [1])
     Ferrite.AMR.balanceforest!(forest)


### PR DESCRIPTION
`ForestBWG` can hold essentially all fields that `NonConformingGrid` has in order to show one materialization step. This eases quite some code parts. One example is that you can hand over `ForestBWG` in each step of the finite element code and even have an invalidation mechanism that tells you that a materialization is needed (which is nice in order to avoid errors). Another example are things that are built on top of adaptivity, e.g. https://github.com/Ferrite-FEM/FerriteViz.jl/pull/168

Another nice part is that `ForestBWG` can actually fulfill in a meaningful way the `AbstractGrid` contract. The `NonConformingGrid` is still there, but I'd like to delete it if everyone agrees thats a better way forward.