### PR TITLE
Constraint support for block systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Atomic assembly support for BlockAssembler. ([#1452])
  - `apply_assemble!` now respects the assembler's atomic mode when non-local affine
    constraints write directly to the global matrix and vector. ([#1465])
+ - Assembling into a `BlockMatrix` is no longer orders of magnitude slower than assembling
+   into an unblocked matrix. The `BlockAssembler` cached the cell dofs as `BlockIndex{1}`,
+   which is not a concrete type, so the scatter loop was type unstable and allocated ~8
+   times per matrix entry. It now splits the cell dofs into their blocks and scatters each
+   block through `Ferrite._assemble_inner!`, i.e. the same routine the CSC and CSR
+   assemblers use, and assembles without allocating. ([#1489])
  - `add_interface_entries!` (and thereby `interface_coupling` builds) no longer errors for
    grids where some cells are not covered by any `SubDofHandler`: an uncovered cell has no
    dofs and contributes no interface entries, but the covered side of such an interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    explicit constraint data and index offsets, so the same methods serve a matrix on its own and
    as a block of a blocked matrix, and the BlockArrays extension contains no format specific
    code. As part of this, `apply!` and `apply_zero!` dispatch on `AbstractMatrix` rather than
-   `AbstractSparseMatrix`. ([#1486])
+   `AbstractSparseMatrix`. ([#1489])
  - `apply!` on a `SparseMatrixCSR` now supports affine constraints, which previously threw
-   `"condensation of ::SparseMatrixCSR{...} matrix not supported"`. ([#1486])
+   `"condensation of ::SparseMatrixCSR{...} matrix not supported"`. ([#1489])
 
 ### Performance
  - `create_coloring` is significantly faster: the incidence matrix construction and the
@@ -1448,4 +1448,4 @@ poking into Ferrite internals:
 [#1475]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1475
 [#1481]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1481
 [#1490]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1490
-[#1486]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1486
+[#1489]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1489

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Atomic assembly (`start_assemble(K, f; atomic = true)`) now supports `Float16` and
    `Complex` of `Float16`/`Float32`/`Float64` as value types, in addition to `Float32`
    and `Float64`. ([#1474])
+ - `apply!` and `apply_zero!` now work for a `BlockMatrix` with blocks in CSC
+   storage (as created by `allocate_matrix(BlockMatrix, ::BlockSparsityPattern)`), including
+   condensation of affine constraints. Previously constraints could only be applied to a
+   blocked system with `apply_assemble!`. As part of this, `apply!` and `apply_zero!`
+   dispatch on `AbstractMatrix` rather than `AbstractSparseMatrix`, so a custom matrix format
+   is supported as soon as it dispatches the internal interface documented in the devdocs on
+   assembly. ([#1486])
 
 ### Performance
  - `create_coloring` is significantly faster: the incidence matrix construction and the
@@ -1437,3 +1444,4 @@ poking into Ferrite internals:
 [#1475]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1475
 [#1481]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1481
 [#1490]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1490
+[#1486]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1486

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Atomic assembly (`start_assemble(K, f; atomic = true)`) now supports `Float16` and
    `Complex` of `Float16`/`Float32`/`Float64` as value types, in addition to `Float32`
    and `Float64`. ([#1474])
- - `apply!` and `apply_zero!` now work for a `BlockMatrix` with blocks in CSC
-   storage (as created by `allocate_matrix(BlockMatrix, ::BlockSparsityPattern)`), including
-   condensation of affine constraints. Previously constraints could only be applied to a
-   blocked system with `apply_assemble!`. As part of this, `apply!` and `apply_zero!`
-   dispatch on `AbstractMatrix` rather than `AbstractSparseMatrix`, so a custom matrix format
-   is supported as soon as it dispatches the internal interface documented in the devdocs on
-   assembly. ([#1486])
+ - `apply!` and `apply_zero!` now work for a `BlockMatrix`, including condensation of affine
+   constraints. Previously constraints could only be applied to a blocked system with
+   `apply_assemble!`. Blocks in either of the sparse formats Ferrite supports (`SparseMatrixCSC`
+   and `SparseMatrixCSR`) work, and so does any custom format implementing the internal
+   interface documented in the devdocs on assembly -- that interface is now phrased in terms of
+   explicit constraint data and index offsets, so the same methods serve a matrix on its own and
+   as a block of a blocked matrix, and the BlockArrays extension contains no format specific
+   code. As part of this, `apply!` and `apply_zero!` dispatch on `AbstractMatrix` rather than
+   `AbstractSparseMatrix`. ([#1486])
+ - `apply!` on a `SparseMatrixCSR` now supports affine constraints, which previously threw
+   `"condensation of ::SparseMatrixCSR{...} matrix not supported"`. ([#1486])
 
 ### Performance
  - `create_coloring` is significantly faster: the incidence matrix construction and the

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/benchmark/benchmarks-assembly.jl
+++ b/benchmark/benchmarks-assembly.jl
@@ -3,6 +3,7 @@
 #----------------------------------------------------------------------#
 using SparseArrays: SparseMatrixCSC
 using SparseMatricesCSR: SparseMatrixCSR
+using BlockArrays: BlockMatrix
 using LinearAlgebra: Symmetric
 
 SUITE["assembly"] = BenchmarkGroup()
@@ -82,6 +83,32 @@ let g = SUITE["assembly"]["global loop"]
         $assemble!($K, $f, $dh, $cv, $(FerriteBenchmarkHelpers.elasticity_kernel!), $C),
         evals = 1, seconds = 1.0,
     )
+
+    # A mixed u-p (Stokes) system assembled into a blocked matrix, i.e. one block per field,
+    # which is what the BlockArrays extension exists for.
+    quadgrid = generate_grid(Quadrilateral, (20, 20))
+    dh = DofHandler(quadgrid)
+    add!(dh, :u, Lagrange{RefQuadrilateral, 2}()^2)
+    add!(dh, :p, Lagrange{RefQuadrilateral, 1}())
+    close!(dh)
+    renumber!(dh, DofOrder.FieldWise())
+    cmv = MultiFieldCellValues(
+        QuadratureRule{RefQuadrilateral}(3),
+        (u = Lagrange{RefQuadrilateral, 2}()^2, p = Lagrange{RefQuadrilateral, 1}()),
+    )
+    ndu = 2 * (2 * 20 + 1)^2 # Lagrange{2}^2 on a 20×20 quadrilateral grid
+    ndp = (20 + 1)^2         # Lagrange{1} on the same grid
+    bsp = BlockSparsityPattern([ndu, ndp])
+    add_sparsity_entries!(bsp, dh)
+    KB = allocate_matrix(BlockMatrix, bsp)
+    fB = similar(KB, axes(KB, 1))
+    stokes! = FerriteBenchmarkHelpers.stokes_kernel!
+    range_u = dof_range(dh, :u)
+    range_p = dof_range(dh, :p)
+    g["Stokes Lagrange{2}²×Lagrange{1} BlockMatrix (Quadrilateral 20×20)"] = @benchmarkable(
+        $assemble!($KB, $fB, $dh, $cmv, $stokes!, $range_u, $range_p),
+        evals = 1, seconds = 1.0,
+    )
 end
 
 # Scatter-only loops with a precomputed element matrix, isolating the sparse `assemble!`
@@ -109,6 +136,27 @@ let g = SUITE["assembly"]["scatter"]
 
     Kcsr = allocate_matrix(SparseMatrixCSR{1, Float64, Int}, dh)
     g["SparseMatrixCSR (Quadrilateral 40×40)"] = @benchmarkable $scatter!($Kcsr, $dofs_batch, $Ke) evals = 1
+
+    # The blocked formats scatter block by block, so a mixed u-p system with the fields in
+    # separate blocks is what exercises them. The same system in an unblocked matrix is not
+    # benchmarked: it is the CSC/CSR path above at the same per-entry cost, only with a
+    # larger element matrix.
+    updh = DofHandler(grid)
+    add!(updh, :u, Lagrange{RefQuadrilateral, 2}()^2)
+    add!(updh, :p, Lagrange{RefQuadrilateral, 1}())
+    close!(updh)
+    renumber!(updh, DofOrder.FieldWise())
+    updofs_batch = FerriteBenchmarkHelpers.celldofs_batch(updh, getncells(grid))
+    upKe = rand(ndofs_per_cell(updh), ndofs_per_cell(updh))
+    ndu = 2 * (2 * 40 + 1)^2 # Lagrange{2}^2 on a 40×40 quadrilateral grid
+    ndp = (40 + 1)^2         # Lagrange{1} on the same grid
+    bsp = BlockSparsityPattern([ndu, ndp])
+    add_sparsity_entries!(bsp, updh)
+
+    for (name, BT) in ("CSC" => SparseMatrixCSC{Float64, Int}, "CSR" => SparseMatrixCSR{1, Float64, Int})
+        KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
+        g["BlockMatrix of $name (Quadrilateral 40×40, u-p)"] = @benchmarkable $scatter!($KB, $updofs_batch, $upKe) evals = 1
+    end
 end
 
 # Boundary load assembly: FacetIterator, FacetValues reinit! and vector scatter.

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -261,6 +261,30 @@ function elasticity_kernel!(Ke, cv, C)
     return Ke
 end
 
+# The (u, p) Stokes saddle point system. Unlike the single field kernels above this fills all
+# the coupling blocks of the element matrix, which is the shape of problem that a blocked
+# global matrix exists for. `range_u` and `range_p` are the `dof_range`s of the two fields.
+function stokes_kernel!(Ke, cmv, range_u, range_p)
+    fill!(Ke, 0)
+    cvu, cvp = cmv.u, cmv.p
+    for q_point in 1:getnquadpoints(cmv)
+        dΩ = getdetJdV(cmv, q_point)
+        for (i, I) in pairs(range_u)
+            ∇φi = shape_gradient(cvu, q_point, i)
+            divφi = shape_divergence(cvu, q_point, i)
+            for (j, J) in pairs(range_u)
+                Ke[I, J] += (∇φi ⊡ shape_gradient(cvu, q_point, j)) * dΩ
+            end
+            for (j, J) in pairs(range_p)
+                v = -divφi * shape_value(cvp, q_point, j) * dΩ
+                Ke[I, J] += v
+                Ke[J, I] += v
+            end
+        end
+    end
+    return Ke
+end
+
 # The divergence coupling block of a mixed u-p (Stokes-like) formulation, exercising
 # shape_divergence and per-field access into a MultiFieldCellValues.
 function mixed_divergence_kernel!(Ke, cmv)

--- a/docs/src/devdocs/assembly.md
+++ b/docs/src/devdocs/assembly.md
@@ -26,24 +26,53 @@ the internal interface
 ```@docs
 Ferrite.zero_out_rows!
 Ferrite.zero_out_columns!
-Ferrite._condense!
+Ferrite.add_inhomogeneities!
+Ferrite.condense_into!
+Ferrite.addindex!
 ```
 
 and the `AbstractMatrix` interface for their custom matrix type. [`apply!`](@ref) itself is
 generic and dispatches on `AbstractMatrix`, so a custom format is supported as soon as the
-functions above are dispatched -- there is no need to add an `apply!` method. Optional
-dispatches to speed up operations might be
+functions above are dispatched -- there is no need to add an `apply!` method.
+
+Each of these takes the constraint data explicitly and, where relevant, index offsets, rather
+than a [`ConstraintHandler`](@ref). That is deliberate: the very same methods are then used
+both for a matrix on its own and for a matrix used as a *block* of a blocked matrix, where the
+indices are block local and the offsets place the block in the global system. A format that
+implements them therefore works with the BlockArrays extension without any further work, and
+without that extension having to know anything about it.
+
+Two conventions are worth calling out:
+
+- `zero_out_rows!` and `zero_out_columns!` receive the set of indices to zero **twice**, once
+  as a sorted list and once as a boolean mask. Which one can be used efficiently depends on the
+  storage: a column-compressed format walks the listed columns directly, while a row-compressed
+  format has to scan its stored column indices against the mask. Passing both avoids forcing
+  every format to build the representation it does not have.
+- `condense_into!` writes into a *destination* matrix that is not necessarily the matrix it
+  reads, which is what lets a block condense into the blocked matrix it belongs to. It only has
+  to handle the matrix; the right-hand side is condensed separately by
+  [`Ferrite._condense!`](@ref), so the order in which stored entries are visited does not
+  matter.
+
+Finally, [`Ferrite._condense!`](@ref) itself is dispatched per format, but is a one-liner over
+`Ferrite.condense_into!` for anything that implements it:
 
 ```@docs
-Ferrite.add_inhomogeneities!
+Ferrite._condense!
 ```
 
-The kernels backing the CSC implementations of the above take the prescribed dofs and the
-constrained mask directly instead of the [`ConstraintHandler`](@ref), so that a matrix built
-from CSC blocks can reuse them per block by passing block local indices. See
-`Ferrite._zero_out_columns!`, `Ferrite._zero_out_rows!`,
-`Ferrite._add_inhomogeneities_cols!` and `Ferrite._condense_column!`, and the BlockArrays
-extension for an example of how they are composed.
+CSC and CSR are mirror images of one another -- one stores columns contiguously, the other
+rows -- so their implementations of the above are shared, parameterised by which index is the
+contiguous one. `Ferrite.minor_indices` is the accessor that abstracts the difference:
+
+```@docs
+Ferrite.minor_indices
+```
+
+This is an implementation detail of those two formats, not part of the interface. A format that
+does not store scalar entries in flat arrays parallel to `nonzeros` -- a blocked format such as
+BSR, say -- simply implements the interface functions directly and never defines it.
 
 ## Custom assembler
 

--- a/docs/src/devdocs/assembly.md
+++ b/docs/src/devdocs/assembly.md
@@ -29,11 +29,21 @@ Ferrite.zero_out_columns!
 Ferrite._condense!
 ```
 
-and the `AbstractSparseMatrix` interface for their custom matrix type. Optional dispatches to speed up operations might be
+and the `AbstractMatrix` interface for their custom matrix type. [`apply!`](@ref) itself is
+generic and dispatches on `AbstractMatrix`, so a custom format is supported as soon as the
+functions above are dispatched -- there is no need to add an `apply!` method. Optional
+dispatches to speed up operations might be
 
 ```@docs
 Ferrite.add_inhomogeneities!
 ```
+
+The kernels backing the CSC implementations of the above take the prescribed dofs and the
+constrained mask directly instead of the [`ConstraintHandler`](@ref), so that a matrix built
+from CSC blocks can reuse them per block by passing block local indices. See
+`Ferrite._zero_out_columns!`, `Ferrite._zero_out_rows!`,
+`Ferrite._add_inhomogeneities_cols!` and `Ferrite._condense_column!`, and the BlockArrays
+extension for an example of how they are composed.
 
 ## Custom assembler
 
@@ -49,6 +59,11 @@ For local elimination support the following functions might also need custom dis
 ```@docs
 Ferrite._condense_local!
 ```
+
+Note that [`apply_assemble!`](@ref) passes the assembler's `atomic` flag on to
+`Ferrite._condense_local!`, so a custom assembler supporting atomic accumulation should
+report it through `Ferrite._is_atomic` in order to make the global writes of non-local
+constraints concurrency-safe as well.
 
 ## Type definitions
 

--- a/docs/src/devdocs/assembly.md
+++ b/docs/src/devdocs/assembly.md
@@ -29,21 +29,29 @@ Ferrite.zero_out_columns!
 Ferrite.add_inhomogeneities!
 Ferrite.condense_into!
 Ferrite.addindex!
+Ferrite._assemble_inner!
 ```
 
 and the `AbstractMatrix` interface for their custom matrix type. [`apply!`](@ref) itself is
 generic and dispatches on `AbstractMatrix`, so a custom format is supported as soon as the
 functions above are dispatched -- there is no need to add an `apply!` method.
 
-Each of these takes the constraint data explicitly and, where relevant, index offsets, rather
-than a [`ConstraintHandler`](@ref). That is deliberate: the very same methods are then used
-both for a matrix on its own and for a matrix used as a *block* of a blocked matrix, where the
-indices are block local and the offsets place the block in the global system. A format that
-implements them therefore works with the BlockArrays extension without any further work, and
-without that extension having to know anything about it.
+Each of these takes its data -- an element matrix or the constraint data -- explicitly, plus
+index offsets where relevant, rather than an assembler or a [`ConstraintHandler`](@ref). That
+is deliberate: the very same methods are then used both for a matrix on its own and for a
+matrix used as a *block* of a blocked matrix, where the indices are block local and the
+offsets place the block in the global system. A format that implements them therefore works
+with the BlockArrays extension without any further work, and without that extension having to
+know anything about it.
 
-Two conventions are worth calling out:
+Three conventions are worth calling out:
 
+- `_assemble_inner!` is the only one of these with a working default implementation: it
+  writes the element matrix entry by entry with `addindex!`, so a format is assembled into as
+  soon as it implements that. Specializing it pays off for a format that stores its entries
+  sorted, since the element matrix and the stored entries can then be walked in a single pass
+  instead of searching for each entry -- which is what makes it worth roughly a factor of
+  three for CSC and CSR.
 - `zero_out_rows!` and `zero_out_columns!` receive the set of indices to zero **twice**, once
   as a sorted list and once as a boolean mask. Which one can be used efficiently depends on the
   storage: a column-compressed format walks the listed columns directly, while a row-compressed

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -1,7 +1,7 @@
 module FerriteBlockArrays
 
 using BlockArrays: Block, BlockArray, BlockIndex, BlockMatrix, BlockVector, block,
-    blockaxes, blockindex, blocks, findblockindex, undef_blocks
+    blockaxes, blockindex, blocks, blocksize, findblockindex, undef_blocks
 using Ferrite:
     Ferrite, BlockSparsityPattern, ConstraintHandler, addindex!, allocate_matrix, assemble!,
     fillzero!, DofCoefficients, _is_atomic
@@ -62,7 +62,9 @@ end
 struct BlockAssembler{Tv, BM <: BlockMatrix{Tv}, Bv <: AbstractVector{Tv}, atomic} <: Ferrite.AbstractAssembler{Tv}
     K::BM
     f::Bv
-    blockindices::Vector{BlockIndex{1}}
+    sorteddofs::Vector{Int}  # cell dofs, sorted and made local to their block
+    permutation::Vector{Int} # sorted position -> index into the element matrix
+    blockstops::Vector{Int}  # block -> last position in `sorteddofs` belonging to it
 end
 
 Ferrite.matrix_handle(ba::BlockAssembler) = ba.K
@@ -73,18 +75,42 @@ Ferrite.vector_handle(ba::BlockAssembler) = ba.f
 Base.@constprop :aggressive function Ferrite.start_assemble(K::BlockMatrix{Tv}, f::AbstractVector = Tv[]; fillzero::Bool = true, atomic::Bool = false) where {Tv}
     Ferrite._check_atomic_eltype(atomic, eltype(K))
     fillzero && (fillzero!(K); fillzero!(f))
-    return BlockAssembler{eltype(K), typeof(K), typeof(f), atomic}(K, f, BlockIndex{1}[])
+    return BlockAssembler{eltype(K), typeof(K), typeof(f), atomic}(K, f, Int[], Int[], Int[])
 end
 
-# Split into the block and the local index
-splindex(idx::BlockIndex{1}) = (block(idx), blockindex(idx))
+# The global index range of block `B` along axis `d`.
+blockrange(K::BlockMatrix, d::Int, B::Block{1}) = axes(K, d)[B]
+
+# Split the (sorted) cell dofs into the per-block, block local dof lists that each block's
+# scatter needs. Since the blocks partition the axis into consecutive index ranges, dofs
+# sorted ascending are also grouped by block, so each block's dofs are a consecutive slice
+# `blockstops[b - 1] + 1 : blockstops[b]` of `sorteddofs`. Returns the number of blocks.
+function split_into_blocks!(sorteddofs::Vector{Int}, blockstops::Vector{Int}, K::BlockMatrix)
+    nblocks = blocksize(K, 1)
+    resize!(blockstops, nblocks)
+    stop = 0
+    @inbounds for b in 1:nblocks
+        rng = blockrange(K, 1, Block(b))
+        start = stop + 1
+        stop = searchsortedlast(sorteddofs, last(rng))
+        offset = first(rng) - 1
+        for k in start:stop
+            sorteddofs[k] -= offset
+        end
+        blockstops[b] = stop
+    end
+    return nblocks
+end
+
+# The slice of `sorteddofs` belonging to block `b`.
+blockslice(blockstops::Vector{Int}, b::Int) = @inbounds (b == 1 ? 1 : blockstops[b - 1] + 1):blockstops[b]
 
 function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Integer}, ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
     atomic = Val(_is_atomic(assembler))
 
     K = assembler.K
     f = assembler.f
-    blockindices = assembler.blockindices
+    blockstops = assembler.blockstops
 
     @assert blockaxes(K, 1) == blockaxes(K, 2)
     @assert axes(K, 1) == axes(K, 2)
@@ -92,30 +118,43 @@ function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Int
     @boundscheck checkbounds(K, dofs, dofs)
     @boundscheck fe === nothing || checkbounds(f, dofs)
 
-    # Update the cached the block indices
-    resize!(blockindices, length(dofs))
-    @inbounds for (i, I) in pairs(dofs)
-        blockindices[i] = findblockindex(axes(K, 1), I)
-    end
+    sorteddofs, permutation = Ferrite._sortdofs_for_assembly!(assembler.permutation, assembler.sorteddofs, dofs)
+    nblocks = split_into_blocks!(sorteddofs, blockstops, K)
 
-    # Assemble matrix entries
-    @inbounds for (j, blockindex_j) in pairs(blockindices)
-        Bj, lj = splindex(blockindex_j)
-        for (i, blockindex_i) in pairs(blockindices)
-            Bi, li = splindex(blockindex_i)
-            KB = @view K[Bi, Bj]
-            addindex!(KB, ke[i, j], li, lj, atomic)
+    # Assemble matrix entries. Each block scatters the part of `ke` that belongs to it
+    # through the same `_assemble_inner!` the unblocked assemblers use, so a block format
+    # needs nothing beyond what it already implements to be assembled into as a block.
+    Kblocks = blocks(K)
+    @inbounds for bj in 1:nblocks
+        cols = blockslice(blockstops, bj)
+        isempty(cols) && continue
+        coloffset = first(blockrange(K, 2, Block(bj))) - 1
+        sortedcoldofs = view(sorteddofs, cols)
+        colpermutation = view(permutation, cols)
+        for bi in 1:nblocks
+            rows = blockslice(blockstops, bi)
+            isempty(rows) && continue
+            rowoffset = first(blockrange(K, 1, Block(bi))) - 1
+            sortedrowdofs = view(sorteddofs, rows)
+            rowpermutation = view(permutation, rows)
+            Ferrite._assemble_inner!(
+                Kblocks[bi, bj], ke,
+                sortedrowdofs, sortedrowdofs, rowpermutation,
+                sortedcoldofs, sortedcoldofs, colpermutation,
+                false, atomic, rowoffset, coloffset,
+            )
         end
     end
 
     # Assemble vector entries
     if fe !== nothing
         if blockaxes(f, 1) == blockaxes(K, 1)
-            # If f::BlockVector with the same axes the same blockindex cache can be used...
-            @inbounds for (i, blockindex_i) in pairs(blockindices)
-                Bi, li = splindex(blockindex_i)
-                fB = @view f[Bi]
-                addindex!(fB, fe[i], li, atomic)
+            # If f::BlockVector with the same axes the block splitting above can be reused...
+            @inbounds for bi in 1:nblocks
+                fb = view(f, Block(bi))
+                for k in blockslice(blockstops, bi)
+                    addindex!(fb, fe[permutation[k]], sorteddofs[k], atomic)
+                end
             end
         else
             # ... otherwise, use regular indexing in fallback assemble!
@@ -137,9 +176,6 @@ Ferrite._is_atomic(::BlockAssembler{<:Any, <:Any, <:Any, atomic}) where {atomic}
 # and forwards to the *same* interface function on the block, so this file knows nothing about
 # how a block stores its entries -- supporting a new format is a matter of implementing that
 # interface for it, with no change here. See the devdocs on assembly for the interface.
-
-# The global index range of block `B` along axis `d`.
-blockrange(K::BlockMatrix, d::Int, B::Block{1}) = axes(K, d)[B]
 
 # `prescribed_dofs` is sorted, so the dofs inside the (contiguous) index range `rng` form a
 # contiguous slice of it. Returns the indices into `prescribed_dofs`, i.e. also the indices
@@ -227,12 +263,14 @@ end
 ## Overloaded assembly pieces from src/arrayutils.jl ##
 #######################################################
 
+# Split a global index into the number of the block holding it and its index within that block
+splindex(idx::BlockIndex{1}) = (Int(block(idx).n[1]), Int(blockindex(idx)))
+
 function Ferrite.addindex!(B::BlockMatrix{Tv}, v::Tv, i::Int, j::Int, ::Val{atomic} = Val(false)) where {Tv, atomic}
     @boundscheck checkbounds(B, i, j)
-    Bi, li = splindex(findblockindex(axes(B, 1), i))
-    Bj, lj = splindex(findblockindex(axes(B, 2), j))
-    BB = @view B[Bi, Bj]
-    @inbounds addindex!(BB, v, li, lj, Val{atomic}())
+    bi, li = splindex(findblockindex(axes(B, 1), i))
+    bj, lj = splindex(findblockindex(axes(B, 2), j))
+    @inbounds addindex!(blocks(B)[bi, bj], v, li, lj, Val{atomic}())
     return B
 end
 
@@ -240,9 +278,8 @@ end
 # `Ferrite._condense_local!` reach the atomic accumulation in the underlying block.
 function Ferrite.addindex!(B::BlockVector{Tv}, v::Tv, i::Int, ::Val{atomic} = Val(false)) where {Tv, atomic}
     @boundscheck checkbounds(B, i)
-    Bi, li = splindex(findblockindex(axes(B, 1), i))
-    BB = @view B[Bi]
-    @inbounds addindex!(BB, v, li, Val{atomic}())
+    bi, li = splindex(findblockindex(axes(B, 1), i))
+    @inbounds addindex!(blocks(B)[bi], v, li, Val{atomic}())
     return B
 end
 

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -6,8 +6,10 @@ using BlockArrays: Block, BlockArray, BlockIndex, BlockMatrix, BlockVector, bloc
     blockaxes, blockindex, blocks, findblockindex, undef_blocks
 using Ferrite:
     Ferrite, BlockSparsityPattern, ConstraintHandler, addindex!, allocate_matrix, assemble!,
-    fillzero!, _is_atomic
-using SparseArrays: SparseMatrixCSC
+    fillzero!, DofCoefficients, _add_inhomogeneities_cols!, _condense_column!,
+    _condense_rhs_column!, _is_atomic, _zero_out_columns!, _zero_out_rows!,
+    coefficients_for_dof
+using SparseArrays: AbstractSparseMatrixCSC, SparseMatrixCSC
 
 
 ##############################
@@ -70,7 +72,9 @@ end
 Ferrite.matrix_handle(ba::BlockAssembler) = ba.K
 Ferrite.vector_handle(ba::BlockAssembler) = ba.f
 
-Base.@constprop :aggressive function Ferrite.start_assemble(K::BlockMatrix, f; fillzero::Bool = true, atomic = false)
+# See src/assembler.jl for the `@constprop` annotation (concrete return type for literal `atomic`).
+Base.@constprop :aggressive function Ferrite.start_assemble(K::BlockMatrix, f; fillzero::Bool = true, atomic::Bool = false)
+    Ferrite._check_atomic_eltype(atomic, eltype(K))
     fillzero && (fillzero!(K); fillzero!(f))
     return BlockAssembler{eltype(K), typeof(K), typeof(f), atomic}(K, f, BlockIndex{1}[])
 end
@@ -116,19 +120,110 @@ function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Int
         end
     else
         # ... otherwise, use regular indexing in fallback assemble!
-        @inbounds assemble!(f, dofs, fe)
+        @inbounds assemble!(f, dofs, fe, atomic)
     end
     return
 end
 
-function Ferrite.apply!(::BlockMatrix, ::AbstractVector, ::ConstraintHandler)
-    error(
-        "Condensation of constraints with `apply!` after assembling not supported yet " *
-            "for BlockMatrix, use local condensation with `apply_assemble!` instead."
-    )
+Ferrite._is_atomic(::BlockAssembler{<:Any, <:Any, <:Any, atomic}) where {atomic} = atomic::Bool
+
+
+########################################################
+## Application of constraints (see `Ferrite.apply!`)  ##
+########################################################
+
+# `Ferrite.apply!` itself is generic over the matrix type; what a blocked matrix has to
+# provide are the hooks below. Every block is a sparse matrix in CSC storage (that is what
+# `allocate_matrix` produces above), so each hook is a loop over the blocks that delegates to
+# the corresponding Ferrite kernel with block local indices. Blocks in another storage format
+# fall back to Ferrite's generic methods, which error rather than silently running a dense
+# algorithm.
+const SparseBlockMatrix = BlockMatrix{<:Any, <:AbstractMatrix{<:AbstractSparseMatrixCSC}}
+
+# The global index range of block `B` along axis `d`.
+blockrange(K::BlockMatrix, d::Int, B::Block{1}) = axes(K, d)[B]
+
+# `prescribed_dofs` is sorted, so the dofs inside the (contiguous) index range `rng` form a
+# contiguous slice of it. Returns the indices into `prescribed_dofs`, i.e. also the indices
+# into `ch.inhomogeneities`.
+function prescribed_range(prescribed_dofs::AbstractVector{<:Integer}, rng::AbstractUnitRange)
+    lo = searchsortedfirst(prescribed_dofs, first(rng))
+    hi = searchsortedlast(prescribed_dofs, last(rng))
+    return lo:hi
 end
 
-Ferrite._is_atomic(::BlockAssembler{<:Any, <:Any, <:Any, atomic}) where {atomic} = atomic::Bool
+function Ferrite.zero_out_columns!(K::SparseBlockMatrix, ch::ConstraintHandler)
+    for Bj in blockaxes(K, 2)
+        cols = blockrange(K, 2, Bj)
+        idxs = prescribed_range(ch.prescribed_dofs, cols)
+        isempty(idxs) && continue
+        local_dofs = ch.prescribed_dofs[idxs] .- (first(cols) - 1)
+        for Bi in blockaxes(K, 1)
+            _zero_out_columns!(@view(K[Bi, Bj]), local_dofs)
+        end
+    end
+    return
+end
+
+function Ferrite.zero_out_rows!(K::SparseBlockMatrix, ch::ConstraintHandler)
+    for Bi in blockaxes(K, 1)
+        isconstrained = view(ch.isconstrained, blockrange(K, 1, Bi))
+        for Bj in blockaxes(K, 2)
+            _zero_out_rows!(@view(K[Bi, Bj]), isconstrained)
+        end
+    end
+    return
+end
+
+# Compute "f -= K*inhomogeneities" block by block. The generic fallback would go through
+# LinearAlgebra's scalar indexing matvec for a BlockMatrix, which is O(ndofs^2).
+function Ferrite.add_inhomogeneities!(f::AbstractVector, K::SparseBlockMatrix, ch::ConstraintHandler)
+    for Bj in blockaxes(K, 2)
+        cols = blockrange(K, 2, Bj)
+        idxs = prescribed_range(ch.prescribed_dofs, cols)
+        isempty(idxs) && continue
+        local_dofs = ch.prescribed_dofs[idxs] .- (first(cols) - 1)
+        inhomogeneities = view(ch.inhomogeneities, idxs)
+        for Bi in blockaxes(K, 1)
+            fi = view(f, blockrange(K, 1, Bi))
+            _add_inhomogeneities_cols!(fi, @view(K[Bi, Bj]), local_dofs, inhomogeneities, false)
+        end
+    end
+    return f
+end
+
+# Condense K := (C' * K * C) and f := (C' * f). The blocks are visited in the order of the
+# global dofs, so the entries are traversed exactly like in the `SparseMatrixCSC` version.
+function Ferrite._condense!(K::SparseBlockMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
+    condense_f = !(length(f) == 0)
+    condense_f && @assert(length(f) == size(K, 1))
+
+    # Return early if there are no non-trivial affine constraints
+    any(i -> !(i === nothing || isempty(i)), dofcoefficients) || return
+
+    if sym
+        error("condensation of ::Symmetric matrix not supported")
+    end
+
+    for Bj in blockaxes(K, 2)
+        cols = blockrange(K, 2, Bj)
+        coloffset = first(cols) - 1
+        for localcol in 1:length(cols)
+            col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, localcol + coloffset)
+            for Bi in blockaxes(K, 1)
+                rowoffset = first(blockrange(K, 1, Bi)) - 1
+                _condense_column!(
+                    K, @view(K[Bi, Bj]), localcol, rowoffset, coloffset,
+                    col_coeffs, dofcoefficients, dofmapping,
+                )
+            end
+            if col_coeffs !== nothing && condense_f
+                _condense_rhs_column!(f, localcol + coloffset, col_coeffs)
+            end
+        end
+    end
+    return
+end
 
 #######################################################
 ## Overloaded assembly pieces from src/arrayutils.jl ##
@@ -140,6 +235,16 @@ function Ferrite.addindex!(B::BlockMatrix{Tv}, v::Tv, i::Int, j::Int, ::Val{atom
     Bj, lj = splindex(findblockindex(axes(B, 2), j))
     BB = @view B[Bi, Bj]
     @inbounds addindex!(BB, v, li, lj, Val{atomic}())
+    return B
+end
+
+# Vector analogue of the method above, needed so that the global vector writes in
+# `Ferrite._condense_local!` reach the atomic accumulation in the underlying block.
+function Ferrite.addindex!(B::BlockVector{Tv}, v::Tv, i::Int, ::Val{atomic} = Val(false)) where {Tv, atomic}
+    @boundscheck checkbounds(B, i)
+    Bi, li = splindex(findblockindex(axes(B, 1), i))
+    BB = @view B[Bi]
+    @inbounds addindex!(BB, v, li, Val{atomic}())
     return B
 end
 

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -6,10 +6,8 @@ using BlockArrays: Block, BlockArray, BlockIndex, BlockMatrix, BlockVector, bloc
     blockaxes, blockindex, blocks, findblockindex, undef_blocks
 using Ferrite:
     Ferrite, BlockSparsityPattern, ConstraintHandler, addindex!, allocate_matrix, assemble!,
-    fillzero!, DofCoefficients, _add_inhomogeneities_cols!, _condense_column!,
-    _condense_rhs_column!, _is_atomic, _zero_out_columns!, _zero_out_rows!,
-    coefficients_for_dof
-using SparseArrays: AbstractSparseMatrixCSC, SparseMatrixCSC
+    fillzero!, DofCoefficients, _is_atomic
+using SparseArrays: SparseMatrixCSC
 
 
 ##############################
@@ -132,13 +130,11 @@ Ferrite._is_atomic(::BlockAssembler{<:Any, <:Any, <:Any, atomic}) where {atomic}
 ## Application of constraints (see `Ferrite.apply!`)  ##
 ########################################################
 
-# `Ferrite.apply!` itself is generic over the matrix type; what a blocked matrix has to
-# provide are the hooks below. Every block is a sparse matrix in CSC storage (that is what
-# `allocate_matrix` produces above), so each hook is a loop over the blocks that delegates to
-# the corresponding Ferrite kernel with block local indices. Blocks in another storage format
-# fall back to Ferrite's generic methods, which error rather than silently running a dense
-# algorithm.
-const SparseBlockMatrix = BlockMatrix{<:Any, <:AbstractMatrix{<:AbstractSparseMatrixCSC}}
+# `Ferrite.apply!` is generic over the matrix type; what a blocked matrix has to provide are the
+# hooks below. Each is a loop over the blocks that slices the constraint data down to the block
+# and forwards to the *same* interface function on the block, so this file knows nothing about
+# how a block stores its entries -- supporting a new format is a matter of implementing that
+# interface for it, with no change here. See the devdocs on assembly for the interface.
 
 # The global index range of block `B` along axis `d`.
 blockrange(K::BlockMatrix, d::Int, B::Block{1}) = axes(K, d)[B]
@@ -152,24 +148,32 @@ function prescribed_range(prescribed_dofs::AbstractVector{<:Integer}, rng::Abstr
     return lo:hi
 end
 
-function Ferrite.zero_out_columns!(K::SparseBlockMatrix, ch::ConstraintHandler)
+# The prescribed dofs inside the index range `rng`, renumbered to be local to it.
+function local_prescribed_dofs(prescribed_dofs::AbstractVector{<:Integer}, rng::AbstractUnitRange)
+    return prescribed_dofs[prescribed_range(prescribed_dofs, rng)] .- (first(rng) - 1)
+end
+
+function Ferrite.zero_out_columns!(K::BlockMatrix, ch::ConstraintHandler)
     for Bj in blockaxes(K, 2)
         cols = blockrange(K, 2, Bj)
-        idxs = prescribed_range(ch.prescribed_dofs, cols)
-        isempty(idxs) && continue
-        local_dofs = ch.prescribed_dofs[idxs] .- (first(cols) - 1)
+        local_dofs = local_prescribed_dofs(ch.prescribed_dofs, cols)
+        mask = view(ch.isconstrained, cols)
+        isempty(local_dofs) && continue
         for Bi in blockaxes(K, 1)
-            _zero_out_columns!(@view(K[Bi, Bj]), local_dofs)
+            Ferrite.zero_out_columns!(@view(K[Bi, Bj]), local_dofs, mask)
         end
     end
     return
 end
 
-function Ferrite.zero_out_rows!(K::SparseBlockMatrix, ch::ConstraintHandler)
+function Ferrite.zero_out_rows!(K::BlockMatrix, ch::ConstraintHandler)
     for Bi in blockaxes(K, 1)
-        isconstrained = view(ch.isconstrained, blockrange(K, 1, Bi))
+        rows = blockrange(K, 1, Bi)
+        local_dofs = local_prescribed_dofs(ch.prescribed_dofs, rows)
+        mask = view(ch.isconstrained, rows)
+        isempty(local_dofs) && continue
         for Bj in blockaxes(K, 2)
-            _zero_out_rows!(@view(K[Bi, Bj]), isconstrained)
+            Ferrite.zero_out_rows!(@view(K[Bi, Bj]), local_dofs, mask)
         end
     end
     return
@@ -177,7 +181,7 @@ end
 
 # Compute "f -= K*inhomogeneities" block by block. The generic fallback would go through
 # LinearAlgebra's scalar indexing matvec for a BlockMatrix, which is O(ndofs^2).
-function Ferrite.add_inhomogeneities!(f::AbstractVector, K::SparseBlockMatrix, ch::ConstraintHandler)
+function Ferrite.add_inhomogeneities!(f::AbstractVector, K::BlockMatrix, ch::ConstraintHandler)
     for Bj in blockaxes(K, 2)
         cols = blockrange(K, 2, Bj)
         idxs = prescribed_range(ch.prescribed_dofs, cols)
@@ -186,15 +190,16 @@ function Ferrite.add_inhomogeneities!(f::AbstractVector, K::SparseBlockMatrix, c
         inhomogeneities = view(ch.inhomogeneities, idxs)
         for Bi in blockaxes(K, 1)
             fi = view(f, blockrange(K, 1, Bi))
-            _add_inhomogeneities_cols!(fi, @view(K[Bi, Bj]), local_dofs, inhomogeneities, false)
+            Ferrite.add_inhomogeneities!(fi, @view(K[Bi, Bj]), local_dofs, inhomogeneities)
         end
     end
     return f
 end
 
-# Condense K := (C' * K * C) and f := (C' * f). The blocks are visited in the order of the
-# global dofs, so the entries are traversed exactly like in the `SparseMatrixCSC` version.
-function Ferrite._condense!(K::SparseBlockMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
+# Condense K := (C' * K * C) and f := (C' * f). Each block condenses its own stored entries
+# into `K`, in whichever order suits its storage; the rhs is condensed once at the end, which
+# is what makes the block (and within-block) traversal order irrelevant.
+function Ferrite._condense!(K::BlockMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
     condense_f = !(length(f) == 0)
     condense_f && @assert(length(f) == size(K, 1))
 
@@ -206,22 +211,13 @@ function Ferrite._condense!(K::SparseBlockMatrix, f::AbstractVector, dofcoeffici
     end
 
     for Bj in blockaxes(K, 2)
-        cols = blockrange(K, 2, Bj)
-        coloffset = first(cols) - 1
-        for localcol in 1:length(cols)
-            col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, localcol + coloffset)
-            for Bi in blockaxes(K, 1)
-                rowoffset = first(blockrange(K, 1, Bi)) - 1
-                _condense_column!(
-                    K, @view(K[Bi, Bj]), localcol, rowoffset, coloffset,
-                    col_coeffs, dofcoefficients, dofmapping,
-                )
-            end
-            if col_coeffs !== nothing && condense_f
-                _condense_rhs_column!(f, localcol + coloffset, col_coeffs)
-            end
+        coloffset = first(blockrange(K, 2, Bj)) - 1
+        for Bi in blockaxes(K, 1)
+            rowoffset = first(blockrange(K, 1, Bi)) - 1
+            Ferrite.condense_into!(K, @view(K[Bi, Bj]), rowoffset, coloffset, dofcoefficients, dofmapping)
         end
     end
+    condense_f && Ferrite._condense_rhs_columns!(f, dofcoefficients, dofmapping)
     return
 end
 

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -1,7 +1,5 @@
 module FerriteBlockArrays
 
-using BlockArrays: BlockArray, BlockIndex, BlockMatrix, BlockVector, block, blockaxes,
-    blockindex, blocks, findblockindex
 using BlockArrays: Block, BlockArray, BlockIndex, BlockMatrix, BlockVector, block,
     blockaxes, blockindex, blocks, findblockindex, undef_blocks
 using Ferrite:
@@ -179,18 +177,18 @@ function Ferrite.zero_out_rows!(K::BlockMatrix, ch::ConstraintHandler)
     return
 end
 
-# Compute "f -= K*inhomogeneities" block by block. The generic fallback would go through
-# LinearAlgebra's scalar indexing matvec for a BlockMatrix, which is O(ndofs^2).
-function Ferrite.add_inhomogeneities!(f::AbstractVector, K::BlockMatrix, ch::ConstraintHandler)
+# Compute "f -= K*g" block by block. The generic fallback would go through LinearAlgebra's
+# scalar indexing matvec for a BlockMatrix, which is O(ndofs^2).
+function Ferrite.add_inhomogeneities!(f::AbstractVector, K::BlockMatrix, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
     for Bj in blockaxes(K, 2)
         cols = blockrange(K, 2, Bj)
-        idxs = prescribed_range(ch.prescribed_dofs, cols)
+        idxs = prescribed_range(columns, cols)
         isempty(idxs) && continue
-        local_dofs = ch.prescribed_dofs[idxs] .- (first(cols) - 1)
-        inhomogeneities = view(ch.inhomogeneities, idxs)
+        local_dofs = columns[idxs] .- (first(cols) - 1)
+        local_inhomogeneities = view(inhomogeneities, idxs)
         for Bi in blockaxes(K, 1)
             fi = view(f, blockrange(K, 1, Bi))
-            Ferrite.add_inhomogeneities!(fi, @view(K[Bi, Bj]), local_dofs, inhomogeneities)
+            Ferrite.add_inhomogeneities!(fi, @view(K[Bi, Bj]), local_dofs, local_inhomogeneities)
         end
     end
     return f

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -115,6 +115,8 @@ function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Int
     @assert blockaxes(K, 1) == blockaxes(K, 2)
     @assert axes(K, 1) == axes(K, 2)
     @assert fe === nothing || axes(f, 1) == axes(K, 1)
+    @boundscheck checkbounds(ke, keys(dofs), keys(dofs))
+    @boundscheck fe === nothing || checkbounds(fe, keys(dofs))
     @boundscheck checkbounds(K, dofs, dofs)
     @boundscheck fe === nothing || checkbounds(f, dofs)
 

--- a/ext/FerriteBlockArrays.jl
+++ b/ext/FerriteBlockArrays.jl
@@ -69,7 +69,8 @@ Ferrite.matrix_handle(ba::BlockAssembler) = ba.K
 Ferrite.vector_handle(ba::BlockAssembler) = ba.f
 
 # See src/assembler.jl for the `@constprop` annotation (concrete return type for literal `atomic`).
-Base.@constprop :aggressive function Ferrite.start_assemble(K::BlockMatrix, f; fillzero::Bool = true, atomic::Bool = false)
+# As for the other formats, `f` may be left out to assemble the matrix only.
+Base.@constprop :aggressive function Ferrite.start_assemble(K::BlockMatrix{Tv}, f::AbstractVector = Tv[]; fillzero::Bool = true, atomic::Bool = false) where {Tv}
     Ferrite._check_atomic_eltype(atomic, eltype(K))
     fillzero && (fillzero!(K); fillzero!(f))
     return BlockAssembler{eltype(K), typeof(K), typeof(f), atomic}(K, f, BlockIndex{1}[])
@@ -78,7 +79,7 @@ end
 # Split into the block and the local index
 splindex(idx::BlockIndex{1}) = (block(idx), blockindex(idx))
 
-function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Integer}, ke::AbstractMatrix, fe::AbstractVector)
+function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Integer}, ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
     atomic = Val(_is_atomic(assembler))
 
     K = assembler.K
@@ -86,9 +87,10 @@ function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Int
     blockindices = assembler.blockindices
 
     @assert blockaxes(K, 1) == blockaxes(K, 2)
-    @assert axes(K, 1) == axes(K, 2) == axes(f, 1)
+    @assert axes(K, 1) == axes(K, 2)
+    @assert fe === nothing || axes(f, 1) == axes(K, 1)
     @boundscheck checkbounds(K, dofs, dofs)
-    @boundscheck checkbounds(f, dofs)
+    @boundscheck fe === nothing || checkbounds(f, dofs)
 
     # Update the cached the block indices
     resize!(blockindices, length(dofs))
@@ -107,16 +109,18 @@ function Ferrite.assemble!(assembler::BlockAssembler, dofs::AbstractVector{<:Int
     end
 
     # Assemble vector entries
-    if blockaxes(f, 1) == blockaxes(K, 1)
-        # If f::BlockVector with the same axes the same blockindex cache can be used...
-        @inbounds for (i, blockindex_i) in pairs(blockindices)
-            Bi, li = splindex(blockindex_i)
-            fB = @view f[Bi]
-            addindex!(fB, fe[i], li, atomic)
+    if fe !== nothing
+        if blockaxes(f, 1) == blockaxes(K, 1)
+            # If f::BlockVector with the same axes the same blockindex cache can be used...
+            @inbounds for (i, blockindex_i) in pairs(blockindices)
+                Bi, li = splindex(blockindex_i)
+                fB = @view f[Bi]
+                addindex!(fB, fe[i], li, atomic)
+            end
+        else
+            # ... otherwise, use regular indexing in fallback assemble!
+            @inbounds assemble!(f, dofs, fe, atomic)
         end
-    else
-        # ... otherwise, use regular indexing in fallback assemble!
-        @inbounds assemble!(f, dofs, fe, atomic)
     end
     return
 end

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -16,7 +16,7 @@ end
         K::SparseMatrixCSR, Ke::AbstractMatrix,
         rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
-        sym::Bool, atomic::Val = Val(false)
+        sym::Bool, atomic::Val = Val(false), rowoffset::Int = 0, coloffset::Int = 0
     )
     current_row = 1
     ld = length(coldofs)
@@ -53,7 +53,7 @@ end
                 else
                     # No entry exists in the global matrix for this column, which is
                     # allowed as long as the value which would have been inserted is zero.
-                    iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kecol_dof)
+                    iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow + rowoffset, Kecol_dof + coloffset)
                     lo = C
                 end
             end
@@ -78,7 +78,7 @@ end
             else # Kcol > Kecol_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow, Kecol_dof)
+                iszero(Ke[Kerow, colpermutation[ci]]) || Ferrite._missing_sparsity_pattern_error(Krow + rowoffset, Kecol_dof + coloffset)
                 # Advance the local matrix row pointer
                 ci += 1
             end
@@ -86,7 +86,7 @@ end
         # Make sure that remaining entries in this column of the local matrix are all zero
         for i in ci:maxlookups
             if !iszero(Ke[Kerow, colpermutation[i]])
-                Ferrite._missing_sparsity_pattern_error(Krow, sortedcoldofs[i])
+                Ferrite._missing_sparsity_pattern_error(Krow + rowoffset, sortedcoldofs[i] + coloffset)
             end
         end
         current_row += 1

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -1,7 +1,7 @@
 module FerriteSparseMatrixCSR
 
 using Ferrite, SparseArrays, SparseMatricesCSR
-import Ferrite: AbstractSparsityPattern, CSRAssembler, getnrows, getncols
+import Ferrite: AbstractSparsityPattern, CSRAssembler, DofCoefficients, getnrows, getncols
 import Base: @propagate_inbounds
 
 # Could be generalized if https://github.com/JuliaSparse/SparseArrays.jl/pull/546 is merged
@@ -93,37 +93,63 @@ end
     end
 end
 
+###########################################################
+## Constraint application (see the devdocs on assembly)  ##
+###########################################################
+
+# CSR is the mirror image of CSC: the rows are stored contiguously ("the majors") and the
+# stored column indices are the minors. That is all the shared kernels in Ferrite need to know,
+# so every method below is a one-liner picking the major or the minor variant.
+#
+# Restricted to `SparseMatrixCSR{1}` throughout: `colvals` returns the raw index array, which
+# for `Bi = 0` holds 0-based column indices, and the kernels index it as a 1-based dof number.
+Ferrite.minor_indices(K::SparseMatrixCSR{1}) = colvals(K)
+
+function Ferrite.zero_out_rows!(K::SparseMatrixCSR{1}, rows::AbstractVector{<:Integer}, ::AbstractVector{Bool})
+    return Ferrite._zero_out_majors!(K, rows)
+end
+
+function Ferrite.zero_out_columns!(K::SparseMatrixCSR{1}, ::AbstractVector{<:Integer}, mask::AbstractVector{Bool})
+    @boundscheck checkbounds(mask, axes(K, 2))
+    return Ferrite._zero_out_minors!(K, mask)
+end
+
+# The prescribed columns are minors here, so they are spread over all rows and every stored
+# entry has to be visited; the inhomogeneities are scattered into a dense vector for lookup.
+function Ferrite.add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSR{1}, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
+    g = Ferrite._dense_inhomogeneities(eltype(K), columns, inhomogeneities, size(K, 2))
+    return Ferrite._add_inhomogeneities_minors!(f, K, g)
+end
+
+function Ferrite.condense_into!(
+        Kdst::AbstractMatrix, K::SparseMatrixCSR{1}, rowoffset::Int, coloffset::Int,
+        dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
+    )
+    return Ferrite._condense_majors!(Kdst, K, Ferrite.MajorIsRow(), rowoffset, coloffset, dofcoefficients, dofmapping)
+end
+
+function Ferrite._condense!(K::SparseMatrixCSR{1}, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
+    return Ferrite._condense_sparse!(K, f, dofcoefficients, dofmapping, sym)
+end
+
+# Mirror of `Ferrite.addindex!(::SparseMatrixCSC, ...)` in src/arrayutils.jl. Needed to write
+# the affine contributions of `condense_into!`/`_condense_local!` into a CSR matrix, and to
+# assemble into CSR blocks of a blocked matrix.
 function Ferrite.addindex!(A::SparseMatrixCSR{Bi, Tv}, v::Tv, i::Int, j::Int, ::Val{atomic} = Val(false)) where {Bi, Tv, atomic}
     @boundscheck checkbounds(A, i, j)
+    # Return early if v is 0
     iszero(v) && return A
+    # Search row i for column j
     nzr = nzrange(A, i)
     stored_j = j - (1 - Bi)
     searchk = searchsortedfirst(A.colval, stored_j, first(nzr), last(nzr), Base.Order.Forward)
     if searchk <= last(nzr) && A.colval[searchk] == stored_j
+        # Row i contains entry A[i,j]. Update and return.
         Ferrite.addindex!(A.nzval, v, searchk, Val{atomic}())
         return A
     else
+        # (i, j) not stored. Throw.
         throw(Ferrite.SparsityError())
-    end
-end
-
-function Ferrite.zero_out_rows!(K::SparseMatrixCSR, ch::ConstraintHandler)
-    @debug @assert issorted(ch.prescribed_dofs)
-    for row in ch.prescribed_dofs
-        r = nzrange(K, row)
-        K.nzval[r] .= 0.0
-    end
-    return
-end
-
-function Ferrite.zero_out_columns!(K::SparseMatrixCSR, ch::ConstraintHandler)
-    @boundscheck checkbounds(ch.isconstrained, axes(K, 2))
-    colval = K.colval
-    nzval = K.nzval
-    return @inbounds for (i, col) in pairs(colval)
-        if ch.isconstrained[col]
-            nzval[i] = 0
-        end
     end
 end
 

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -115,10 +115,9 @@ function Ferrite.zero_out_columns!(K::SparseMatrixCSR{1}, ::AbstractVector{<:Int
 end
 
 # The prescribed columns are minors here, so they are spread over all rows and every stored
-# entry has to be visited; the inhomogeneities are scattered into a dense vector for lookup.
+# entry has to be visited.
 function Ferrite.add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSR{1}, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
-    g = Ferrite._dense_inhomogeneities(eltype(K), columns, inhomogeneities, size(K, 2))
-    return Ferrite._add_inhomogeneities_minors!(f, K, g)
+    return Ferrite._add_inhomogeneities_minors!(f, K, columns, inhomogeneities)
 end
 
 function Ferrite.condense_into!(

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -607,10 +607,15 @@ end
 
 """
 
-    apply!(K::AbstractSparseMatrix, rhs::AbstractVector, ch::ConstraintHandler)
+    apply!(K::AbstractMatrix, rhs::AbstractVector, ch::ConstraintHandler)
 
 Adjust the matrix `K` and right hand side `rhs` to account for the Dirichlet boundary
 conditions specified in `ch` such that `K \\ rhs` gives the expected solution.
+
+`K` can be a `SparseMatrixCSC`, a `Symmetric` of one, a `SparseMatrixCSR` (with
+SparseMatricesCSR loaded) or a `BlockMatrix` of any of these (with BlockArrays loaded). Other
+matrix types are supported as soon as they implement the internal constraint interface, see
+[the devdocs on assembly](@ref devdocs-assembly).
 
 !!! note
     `apply!(K, rhs, ch)` essentially calculates
@@ -644,11 +649,12 @@ apply!(u, ch)               # Explicitly make sure bcs are correct
 apply!
 
 """
-    apply_zero!(K::SparseMatrixCSC, rhs::AbstractVector, ch::ConstraintHandler)
+    apply_zero!(K::AbstractMatrix, rhs::AbstractVector, ch::ConstraintHandler)
 
 Adjust the matrix `K` and the right hand side `rhs` to account for prescribed Dirichlet
 boundary conditions and affine constraints such that `du = K \\ rhs` gives the expected
-result (e.g. `du` zero for all prescribed degrees of freedom).
+result (e.g. `du` zero for all prescribed degrees of freedom). The supported matrix types are
+the same as for [`apply!`](@ref).
 
     apply_zero!(v::AbstractVector, ch::ConstraintHandler)
 
@@ -748,11 +754,13 @@ end
     add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, ch::ConstraintHandler)
 
 Compute "f -= K*inhomogeneities".
-By default this is a generic version via SpMSpV kernel.
+
+Forwards to the four argument form below, which is the one a matrix format dispatches. The only
+type needing its own method here is `Symmetric`, which has to account for the triangle that is
+not stored.
 """
-function add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, ch::ConstraintHandler)
-    return mul!(f, K, sparsevec(ch.prescribed_dofs, ch.inhomogeneities, size(K, 2)), -1, 1)
-end
+add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, ch::ConstraintHandler) =
+    add_inhomogeneities!(f, K, ch.prescribed_dofs, ch.inhomogeneities)
 
 """
     add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
@@ -761,17 +769,17 @@ Compute "f -= K * g", where `g` is zero except at `columns`, where it takes the 
 `inhomogeneities`. The indices are local to `K`, so the same method serves a whole matrix and a
 block of a blocked matrix (`f` is then a view of the corresponding rows).
 
-This is the form a matrix format dispatches. The three argument form taking a
-[`ConstraintHandler`](@ref) forwards to it, except for `Symmetric` matrices, which need to
-account for the triangle that is not stored.
+This is the form a matrix format dispatches. The default below is a generic SpMSpV kernel; a
+format that can walk its stored entries directly should replace it, as the sparse formats
+Ferrite ships with do.
 """
-function add_inhomogeneities! end
+function add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
+    return mul!(f, K, sparsevec(columns, inhomogeneities, size(K, 2)), -1, 1)
+end
 
 # Optimized version for SparseMatrixCSC
 add_inhomogeneities!(f::AbstractVector, K::AbstractSparseMatrixCSC, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector) =
     _add_inhomogeneities_majors!(f, K, columns, inhomogeneities)
-add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler) =
-    add_inhomogeneities!(f, K, ch.prescribed_dofs, ch.inhomogeneities)
 # Compute "f -= K * g" where `g` is zero except at the prescribed dofs, for a matrix whose
 # *majors* are the columns (CSC): only the prescribed columns have to be visited. `f` is
 # indexed by the minors (rows). With `sym` only the stored upper triangle is visited.
@@ -793,29 +801,28 @@ function _add_inhomogeneities_majors!(f::AbstractVector, K::AbstractSparseMatrix
 end
 
 # Same, for a matrix whose *minors* are the columns (CSR): the prescribed columns are spread
-# over all majors (rows), so every stored entry has to be visited and `g` is looked up densely.
-# `f` is indexed by the majors (rows).
-function _add_inhomogeneities_minors!(f::AbstractVector, K::AbstractSparseMatrix, g::AbstractVector)
+# over all majors (rows), so every stored entry has to be visited and the inhomogeneities are
+# scattered into a dense vector for lookup. `f` is indexed by the majors (rows).
+function _add_inhomogeneities_minors!(f::AbstractVector, K::AbstractSparseMatrix, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
+    # The dense vector keeps the inhomogeneities in their own precision, so that the products
+    # below promote exactly like the `v * vals[j]` of the major variant. Storing them as
+    # `eltype(K)` would instead round them to the matrix precision first, which is a silent
+    # loss for e.g. a Float32 matrix constrained to Float64 values.
+    g = zeros(eltype(inhomogeneities), size(K, 2))
+    @inbounds for i in eachindex(columns, inhomogeneities)
+        g[columns[i]] = inhomogeneities[i]
+    end
     minors = minor_indices(K)
     vals = nonzeros(K)
+    Tacc = promote_type(eltype(f), eltype(g), eltype(vals))
     @inbounds for major in axes(K, 1) # the majors are the rows, and `f` is indexed by them
-        acc = zero(eltype(f))
+        acc = zero(Tacc)
         for j in nzrange(K, major)
             acc += g[minors[j]] * vals[j]
         end
         f[major] -= acc
     end
     return f
-end
-
-# Scatter `inhomogeneities` at `prescribed` into a dense vector of length `n`, as needed by
-# `_add_inhomogeneities_minors!`.
-function _dense_inhomogeneities(::Type{T}, prescribed::AbstractVector{<:Integer}, inhomogeneities::AbstractVector, n::Int) where {T}
-    g = zeros(T, n)
-    @inbounds for (i, d) in pairs(prescribed)
-        g[d] = inhomogeneities[i]
-    end
-    return g
 end
 
 function add_inhomogeneities!(f::AbstractVector, KK::Symmetric{<:Any, <:SparseMatrixCSC}, ch::ConstraintHandler)
@@ -891,19 +898,52 @@ function condense_into!(
     return _condense_majors!(Kdst, K, MajorIsColumn(), rowoffset, coloffset, dofcoefficients, dofmapping)
 end
 
+# An index offset that maps an index of `K` into the dof numbering of `Kdst`. The offsets are
+# zero whenever a matrix is condensed into itself -- everything except a block of a blocked
+# matrix -- and `NoOffset` gives that case a type of its own, which keeps the arithmetic out of
+# the loop over the stored entries.
+struct NoOffset end
+struct Offset
+    offset::Int
+end
+@inline Base.:+(i::Integer, ::NoOffset) = i
+@inline Base.:+(i::Integer, o::Offset) = i + o.offset
+
+# `nothing` as the destination means "condense `K` into itself". Resolving it to `K` inside the
+# kernel gives the compiler a single matrix, so the reads of the stored entries and the writes
+# of `addindex!` provably go through the same arrays -- passing `K` twice instead costs ~7% on
+# the condensation hot path.
+@inline _condense_destination(::Nothing, K) = K
+@inline _condense_destination(Kdst, K) = Kdst
+
 # Loop the majors of `K` and condense each in turn. Shared by the compressed sparse formats;
 # `orient` says whether the major is the row or the column, which is all that differs between
-# them.
+# them. This is the entry point, which picks the specialization to run.
 function _condense_majors!(
         Kdst::AbstractMatrix, K::AbstractSparseMatrix, orient, rowoffset::Int, coloffset::Int,
         dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
     )
+    # A matrix condensed into itself -- everything except a block of a blocked matrix -- takes
+    # the specialization without a destination and without index arithmetic.
+    return if Kdst === K && iszero(rowoffset) && iszero(coloffset)
+        _condense_majors!(nothing, K, orient, NoOffset(), NoOffset(), dofcoefficients, dofmapping)
+    else
+        _condense_majors!(Kdst, K, orient, Offset(rowoffset), Offset(coloffset), dofcoefficients, dofmapping)
+    end
+end
+
+function _condense_majors!(
+        Kdst::Union{AbstractMatrix, Nothing}, K::AbstractSparseMatrix, orient,
+        rowoffset::Union{Offset, NoOffset}, coloffset::Union{Offset, NoOffset},
+        dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
+    )
+    dst = _condense_destination(Kdst, K)
     # `_rowcol` swaps or keeps its two arguments, so it is its own inverse and maps the
     # (row, col) offsets to the (major, minor) offsets just as well.
     majoroffset, minoroffset = _rowcol(orient, rowoffset, coloffset)
     for major in axes(K, _major_axis(orient))
         major_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, major + majoroffset)
-        _condense_major!(Kdst, K, major, orient, majoroffset, minoroffset, major_coeffs, dofcoefficients, dofmapping)
+        _condense_major!(dst, K, major, orient, majoroffset, minoroffset, major_coeffs, dofcoefficients, dofmapping)
     end
     return
 end
@@ -918,6 +958,10 @@ Condense the stored entries of one major (a column of a CSC matrix, a row of a C
 adding their affine contributions to `Kdst`. `major_coeffs` are the coefficients of the dof that
 the major corresponds to.
 
+A constrained index is replaced by the master dofs it is a combination of, which is the only
+thing the three branches below differ in; `_rowcol` puts the resulting (major, minor) pair back
+in (row, col) order for the write.
+
 The contributions are always added to unconstrained rows *and* columns, i.e. to entries whose
 own coefficients are `nothing`. Writing into `Kdst` while iterating `K` is therefore safe
 regardless of the order the majors are visited in: a modified entry is skipped when the
@@ -925,33 +969,31 @@ iteration reaches it.
 """
 @inline function _condense_major!(
         Kdst::AbstractMatrix, K::AbstractSparseMatrix, major::Int, orient,
-        majoroffset::Int, minoroffset::Int, major_coeffs,
+        majoroffset, minoroffset, major_coeffs,
         dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
     )
-    minors = minor_indices(K)
-    vals = nonzeros(K)
+    maj = major + majoroffset
     for a in nzrange(K, major)
-        Kval = vals[a]
+        Kval = nonzeros(K)[a]
         iszero(Kval) && continue
-        minor_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, minors[a] + minoroffset)
-        row, col = _rowcol(orient, major + majoroffset, minors[a] + minoroffset)
-        row_coeffs, col_coeffs = _rowcol(orient, major_coeffs, minor_coeffs)
-        if col_coeffs === nothing
-            row_coeffs === nothing && continue
-            for (d, v) in row_coeffs
-                addindex!(Kdst, v * Kval, d, col)
+        minor = minor_indices(K)[a] + minoroffset
+        minor_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, minor)
+        if major_coeffs === nothing
+            minor_coeffs === nothing && continue
+            for (d, v) in minor_coeffs
+                addindex!(Kdst, v * Kval, _rowcol(orient, maj, d)...)
             end
             # Perform f - K*g. However, this has already been done outside of this function so we skip this.
             # if condense_f
             #     f[col] -= Kval * ac.b;
             # end
-        elseif row_coeffs === nothing
-            for (d, v) in col_coeffs
-                addindex!(Kdst, v * Kval, row, d)
+        elseif minor_coeffs === nothing
+            for (d, v) in major_coeffs
+                addindex!(Kdst, v * Kval, _rowcol(orient, d, minor)...)
             end
         else
-            for (d1, v1) in row_coeffs, (d2, v2) in col_coeffs
-                addindex!(Kdst, v1 * v2 * Kval, d1, d2)
+            for (d1, v1) in major_coeffs, (d2, v2) in minor_coeffs
+                addindex!(Kdst, v1 * v2 * Kval, _rowcol(orient, d1, d2)...)
             end
         end
     end
@@ -996,12 +1038,19 @@ end
 
 # Condense the right hand side: f := C' * f, for the constrained columns. Independent of the
 # matrix and of its storage. Distinct from `_condense_rhs!` above, which is the standalone
-# version used by `apply_rhs!` and which also zeroes the prescribed dofs. The columns are
-# visited in ascending order, matching the order the entries were accumulated in before the
-# matrix and rhs condensation were separated.
+# version used by `apply_rhs!` and which also zeroes the prescribed dofs.
+#
+# `dofmapping` maps a prescribed dof to its index in `dofcoefficients`, so inverting it lists
+# the prescribed dofs -- in ascending order, since `close!` sorts `ch.prescribed_dofs`. Only
+# those columns can contribute, and visiting them in that order matches the accumulation order
+# of the interleaved implementation this replaced.
 function _condense_rhs_columns!(f::AbstractVector, dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer})
-    for col in 1:length(f)
-        col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, col)
+    prescribed = Vector{Int}(undef, length(dofcoefficients))
+    for (dof, i) in dofmapping
+        prescribed[i] = dof
+    end
+    for (i, col) in pairs(prescribed)
+        col_coeffs = dofcoefficients[i]
         col_coeffs === nothing || _condense_rhs_column!(f, col, col_coeffs)
     end
     return

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -754,22 +754,36 @@ function add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, ch::Constrai
     return mul!(f, K, sparsevec(ch.prescribed_dofs, ch.inhomogeneities, size(K, 2)), -1, 1)
 end
 
+"""
+    add_inhomogeneities!(f::AbstractVector, K::AbstractMatrix, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector)
+
+Compute "f -= K * g", where `g` is zero except at `columns`, where it takes the values
+`inhomogeneities`. The indices are local to `K`, so the same method serves a whole matrix and a
+block of a blocked matrix (`f` is then a view of the corresponding rows).
+
+This is the form a matrix format dispatches. The three argument form taking a
+[`ConstraintHandler`](@ref) forwards to it, except for `Symmetric` matrices, which need to
+account for the triangle that is not stored.
+"""
+function add_inhomogeneities! end
+
 # Optimized version for SparseMatrixCSC
-add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler) = add_inhomogeneities_csc!(f, K, ch, false)
-add_inhomogeneities!(f::AbstractVector, K::Symmetric{<:Any, <:SparseMatrixCSC}, ch::ConstraintHandler) = add_inhomogeneities_csc!(f, K.data, ch, true)
-# Compute "f -= K[:, d] * v" for each prescribed dof `d` with inhomogeneity `v`. The dofs
-# and the rows of `K` are indexed in the same numbering, which is the global one for a plain
-# matrix and the block local one when `K` is a block of a blocked matrix (`f` is then a view
-# of the corresponding rows). With `sym` only the stored upper triangle is visited.
-function _add_inhomogeneities_cols!(f::AbstractVector, K::AbstractSparseMatrixCSC, prescribed_dofs::AbstractVector{<:Integer}, inhomogeneities::AbstractVector, sym::Bool)
-    rows = rowvals(K)
+add_inhomogeneities!(f::AbstractVector, K::AbstractSparseMatrixCSC, columns::AbstractVector{<:Integer}, inhomogeneities::AbstractVector) =
+    _add_inhomogeneities_majors!(f, K, columns, inhomogeneities)
+add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler) =
+    add_inhomogeneities!(f, K, ch.prescribed_dofs, ch.inhomogeneities)
+# Compute "f -= K * g" where `g` is zero except at the prescribed dofs, for a matrix whose
+# *majors* are the columns (CSC): only the prescribed columns have to be visited. `f` is
+# indexed by the minors (rows). With `sym` only the stored upper triangle is visited.
+function _add_inhomogeneities_majors!(f::AbstractVector, K::AbstractSparseMatrix, prescribed::AbstractVector{<:Integer}, inhomogeneities::AbstractVector, sym::Bool = false)
+    minors = minor_indices(K)
     vals = nonzeros(K)
     @inbounds for i in 1:length(inhomogeneities)
-        d = prescribed_dofs[i]
+        d = prescribed[i]
         v = inhomogeneities[i]
         if v != 0
             for j in nzrange(K, d)
-                r = rows[j]
+                r = minors[j]
                 sym && r > d && break # don't look below diagonal
                 f[r] -= v * vals[j]
             end
@@ -778,24 +792,49 @@ function _add_inhomogeneities_cols!(f::AbstractVector, K::AbstractSparseMatrixCS
     return f
 end
 
-function add_inhomogeneities_csc!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler, sym::Bool)
-    (; inhomogeneities, prescribed_dofs, dofmapping) = ch
+# Same, for a matrix whose *minors* are the columns (CSR): the prescribed columns are spread
+# over all majors (rows), so every stored entry has to be visited and `g` is looked up densely.
+# `f` is indexed by the majors (rows).
+function _add_inhomogeneities_minors!(f::AbstractVector, K::AbstractSparseMatrix, g::AbstractVector)
+    minors = minor_indices(K)
+    vals = nonzeros(K)
+    @inbounds for major in axes(K, 1) # the majors are the rows, and `f` is indexed by them
+        acc = zero(eltype(f))
+        for j in nzrange(K, major)
+            acc += g[minors[j]] * vals[j]
+        end
+        f[major] -= acc
+    end
+    return f
+end
 
-    _add_inhomogeneities_cols!(f, K, prescribed_dofs, inhomogeneities, sym)
-    if sym
-        # In the symmetric case, for a constrained dof `d`, we handle the contribution
-        # from `K[1:d, d]` in the loop above, but we are still missing the contribution
-        # from `K[(d+1):size(K,1), d]`. These values are not stored, but since the
-        # matrix is symmetric we can instead use `K[d, (d+1):size(K,1)]`. Looping over
-        # rows is slow, so loop over all columns again, and check if the row is a
-        # constrained row.
-        @inbounds for col in 1:size(K, 2)
-            for ri in nzrange(K, col)
-                row = K.rowval[ri]
-                row >= col && break
-                if (i = get(dofmapping, row, 0); i != 0)
-                    f[col] -= inhomogeneities[i] * K.nzval[ri]
-                end
+# Scatter `inhomogeneities` at `prescribed` into a dense vector of length `n`, as needed by
+# `_add_inhomogeneities_minors!`.
+function _dense_inhomogeneities(::Type{T}, prescribed::AbstractVector{<:Integer}, inhomogeneities::AbstractVector, n::Int) where {T}
+    g = zeros(T, n)
+    @inbounds for (i, d) in pairs(prescribed)
+        g[d] = inhomogeneities[i]
+    end
+    return g
+end
+
+function add_inhomogeneities!(f::AbstractVector, KK::Symmetric{<:Any, <:SparseMatrixCSC}, ch::ConstraintHandler)
+    (; inhomogeneities, prescribed_dofs, dofmapping) = ch
+    K = KK.data
+
+    _add_inhomogeneities_majors!(f, K, prescribed_dofs, inhomogeneities, true)
+    # In the symmetric case, for a constrained dof `d`, we handle the contribution
+    # from `K[1:d, d]` in the loop above, but we are still missing the contribution
+    # from `K[(d+1):size(K,1), d]`. These values are not stored, but since the
+    # matrix is symmetric we can instead use `K[d, (d+1):size(K,1)]`. Looping over
+    # rows is slow, so loop over all columns again, and check if the row is a
+    # constrained row.
+    @inbounds for col in 1:size(K, 2)
+        for ri in nzrange(K, col)
+            row = K.rowval[ri]
+            row >= col && break
+            if (i = get(dofmapping, row, 0); i != 0)
+                f[col] -= inhomogeneities[i] * K.nzval[ri]
             end
         end
     end
@@ -822,31 +861,81 @@ function _condense!(K::AbstractMatrix, f::AbstractVector, dofcoefficients::Vecto
 end
 
 """
-    _condense_column!(Kdst, Ksrc::AbstractSparseMatrixCSC, srccol::Int, rowoffset::Int, coloffset::Int, col_coeffs, dofcoefficients, dofmapping)
+    condense_into!(Kdst::AbstractMatrix, K::AbstractMatrix, rowoffset::Int, coloffset::Int, dofcoefficients::Vector, dofmapping::Dict)
 
-Condense the stored entries of column `srccol` of `Ksrc` by adding their affine contributions
-to `Kdst`. `rowoffset`/`coloffset` translate the indices of `Ksrc` into the global dof
-numbering of `Kdst`; they are zero when `Ksrc === Kdst` and equal to the block offsets when
-`Ksrc` is a block of a blocked `Kdst`. `col_coeffs` are the coefficients of the global column
-`srccol + coloffset`.
+Condense the stored entries of `K` by adding their affine contributions to `Kdst`.
+`rowoffset`/`coloffset` translate the indices of `K` into the dof numbering of `Kdst`; both are
+zero when `Kdst === K` and equal the block offsets when `K` is a block of a blocked `Kdst`. This
+is the matrix half of [`Ferrite._condense!`](@ref); the right hand side is condensed separately
+and independently of the matrix, see `Ferrite._condense_rhs_column!`.
 
-The contributions are always added to unconstrained rows/columns, i.e. to entries whose own
-coefficients are `nothing`. Writing into `Kdst` while iterating `Ksrc` is therefore safe: a
-modified entry is skipped when the iteration reaches it.
+This is the form a matrix format dispatches in order to support affine constraints, both on its
+own and as a block of a blocked matrix. Note that the contributions are written through
+[`Ferrite.addindex!`](@ref) on `Kdst`, which for a blocked `Kdst` is not the same object as `K`.
 """
-@inline function _condense_column!(
-        Kdst::AbstractMatrix, Ksrc::AbstractSparseMatrixCSC, srccol::Int,
-        rowoffset::Int, coloffset::Int, col_coeffs,
+function condense_into! end
+
+# Which index of a compressed sparse matrix is stored contiguously ("the major"): the columns
+# for CSC, the rows for CSR. Used as an argument to the shared kernels below, not as a trait on
+# the matrix type -- a format that is not laid out this way implements `condense_into!` itself.
+struct MajorIsColumn end
+struct MajorIsRow end
+
+@inline _rowcol(::MajorIsColumn, major, minor) = (minor, major)
+@inline _rowcol(::MajorIsRow, major, minor) = (major, minor)
+
+function condense_into!(
+        Kdst::AbstractMatrix, K::AbstractSparseMatrixCSC, rowoffset::Int, coloffset::Int,
         dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
     )
-    col = srccol + coloffset
-    rows = rowvals(Ksrc)
-    vals = nonzeros(Ksrc)
-    for a in nzrange(Ksrc, srccol)
+    return _condense_majors!(Kdst, K, MajorIsColumn(), rowoffset, coloffset, dofcoefficients, dofmapping)
+end
+
+# Loop the majors of `K` and condense each in turn. Shared by the compressed sparse formats;
+# `orient` says whether the major is the row or the column, which is all that differs between
+# them.
+function _condense_majors!(
+        Kdst::AbstractMatrix, K::AbstractSparseMatrix, orient, rowoffset::Int, coloffset::Int,
+        dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
+    )
+    # `_rowcol` swaps or keeps its two arguments, so it is its own inverse and maps the
+    # (row, col) offsets to the (major, minor) offsets just as well.
+    majoroffset, minoroffset = _rowcol(orient, rowoffset, coloffset)
+    for major in axes(K, _major_axis(orient))
+        major_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, major + majoroffset)
+        _condense_major!(Kdst, K, major, orient, majoroffset, minoroffset, major_coeffs, dofcoefficients, dofmapping)
+    end
+    return
+end
+
+@inline _major_axis(::MajorIsColumn) = 2
+@inline _major_axis(::MajorIsRow) = 1
+
+"""
+    _condense_major!(Kdst, K, major, orient, majoroffset, minoroffset, major_coeffs, dofcoefficients, dofmapping)
+
+Condense the stored entries of one major (a column of a CSC matrix, a row of a CSR one) by
+adding their affine contributions to `Kdst`. `major_coeffs` are the coefficients of the dof that
+the major corresponds to.
+
+The contributions are always added to unconstrained rows *and* columns, i.e. to entries whose
+own coefficients are `nothing`. Writing into `Kdst` while iterating `K` is therefore safe
+regardless of the order the majors are visited in: a modified entry is skipped when the
+iteration reaches it.
+"""
+@inline function _condense_major!(
+        Kdst::AbstractMatrix, K::AbstractSparseMatrix, major::Int, orient,
+        majoroffset::Int, minoroffset::Int, major_coeffs,
+        dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
+    )
+    minors = minor_indices(K)
+    vals = nonzeros(K)
+    for a in nzrange(K, major)
         Kval = vals[a]
         iszero(Kval) && continue
-        row = rows[a] + rowoffset
-        row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
+        minor_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, minors[a] + minoroffset)
+        row, col = _rowcol(orient, major + majoroffset, minors[a] + minoroffset)
+        row_coeffs, col_coeffs = _rowcol(orient, major_coeffs, minor_coeffs)
         if col_coeffs === nothing
             row_coeffs === nothing && continue
             for (d, v) in row_coeffs
@@ -880,7 +969,14 @@ end
 
 # Condenses K and f: C'*K*C, C'*f, in-place assuming the sparsity pattern is correct
 function _condense!(K::SparseMatrixCSC, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
+    return _condense_sparse!(K, f, dofcoefficients, dofmapping, sym)
+end
 
+# Shared by the matrix formats implementing `condense_into!`: condense the matrix, then the
+# right hand side. The two are independent -- `_condense_rhs_column!` never touches `K` -- so
+# the rhs does not have to be interleaved with the matrix traversal. That is what allows a
+# format to visit the stored entries in whichever order suits its storage.
+function _condense_sparse!(K::AbstractMatrix, f::AbstractVector, dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false)
     ndofs = size(K, 1)
     condense_f = !(length(f) == 0)
     condense_f && @assert(length(f) == ndofs)
@@ -893,12 +989,20 @@ function _condense!(K::SparseMatrixCSC, f::AbstractVector, dofcoefficients::Vect
         error("condensation of ::Symmetric matrix not supported")
     end
 
-    for col in 1:ndofs
+    condense_into!(K, K, 0, 0, dofcoefficients, dofmapping)
+    condense_f && _condense_rhs_columns!(f, dofcoefficients, dofmapping)
+    return
+end
+
+# Condense the right hand side: f := C' * f, for the constrained columns. Independent of the
+# matrix and of its storage. Distinct from `_condense_rhs!` above, which is the standalone
+# version used by `apply_rhs!` and which also zeroes the prescribed dofs. The columns are
+# visited in ascending order, matching the order the entries were accumulated in before the
+# matrix and rhs condensation were separated.
+function _condense_rhs_columns!(f::AbstractVector, dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer})
+    for col in 1:length(f)
         col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, col)
-        _condense_column!(K, K, col, 0, 0, col_coeffs, dofcoefficients, dofmapping)
-        if col_coeffs !== nothing && condense_f
-            _condense_rhs_column!(f, col, col_coeffs)
-        end
+        col_coeffs === nothing || _condense_rhs_column!(f, col, col_coeffs)
     end
     return
 end
@@ -954,44 +1058,63 @@ function create_constraint_matrix(ch::ConstraintHandler{dh, T}) where {dh, T}
 end
 """
     zero_out_columns!(K::AbstractMatrix, ch::ConstraintHandler)
+    zero_out_columns!(K::AbstractMatrix, columns::AbstractVector{<:Integer}, mask::AbstractVector{Bool})
+
 Set the values of all columns associated with constrained dofs to zero.
+
+The three argument form is the one a matrix format has to dispatch; the two argument form
+forwards to it. `columns` is the sorted list of the columns to zero and `mask` flags the same
+set (`mask[j]` is `true` iff `j ∈ columns`). Both forms of the same information are passed
+because which one can be used efficiently depends on the storage: a column-compressed format
+walks `columns`, a row-compressed one scans its stored column indices against `mask`. The
+indices are local to `K`, so the same method serves a whole matrix and a block of a blocked
+matrix.
 """
 zero_out_columns!
 
 """
     zero_out_rows!(K::AbstractMatrix, ch::ConstraintHandler)
-Set the values of all rows associated with constrained dofs to zero.
+    zero_out_rows!(K::AbstractMatrix, rows::AbstractVector{<:Integer}, mask::AbstractVector{Bool})
+
+Set the values of all rows associated with constrained dofs to zero. See
+[`Ferrite.zero_out_columns!`](@ref) for the meaning of the three argument form.
 """
 zero_out_rows!
 
 # columns need to be stored entries, this is not checked
-function zero_out_columns!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler) # can be removed in 0.7 with #24711 merged
-    return _zero_out_columns!(K, ch.prescribed_dofs)
+function zero_out_columns!(K::AbstractMatrix, ch::ConstraintHandler) # can be removed in 0.7 with #24711 merged
+    return zero_out_columns!(K, ch.prescribed_dofs, ch.isconstrained)
 end
 
-function zero_out_rows!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler)
-    return _zero_out_rows!(K, ch.isconstrained)
+function zero_out_rows!(K::AbstractMatrix, ch::ConstraintHandler)
+    return zero_out_rows!(K, ch.prescribed_dofs, ch.isconstrained)
 end
 
-# Kernels for the two functions above, taking the prescribed dofs and the constrained mask
-# directly instead of the constraint handler. This lets a blocked matrix reuse them per block
-# by passing the block local dofs and a view of the mask, see the BlockArrays extension.
-function _zero_out_columns!(K::AbstractSparseMatrixCSC, prescribed_dofs::AbstractVector{<:Integer})
-    @debug @assert issorted(prescribed_dofs)
+# For CSC the columns are the majors and the rows the minors.
+zero_out_columns!(K::AbstractSparseMatrixCSC, columns::AbstractVector{<:Integer}, ::AbstractVector{Bool}) = _zero_out_majors!(K, columns)
+function zero_out_rows!(K::AbstractSparseMatrixCSC, ::AbstractVector{<:Integer}, mask::AbstractVector{Bool})
+    @boundscheck checkbounds(mask, axes(K, 1))
+    return _zero_out_minors!(K, mask)
+end
+
+# Kernels shared by the compressed sparse formats: zeroing the entries of the listed majors is
+# a walk over those majors only, zeroing the entries of the flagged minors is a scan over all
+# stored entries. See `Ferrite.minor_indices`.
+function _zero_out_majors!(K::AbstractSparseMatrix, majors::AbstractVector{<:Integer})
+    @debug @assert issorted(majors)
     nzval = nonzeros(K)
-    for col in prescribed_dofs
-        r = nzrange(K, col)
+    for k in majors
+        r = nzrange(K, k)
         nzval[r] .= 0
     end
     return
 end
 
-function _zero_out_rows!(K::AbstractSparseMatrixCSC, isconstrained::AbstractVector{Bool})
-    @boundscheck checkbounds(isconstrained, axes(K, 1))
-    rowval = rowvals(K)
+function _zero_out_minors!(K::AbstractSparseMatrix, mask::AbstractVector{Bool})
+    minors = minor_indices(K)
     nzval = nonzeros(K)
-    @inbounds for (i, row) in pairs(rowval)
-        if isconstrained[row]
+    @inbounds for (i, minor) in pairs(minors)
+        if mask[minor]
             nzval[i] = zero(eltype(K))
         end
     end

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -699,15 +699,20 @@ function _apply_v(v::AbstractVector, ch::ConstraintHandler, apply_zero::Bool)
     return v
 end
 
-function apply!(K::Union{AbstractSparseMatrix, Symmetric}, ch::ConstraintHandler)
+function apply!(K::AbstractMatrix, ch::ConstraintHandler)
     return apply!(K, eltype(K)[], ch, true)
 end
 
-function apply_zero!(K::Union{AbstractSparseMatrix, Symmetric}, f::AbstractVector, ch::ConstraintHandler)
+function apply_zero!(K::AbstractMatrix, f::AbstractVector, ch::ConstraintHandler)
     return apply!(K, f, ch, true)
 end
 
-function apply!(KK::Union{AbstractSparseMatrix, Symmetric{<:Any, <:AbstractSparseMatrix}}, f::AbstractVector, ch::ConstraintHandler, applyzero::Bool = false)
+# The implementation below only uses the internal matrix interface (`meandiag`,
+# `add_inhomogeneities!`, `_condense!`, `zero_out_columns!`, `zero_out_rows!` and scalar
+# `setindex!`), so any matrix type dispatching those is supported -- see the devdocs on
+# assembly. `AbstractSparseMatrixCSC` and `SparseMatrixCSR` are covered here and in the
+# SparseMatricesCSR extension, `BlockMatrix` in the BlockArrays extension.
+function apply!(KK::AbstractMatrix, f::AbstractVector, ch::ConstraintHandler, applyzero::Bool = false)
     @assert isclosed(ch)
     sym = isa(KK, Symmetric)
     K = sym ? KK.data : KK
@@ -752,20 +757,31 @@ end
 # Optimized version for SparseMatrixCSC
 add_inhomogeneities!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler) = add_inhomogeneities_csc!(f, K, ch, false)
 add_inhomogeneities!(f::AbstractVector, K::Symmetric{<:Any, <:SparseMatrixCSC}, ch::ConstraintHandler) = add_inhomogeneities_csc!(f, K.data, ch, true)
-function add_inhomogeneities_csc!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler, sym::Bool)
-    (; inhomogeneities, prescribed_dofs, dofmapping) = ch
-
+# Compute "f -= K[:, d] * v" for each prescribed dof `d` with inhomogeneity `v`. The dofs
+# and the rows of `K` are indexed in the same numbering, which is the global one for a plain
+# matrix and the block local one when `K` is a block of a blocked matrix (`f` is then a view
+# of the corresponding rows). With `sym` only the stored upper triangle is visited.
+function _add_inhomogeneities_cols!(f::AbstractVector, K::AbstractSparseMatrixCSC, prescribed_dofs::AbstractVector{<:Integer}, inhomogeneities::AbstractVector, sym::Bool)
+    rows = rowvals(K)
+    vals = nonzeros(K)
     @inbounds for i in 1:length(inhomogeneities)
         d = prescribed_dofs[i]
         v = inhomogeneities[i]
         if v != 0
             for j in nzrange(K, d)
-                r = K.rowval[j]
+                r = rows[j]
                 sym && r > d && break # don't look below diagonal
-                f[r] -= v * K.nzval[j]
+                f[r] -= v * vals[j]
             end
         end
     end
+    return f
+end
+
+function add_inhomogeneities_csc!(f::AbstractVector, K::SparseMatrixCSC, ch::ConstraintHandler, sym::Bool)
+    (; inhomogeneities, prescribed_dofs, dofmapping) = ch
+
+    _add_inhomogeneities_cols!(f, K, prescribed_dofs, inhomogeneities, sym)
     if sym
         # In the symmetric case, for a constrained dof `d`, we handle the contribution
         # from `K[1:d, d]` in the loop above, but we are still missing the contribution
@@ -795,14 +811,71 @@ end
 end
 
 """
-    _condense!(K::AbstractSparseMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false)
+    _condense!(K::AbstractMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false)
 
 Condenses affine constraints K := C'*K*C and f := C'*f in-place, assuming the sparsity pattern is correct.
 """
-function _condense!(K::AbstractSparseMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
+function _condense!(K::AbstractMatrix, f::AbstractVector, dofcoefficients::Vector{Union{Nothing, DofCoefficients{T, Ti}}}, dofmapping::Dict{<:Integer, <:Integer}, sym::Bool = false) where {T, Ti}
     # Return early if there are no non-trivial affine constraints
     any(i -> !(i === nothing || isempty(i)), dofcoefficients) || return
     error("condensation of ::$(typeof(K)) matrix not supported")
+end
+
+"""
+    _condense_column!(Kdst, Ksrc::AbstractSparseMatrixCSC, srccol::Int, rowoffset::Int, coloffset::Int, col_coeffs, dofcoefficients, dofmapping)
+
+Condense the stored entries of column `srccol` of `Ksrc` by adding their affine contributions
+to `Kdst`. `rowoffset`/`coloffset` translate the indices of `Ksrc` into the global dof
+numbering of `Kdst`; they are zero when `Ksrc === Kdst` and equal to the block offsets when
+`Ksrc` is a block of a blocked `Kdst`. `col_coeffs` are the coefficients of the global column
+`srccol + coloffset`.
+
+The contributions are always added to unconstrained rows/columns, i.e. to entries whose own
+coefficients are `nothing`. Writing into `Kdst` while iterating `Ksrc` is therefore safe: a
+modified entry is skipped when the iteration reaches it.
+"""
+@inline function _condense_column!(
+        Kdst::AbstractMatrix, Ksrc::AbstractSparseMatrixCSC, srccol::Int,
+        rowoffset::Int, coloffset::Int, col_coeffs,
+        dofcoefficients::Vector, dofmapping::Dict{<:Integer, <:Integer},
+    )
+    col = srccol + coloffset
+    rows = rowvals(Ksrc)
+    vals = nonzeros(Ksrc)
+    for a in nzrange(Ksrc, srccol)
+        Kval = vals[a]
+        iszero(Kval) && continue
+        row = rows[a] + rowoffset
+        row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
+        if col_coeffs === nothing
+            row_coeffs === nothing && continue
+            for (d, v) in row_coeffs
+                addindex!(Kdst, v * Kval, d, col)
+            end
+            # Perform f - K*g. However, this has already been done outside of this function so we skip this.
+            # if condense_f
+            #     f[col] -= Kval * ac.b;
+            # end
+        elseif row_coeffs === nothing
+            for (d, v) in col_coeffs
+                addindex!(Kdst, v * Kval, row, d)
+            end
+        else
+            for (d1, v1) in row_coeffs, (d2, v2) in col_coeffs
+                addindex!(Kdst, v1 * v2 * Kval, d1, d2)
+            end
+        end
+    end
+    return
+end
+
+# Condense the rhs contribution of the constrained column `col` with coefficients `col_coeffs`.
+@inline function _condense_rhs_column!(f::AbstractVector, col::Int, col_coeffs)
+    for (d, v) in col_coeffs
+        f[d] += f[col] * v
+    end
+    f[col] = 0
+    return
 end
 
 # Condenses K and f: C'*K*C, C'*f, in-place assuming the sparsity pattern is correct
@@ -822,45 +895,9 @@ function _condense!(K::SparseMatrixCSC, f::AbstractVector, dofcoefficients::Vect
 
     for col in 1:ndofs
         col_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, col)
-        if col_coeffs === nothing
-            for a in nzrange(K, col)
-                Kval = K.nzval[a]
-                iszero(Kval) && continue
-                row = K.rowval[a]
-                row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
-                row_coeffs === nothing && continue
-                for (d, v) in row_coeffs
-                    addindex!(K, v * Kval, d, col)
-                end
-
-                # Perform f - K*g. However, this has already been done in outside this functions so we skip this.
-                # if condense_f
-                #     f[col] -= K.nzval[a] * ac.b;
-                # end
-            end
-        else
-            for a in nzrange(K, col)
-                Kval = K.nzval[a]
-                iszero(Kval) && continue
-                row = K.rowval[a]
-                row_coeffs = coefficients_for_dof(dofmapping, dofcoefficients, row)
-                if row_coeffs === nothing
-                    for (d, v) in col_coeffs
-                        addindex!(K, v * Kval, row, d)
-                    end
-                else
-                    for (d1, v1) in row_coeffs, (d2, v2) in col_coeffs
-                        addindex!(K, v1 * v2 * Kval, d1, d2)
-                    end
-                end
-            end
-
-            if condense_f
-                for (d, v) in col_coeffs
-                    f[d] += f[col] * v
-                end
-                f[col] = 0.0
-            end
+        _condense_column!(K, K, col, 0, 0, col_coeffs, dofcoefficients, dofmapping)
+        if col_coeffs !== nothing && condense_f
+            _condense_rhs_column!(f, col, col_coeffs)
         end
     end
     return
@@ -929,20 +966,32 @@ zero_out_rows!
 
 # columns need to be stored entries, this is not checked
 function zero_out_columns!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler) # can be removed in 0.7 with #24711 merged
-    @debug @assert issorted(ch.prescribed_dofs)
-    for col in ch.prescribed_dofs
+    return _zero_out_columns!(K, ch.prescribed_dofs)
+end
+
+function zero_out_rows!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler)
+    return _zero_out_rows!(K, ch.isconstrained)
+end
+
+# Kernels for the two functions above, taking the prescribed dofs and the constrained mask
+# directly instead of the constraint handler. This lets a blocked matrix reuse them per block
+# by passing the block local dofs and a view of the mask, see the BlockArrays extension.
+function _zero_out_columns!(K::AbstractSparseMatrixCSC, prescribed_dofs::AbstractVector{<:Integer})
+    @debug @assert issorted(prescribed_dofs)
+    nzval = nonzeros(K)
+    for col in prescribed_dofs
         r = nzrange(K, col)
-        K.nzval[r] .= 0.0
+        nzval[r] .= 0
     end
     return
 end
 
-function zero_out_rows!(K::AbstractSparseMatrixCSC, ch::ConstraintHandler)
-    @boundscheck checkbounds(ch.isconstrained, axes(K, 1))
-    rowval = K.rowval
-    nzval = K.nzval
+function _zero_out_rows!(K::AbstractSparseMatrixCSC, isconstrained::AbstractVector{Bool})
+    @boundscheck checkbounds(isconstrained, axes(K, 1))
+    rowval = rowvals(K)
+    nzval = nonzeros(K)
     @inbounds for (i, row) in pairs(rowval)
-        if ch.isconstrained[row]
+        if isconstrained[row]
             nzval[i] = zero(eltype(K))
         end
     end
@@ -1759,7 +1808,8 @@ function apply_local!(
 end
 
 # Element local application of boundary conditions. Global matrix and vectors are necessary
-# if there are affine constraints that connect dofs from different elements.
+# if there are affine constraints that connect dofs from different elements. `atomic` controls
+# whether those global writes use atomic additions, see `start_assemble`.
 function _apply_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,
         global_dofs::AbstractVector, ch::ConstraintHandler, apply_zero::Bool,
@@ -1830,7 +1880,9 @@ end
     )
 
 Condensation of affine constraints on element level. If possible this function only
-modifies the local arrays.
+modifies the local arrays. Constraints reaching outside of `global_dofs` are written
+directly into `global_matrix`/`global_vector`; `atomic` controls whether those writes use
+atomic additions, which is required when assembling concurrently without grid coloring.
 """
 function _condense_local!(
         local_matrix::AbstractMatrix, local_vector::AbstractVector,

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -119,6 +119,25 @@ function fillzero!(A::AbstractVecOrMat{T}) where {T}
     return fill!(A, zero(T))
 end
 
+"""
+    Ferrite.minor_indices(K::AbstractSparseMatrix)
+
+For a sparse matrix that stores the entries of one index contiguously ("the major"), return the
+vector of the *other* index ("the minor") of every stored entry, parallel to `nonzeros(K)`. This
+is `rowvals(K)` for column-compressed storage (CSC) and `colvals(K)` for row-compressed storage
+(CSR).
+
+This is an internal helper shared by the CSC and CSR implementations of the constraint
+application interface (see the devdocs on assembly); it is *not* part of that interface. A format
+that does not store scalar entries in flat arrays parallel to `nonzeros` -- a blocked format such
+as BSR, for instance -- simply does not define it, and implements the interface functions
+directly.
+"""
+function minor_indices end
+
+minor_indices(K::AbstractSparseMatrixCSC) = rowvals(K)
+
+
 ##################################
 ## SparseArrays.SparseMatrixCSC ##
 ##################################

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -373,11 +373,47 @@ end
 # search instead of the linear merge walk in `_assemble_inner!`.
 const SPARSE_COLUMN_SEARCH_RATIO = 8
 
+"""
+    Ferrite._assemble_inner!(K, Ke, rowdofs, sortedrowdofs, rowpermutation, coldofs, sortedcoldofs, colpermutation, sym, atomic, rowoffset, coloffset)
+
+Scatter the element matrix `Ke` into the (already allocated) entries of `K`, i.e.
+`K[rowdofs, coldofs] += Ke`. The dofs are passed both in element order (`rowdofs`, `coldofs`)
+and sorted ascending (`sortedrowdofs`, `sortedcoldofs`), the latter together with the
+permutations mapping a sorted position back to its index in `Ke`, so that a format storing
+its entries in sorted order can walk them and the element matrix in a single pass. If `sym`
+is `true` only the upper triangle of `Ke` is read. `atomic` is a `Val{Bool}` selecting
+whether the accumulation is concurrency safe.
+
+`rowoffset` and `coloffset` place the matrix within a larger system; they are only used to
+report global indices when an entry is missing from the sparsity pattern, and are nonzero
+when `K` is used as a *block* of a blocked matrix.
+
+The default implementation writes the entries one by one with [`Ferrite.addindex!`](@ref),
+which is all a custom format has to provide. A format that stores its entries sorted should
+specialize this and walk them together with the element matrix, as CSC and CSR do.
+"""
+@propagate_inbounds function _assemble_inner!(
+        K::AbstractMatrix, Ke::AbstractMatrix,
+        rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
+        coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
+        sym::Bool, atomic::Val = Val(false), rowoffset::Int = 0, coloffset::Int = 0
+    )
+    ld = length(rowdofs)
+    @inbounds for (current_col, Kcol) in pairs(sortedcoldofs)
+        Kecol = colpermutation[current_col]
+        maxlookups = sym ? current_col : ld
+        for ri in 1:maxlookups
+            addindex!(K, Ke[rowpermutation[ri], Kecol], sortedrowdofs[ri], Kcol, atomic)
+        end
+    end
+    return
+end
+
 @propagate_inbounds function _assemble_inner!(
         K::SparseMatrixCSC, Ke::AbstractMatrix,
         rowdofs::AbstractVector, sortedrowdofs::AbstractVector, rowpermutation::AbstractVector,
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
-        sym::Bool, atomic::Val = Val(false)
+        sym::Bool, atomic::Val = Val(false), rowoffset::Int = 0, coloffset::Int = 0
     )
     current_col = 1
     Krows = rowvals(K)
@@ -413,7 +449,7 @@ const SPARSE_COLUMN_SEARCH_RATIO = 8
                 else
                     # No entry exists in the global matrix for this row, which is allowed
                     # as long as the value which would have been inserted is zero.
-                    iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof, Kcol)
+                    iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof + rowoffset, Kcol + coloffset)
                     lo = R
                 end
             end
@@ -440,7 +476,7 @@ const SPARSE_COLUMN_SEARCH_RATIO = 8
             else # Krow > Kerow_dof
                 # No match: no entry exist in the global matrix for this row. This is
                 # allowed as long as the value which would have been inserted is zero.
-                iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof, Kcol)
+                iszero(Ke[rowpermutation[ri], Kecol]) || _missing_sparsity_pattern_error(Kerow_dof + rowoffset, Kcol + coloffset)
                 # Advance the local matrix row pointer
                 ri += 1
             end
@@ -448,7 +484,7 @@ const SPARSE_COLUMN_SEARCH_RATIO = 8
         # Make sure that remaining entries in this column of the local matrix are all zero
         for i in ri:maxlookups
             if !iszero(Ke[rowpermutation[i], Kecol])
-                _missing_sparsity_pattern_error(sortedrowdofs[i], Kcol)
+                _missing_sparsity_pattern_error(sortedrowdofs[i] + rowoffset, Kcol + coloffset)
             end
         end
         current_col += 1

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -1,6 +1,11 @@
 using Ferrite, BlockArrays, SparseArrays, LinearAlgebra, Test
+import SparseMatricesCSR: SparseMatrixCSR
 
-@testset "BlockArrays.jl extension" begin
+# The constraint application interface is implemented per block type, so everything below is
+# run for both of the sparse formats Ferrite ships with.
+const BLOCK_TYPES = ("CSC" => SparseMatrixCSC{Float64, Int}, "CSR" => SparseMatrixCSR{1, Float64, Int})
+
+@testset "BlockArrays.jl extension ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
     grid = generate_grid(Triangle, (10, 10))
 
     dh = DofHandler(grid)
@@ -24,7 +29,7 @@ using Ferrite, BlockArrays, SparseArrays, LinearAlgebra, Test
     # TODO: allocate_matrix(BlockMatrix, ...) should work and default to field blocking
     bsp = BlockSparsityPattern([2nd, 1nd])
     add_sparsity_entries!(bsp, dh, ch)
-    KB = allocate_matrix(BlockMatrix, bsp)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
     @test KB isa BlockMatrix
     @test blocksize(KB) == (2, 2)
     @test size(KB[Block(1), Block(1)]) == (2nd, 2nd)
@@ -102,7 +107,7 @@ using Ferrite, BlockArrays, SparseArrays, LinearAlgebra, Test
     block_sizes = [nfree, npres]
     bsp = BlockSparsityPattern(block_sizes)
     add_sparsity_entries!(bsp, dh, ch)
-    KB = allocate_matrix(BlockMatrix, bsp)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
     @test blocksize(KB) == (2, 2)
     @test size(KB[Block(1), Block(1)]) == (nfree, nfree)
     @test size(KB[Block(2), Block(1)]) == (npres, nfree)
@@ -114,7 +119,7 @@ using Ferrite, BlockArrays, SparseArrays, LinearAlgebra, Test
     @test K == KB
 end
 
-@testset "BlockAssembler with atomic accumulation" begin
+@testset "BlockAssembler with atomic accumulation ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
     grid = generate_grid(Triangle, (10, 10))
     dh = DofHandler(grid)
     ip = Lagrange{RefTriangle, 1}()
@@ -134,7 +139,7 @@ end
 
     bsp = BlockSparsityPattern([2nd, 1nd])
     add_sparsity_entries!(bsp, dh, ch)
-    allocate_block_matrix() = allocate_matrix(BlockMatrix, bsp)
+    allocate_block_matrix() = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
 
     # Deterministic fake element contributions computed from the dofs
     element_matrix(dofs) = [sin(i * j / 100) for i in dofs, j in dofs]

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -119,6 +119,42 @@ const BLOCK_TYPES = ("CSC" => SparseMatrixCSC{Float64, Int}, "CSR" => SparseMatr
     @test K == KB
 end
 
+@testset "BlockAssembler matrix only ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
+    # Both `f` and `fe` are optional, as for the CSC and CSR assemblers, so that a matrix only
+    # sweep works the same way for a blocked system.
+    grid = generate_grid(Triangle, (4, 4))
+    dh = DofHandler(grid)
+    ip = Lagrange{RefTriangle, 1}()
+    add!(dh, :u, ip^2)
+    add!(dh, :p, ip)
+    close!(dh)
+    renumber!(dh, DofOrder.FieldWise())
+    nd = ndofs(dh) ÷ 3
+
+    bsp = BlockSparsityPattern([2nd, 1nd])
+    add_sparsity_entries!(bsp, dh)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
+    K = allocate_matrix(dh)
+
+    assembler = start_assemble(K)
+    block_assembler = start_assemble(KB)
+    @test isempty(Ferrite.vector_handle(block_assembler))
+    for cc in CellIterator(dh)
+        dofs = celldofs(cc)
+        ke = [sin(i * j / 10) for i in dofs, j in dofs]
+        assemble!(assembler, dofs, ke)
+        assemble!(block_assembler, dofs, ke)
+    end
+    @test K ≈ KB
+
+    # Omitting `fe` leaves the vector alone also when the assembler was given one
+    fB = similar(KB, axes(KB, 1))
+    fill!(fB, 1)
+    npc = ndofs_per_cell(dh)
+    assemble!(start_assemble(KB, fB; fillzero = false), celldofs(dh, 1), zeros(npc, npc))
+    @test all(isone, fB)
+end
+
 @testset "BlockMatrix affine constraints across blocks ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
     # The periodic constraint in the fixture above lives entirely inside the :u block, so it
     # never exercises a coefficient that maps a dof of one block onto a dof of another. Here

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -119,6 +119,63 @@ const BLOCK_TYPES = ("CSC" => SparseMatrixCSC{Float64, Int}, "CSR" => SparseMatr
     @test K == KB
 end
 
+@testset "BlockMatrix affine constraints across blocks ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
+    # The periodic constraint in the fixture above lives entirely inside the :u block, so it
+    # never exercises a coefficient that maps a dof of one block onto a dof of another. Here
+    # a :p dof is constrained to :u dofs and a :u dof to a :p dof, so condensation has to move
+    # contributions between blocks in both directions.
+    grid = generate_grid(Triangle, (4, 4))
+    dh = DofHandler(grid)
+    ip = Lagrange{RefTriangle, 1}()
+    add!(dh, :u, ip^2)
+    add!(dh, :p, ip)
+    close!(dh)
+    renumber!(dh, DofOrder.FieldWise())
+    nd = ndofs(dh) ÷ 3 # :u occupies 1:2nd (block 1), :p occupies 2nd .+ (1:nd) (block 2)
+
+    ch = ConstraintHandler(dh)
+    add!(ch, AffineConstraint(2nd + 1, [1 => 0.4, 2 => 0.3], 1.2)) # a :p dof from :u dofs
+    add!(ch, AffineConstraint(3, [2nd + 2 => 0.5], -0.7))          # a :u dof from a :p dof
+    close!(ch)
+    update!(ch, 0)
+
+    K = allocate_matrix(dh, ch)
+    f = zeros(ndofs(dh))
+    bsp = BlockSparsityPattern([2nd, 1nd])
+    add_sparsity_entries!(bsp, dh, ch)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
+    fB = similar(KB, axes(KB, 1))
+
+    assembler = start_assemble(K, f)
+    block_assembler = start_assemble(KB, fB)
+    npc = ndofs_per_cell(dh)
+    for cc in CellIterator(dh)
+        dofs = celldofs(cc)
+        ke = [sin(i * j / 10) for i in dofs, j in dofs]
+        fe = [cos(i) for i in dofs]
+        assemble!(assembler, dofs, ke, fe)
+        assemble!(block_assembler, dofs, ke, fe)
+    end
+    @test K ≈ KB
+    @test f ≈ fB
+
+    # The condensed free block must equal the explicit C' * K * C and C' * (f - K * g)
+    C, g = Ferrite.create_constraint_matrix(ch)
+    Kref = C' * K * C
+    fref = C' * (f - K * g)
+    fdofs = Ferrite.free_dofs(ch)
+    apply!(K, f, ch)
+    apply!(KB, fB, ch)
+    @test K ≈ KB
+    @test f ≈ fB
+    @test KB[fdofs, fdofs] ≈ Kref
+    @test fB[fdofs] ≈ fref
+    @test K \ f ≈ KB \ fB
+
+    # ... but condensing a Symmetric blocked matrix is unsupported, as for the plain formats
+    @test_throws ErrorException("condensation of ::Symmetric matrix not supported") apply_zero!(Symmetric(KB), fB, ch)
+end
+
 @testset "BlockAssembler with atomic accumulation ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
     grid = generate_grid(Triangle, (10, 10))
     dh = DofHandler(grid)

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -1,4 +1,4 @@
-using Ferrite, BlockArrays, SparseArrays, Test
+using Ferrite, BlockArrays, SparseArrays, LinearAlgebra, Test
 
 @testset "BlockArrays.jl extension" begin
     grid = generate_grid(Triangle, (10, 10))
@@ -67,8 +67,31 @@ using Ferrite, BlockArrays, SparseArrays, Test
     @test K ≈ KB
     @test f ≈ fB
 
-    # Global application of BC not supported yet
-    @test_throws ErrorException apply!(KB, fB, ch)
+    # Global application of BC, including the non-local affine (periodic) constraints
+    fdofs = Ferrite.free_dofs(ch)
+    pdofs = ch.prescribed_dofs
+    let K = copy(K), f = copy(f), KB = copy(KB), fB = copy(fB)
+        apply!(K, f, ch)
+        apply!(KB, fB, ch)
+        @test K ≈ KB
+        @test f ≈ fB
+        # The free block is the condensed system, the prescribed block is diagonal
+        @test KB[fdofs, fdofs] ≈ K[fdofs, fdofs]
+        @test isdiag(KB[pdofs, pdofs])
+        @test K \ f ≈ KB \ fB
+    end
+    let K = copy(K), f = copy(f), KB = copy(KB), fB = copy(fB)
+        apply_zero!(K, f, ch)
+        apply_zero!(KB, fB, ch)
+        @test K ≈ KB
+        @test f ≈ fB
+    end
+    # Matrix only, i.e. with an empty rhs
+    let K = copy(K), KB = copy(KB)
+        apply!(K, ch)
+        apply!(KB, ch)
+        @test K ≈ KB
+    end
 
     # Custom blocking
     perm = invperm([ch.free_dofs; ch.prescribed_dofs])
@@ -89,6 +112,104 @@ using Ferrite, BlockArrays, SparseArrays, Test
     fill!(K.nzval, 1)
     foreach(x -> fill!(x.nzval, 1), blocks(KB))
     @test K == KB
+end
+
+@testset "BlockAssembler with atomic accumulation" begin
+    grid = generate_grid(Triangle, (10, 10))
+    dh = DofHandler(grid)
+    ip = Lagrange{RefTriangle, 1}()
+    add!(dh, :u, ip^2)
+    add!(dh, :p, ip)
+    close!(dh)
+    renumber!(dh, DofOrder.FieldWise())
+    nd = ndofs(dh) ÷ 3
+
+    # Periodic constraints couple dofs across elements, so `apply_assemble!` below has to
+    # write into the global matrix and vector from `Ferrite._condense_local!`
+    ch = ConstraintHandler(dh)
+    add!(ch, PeriodicDirichlet(:u, collect_periodic_facets(grid, "top", "bottom")))
+    add!(ch, Dirichlet(:p, getfacetset(grid, "left"), (x, t) -> 0))
+    close!(ch)
+    update!(ch, 0)
+
+    bsp = BlockSparsityPattern([2nd, 1nd])
+    add_sparsity_entries!(bsp, dh, ch)
+    allocate_block_matrix() = allocate_matrix(BlockMatrix, bsp)
+
+    # Deterministic fake element contributions computed from the dofs
+    element_matrix(dofs) = [sin(i * j / 100) for i in dofs, j in dofs]
+    element_vector(dofs) = [cos(i) for i in dofs]
+
+    function doassemble!(assembler; condense = false)
+        for cc in CellIterator(dh)
+            dofs = celldofs(cc)
+            ke = element_matrix(dofs)
+            fe = element_vector(dofs)
+            if condense
+                apply_assemble!(assembler, ch, dofs, ke, fe)
+            else
+                assemble!(assembler, dofs, ke, fe)
+            end
+        end
+        return
+    end
+
+    # Sequential atomic assembly gives bitwise identical results, both for plain assembly
+    # and for assembly with local condensation of constraints
+    for condense in (false, true)
+        K = allocate_block_matrix()
+        f = similar(K, axes(K, 1))
+        Ka = allocate_block_matrix()
+        fa = similar(Ka, axes(Ka, 1))
+        doassemble!(start_assemble(K, f); condense)
+        doassemble!(start_assemble(Ka, fa; atomic = true); condense)
+        @test K == Ka
+        @test f == fa
+    end
+
+    # A rhs which is not blocked like the matrix takes the fallback path in `assemble!`,
+    # which must be atomic too
+    K = allocate_block_matrix()
+    f = zeros(ndofs(dh))
+    Ka = allocate_block_matrix()
+    fa = zeros(ndofs(dh))
+    doassemble!(start_assemble(K, f))
+    doassemble!(start_assemble(Ka, fa; atomic = true))
+    @test K == Ka
+    @test f == fa
+
+    # Concurrent assembly: shared K and f, but one assembler per task and no coloring
+    Kc = allocate_block_matrix()
+    fc = similar(Kc, axes(Kc, 1))
+    _ = start_assemble(Kc, fc) # zero out
+    @sync for chunk in Iterators.partition(1:getncells(grid), cld(getncells(grid), 4))
+        Threads.@spawn begin
+            asm = start_assemble(Kc, fc; fillzero = false, atomic = true)
+            for cellidx in chunk
+                dofs = celldofs(dh, cellidx)
+                apply_assemble!(asm, ch, dofs, element_matrix(dofs), element_vector(dofs))
+            end
+        end
+    end
+    Ks = allocate_block_matrix()
+    fs = similar(Ks, axes(Ks, 1))
+    doassemble!(start_assemble(Ks, fs; atomic = true); condense = true)
+    # Equal up to the (task dependent) summation order
+    @test Kc ≈ Ks rtol = 1.0e-14
+    @test fc ≈ fs rtol = 1.0e-14
+
+    # Atomic accumulation is only supported for real/complex Float16/Float32/Float64
+    Ki = BlockArray(zeros(Int, 4, 4), [2, 2], [2, 2])
+    fi = BlockArray(zeros(Int, 4), [2, 2])
+    @test_throws ArgumentError start_assemble(Ki, fi; atomic = true)
+
+    # Literal `atomic` values propagate to the type parameter, i.e. `@inferred` holds and
+    # the flag is a compile time constant
+    KB = allocate_block_matrix()
+    fB = similar(KB, axes(KB, 1))
+    @test Ferrite._is_atomic(@inferred ((K, f) -> start_assemble(K, f; atomic = true))(KB, fB))
+    @test !Ferrite._is_atomic(@inferred ((K, f) -> start_assemble(K, f; atomic = false))(KB, fB))
+    @test !Ferrite._is_atomic(@inferred ((K, f) -> start_assemble(K, f))(KB, fB))
 end
 
 @testset "BlockAssembler with dense blocks" begin

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -329,3 +329,40 @@ end
     atomic_assembler = start_assemble(KB, fB; atomic = true)
     @test_throws ErrorException assemble!(atomic_assembler, dofs, ke, fe)
 end
+
+@testset "BlockAssembler scatter ($blockname blocks)" for (blockname, BT) in BLOCK_TYPES
+    grid = generate_grid(Triangle, (10, 10))
+    dh = DofHandler(grid)
+    ip = Lagrange{RefTriangle, 1}()
+    add!(dh, :u, ip^2)
+    add!(dh, :p, ip)
+    close!(dh)
+    renumber!(dh, DofOrder.FieldWise())
+    nd = ndofs(dh) ÷ 3
+
+    bsp = BlockSparsityPattern([2nd, 1nd])
+    add_sparsity_entries!(bsp, dh)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, bsp)
+    fB = similar(KB, axes(KB, 1))
+
+    npc = ndofs_per_cell(dh)
+    ke = rand(npc, npc)
+    fe = rand(npc)
+    dofs = celldofs(dh, 1)
+
+    # The scatter reuses the buffers in the assembler, so after the first cell an assembly
+    # loop must not allocate at all.
+    assembler = start_assemble(KB, fB)
+    assemble!(assembler, dofs, ke, fe)
+    @test (@allocated assemble!(assembler, dofs, ke, fe)) == 0
+    @test (@allocated assemble!(assembler, dofs, ke)) == 0
+
+    # Writing outside the sparsity pattern is reported with the global dof numbers, even
+    # though each block is assembled through block local indices. The :p dofs live in the
+    # second block, so the reported index is only correct if the block offset is applied.
+    pdofs = filter(>(2nd), dofs)
+    KB = allocate_matrix(BlockMatrix{Float64, Matrix{BT}}, BlockSparsityPattern([2nd, 1nd]))
+    assembler = start_assemble(KB)
+    m = minimum(pdofs)
+    @test_throws "K[$m, $m]" assemble!(assembler, pdofs, ones(length(pdofs), length(pdofs)))
+end

--- a/test/blockarrays.jl
+++ b/test/blockarrays.jl
@@ -325,6 +325,11 @@ end
     g[dofs] = fe
     @test KB == D
     @test fB == g
+
+    # Element arrays are bounds checked before entering the inbounds scatter loops
+    @test_throws BoundsError assemble!(assembler, dofs, ones(1, 1), fe)
+    @test_throws BoundsError assemble!(assembler, dofs, ke, ones(1))
+
     # Atomic assembly is not supported for dense blocks
     atomic_assembler = start_assemble(KB, fB; atomic = true)
     @test_throws ErrorException assemble!(atomic_assembler, dofs, ke, fe)

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -31,11 +31,49 @@ using SparseArrays, LinearAlgebra
         @test K1 == K2
         @test f0 ≈ f1
         @test f1 ≈ f2
-        # Error for affine constraints
+        # Affine constraints are condensed just like for the CSC matrix. The sparsity pattern
+        # has to hold the fill-in, so allocate it through the constraint handler.
         ch = ConstraintHandler(dh)
         add!(ch, AffineConstraint(1, [3 => 1.0], 1.0))
         close!(ch)
-        @test_throws ErrorException("condensation of ::SparseMatrixCSR{1, Float64, Int64} matrix not supported") apply!(K2, f2, ch)
+        Kc = allocate_matrix(dh, ch)
+        Kr = allocate_matrix(SparseMatrixCSR, dh, ch)
+        ac = start_assemble(Kc)
+        ar = start_assemble(Kr)
+        ke = [1.0 2.0; 3.0 4.0]
+        for dofs in ([1, 2], [3, 2])
+            assemble!(ac, dofs, ke)
+            assemble!(ar, dofs, ke)
+        end
+        @test Kc ≈ Kr
+        fc = collect(1.0:3.0)
+        fr = collect(1.0:3.0)
+        apply!(Kc, fc, ch)
+        apply!(Kr, fr, ch)
+        @test Kc ≈ Kr
+        @test fc ≈ fr
+        # ... but the symmetric case still is not supported
+        @test_throws ErrorException("condensation of ::Symmetric matrix not supported") apply!(Symmetric(Kr), fr, ch)
+    end
+
+    @testset "addindex!(::SparseMatrixCSR,...)" begin
+        I = [1, 1, 2, 3]
+        J = [1, 3, 2, 3]
+        K = sparsecsr(I, J, zeros(4))
+        Ferrite.addindex!(K, 1.0, 1, 3)
+        Ferrite.addindex!(K, 2.0, 1, 3)
+        @test K[1, 3] == 3.0
+        # Zeros short-circuit before the pattern lookup, also outside the pattern
+        Ferrite.addindex!(K, 0.0, 2, 3)
+        @test K[2, 3] == 0.0
+        # Writing outside the pattern is an error, and the same one as for CSC
+        @test_throws Ferrite.SparsityError Ferrite.addindex!(K, 1.0, 2, 3)
+        @test_throws BoundsError Ferrite.addindex!(K, 1.0, 4, 1)
+        # Atomic accumulation gives identical results sequentially
+        Ka = sparsecsr(I, J, zeros(4))
+        Ferrite.addindex!(Ka, 1.0, 1, 3, Val(true))
+        Ferrite.addindex!(Ka, 2.0, 1, 3, Val(true))
+        @test Ka[1, 3] == K[1, 3]
     end
 
     @testset "assembly integration" begin

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -56,6 +56,26 @@ using SparseArrays, LinearAlgebra
         @test_throws ErrorException("condensation of ::Symmetric matrix not supported") apply!(Symmetric(Kr), fr, ch)
     end
 
+    @testset "add_inhomogeneities!(::SparseMatrixCSR,...)" begin
+        # `apply!` has to reach the format specific kernel, not the generic SpMSpV fallback,
+        # which for a CSR matrix indexes the sparse vector once per stored entry.
+        csr_ext = Base.get_extension(Ferrite, :FerriteSparseMatrixCSR)
+        m = which(Ferrite.add_inhomogeneities!, Tuple{Vector{Float64}, SparseMatrixCSR{1, Float64, Int}, Vector{Int}, Vector{Float64}})
+        @test m.module === csr_ext
+
+        # The inhomogeneities keep their own precision. CSC multiplies each of them by the
+        # stored matrix value, so a Float32 matrix with Float64 constraints does the product in
+        # Float64; CSR gathers them into a dense vector first and must not round them to
+        # Float32 on the way. `1 + 2^-30` is exactly the difference.
+        A = sparse(Float32[1 0; 0 1])
+        v = 1.0 + 2.0^-30
+        for K in (A, sparsecsr(findnz(A)..., size(A)...))
+            f = zeros(Float64, 2)
+            Ferrite.add_inhomogeneities!(f, K, [1], [v])
+            @test f[1] == -v
+        end
+    end
+
     @testset "addindex!(::SparseMatrixCSR,...)" begin
         I = [1, 1, 2, 3]
         J = [1, 3, 2, 3]
@@ -258,6 +278,52 @@ using SparseArrays, LinearAlgebra
                 @test_throws ErrorException assemble!(a, dofs, Ke_rand)
             end
         end
+    end
+
+    @testset "concurrent apply_assemble! ($name)" for (name, allocate) in (
+            "CSC" => (dh, ch) -> allocate_matrix(dh, ch),
+            "CSR" => (dh, ch) -> allocate_matrix(SparseMatrixCSR, dh, ch),
+        )
+        # Condensing a constraint that reaches outside the element (here periodic) makes
+        # `apply_assemble!` write into the global matrix and vector, so those writes have to be
+        # atomic too when the assembler is. See test/blockarrays.jl for the BlockAssembler.
+        grid = generate_grid(Triangle, (10, 10))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefTriangle, 1}())
+        close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, PeriodicDirichlet(:u, collect_periodic_facets(grid, "top", "bottom")))
+        close!(ch)
+        update!(ch, 0)
+
+        element_matrix(dofs) = [sin(i * j / 100) for i in dofs, j in dofs]
+        element_vector(dofs) = [cos(i) for i in dofs]
+
+        Ks = allocate(dh, ch)
+        fs = zeros(ndofs(dh))
+        let assembler = start_assemble(Ks, fs; atomic = true)
+            for cc in CellIterator(dh)
+                dofs = celldofs(cc)
+                apply_assemble!(assembler, ch, dofs, element_matrix(dofs), element_vector(dofs))
+            end
+        end
+
+        # Shared K and f, but one assembler per task and no coloring
+        Kc = allocate(dh, ch)
+        fc = zeros(ndofs(dh))
+        _ = start_assemble(Kc, fc) # zero out
+        @sync for chunk in Iterators.partition(1:getncells(grid), cld(getncells(grid), 4))
+            Threads.@spawn begin
+                assembler = start_assemble(Kc, fc; fillzero = false, atomic = true)
+                for cellidx in chunk
+                    dofs = celldofs(dh, cellidx)
+                    apply_assemble!(assembler, ch, dofs, element_matrix(dofs), element_vector(dofs))
+                end
+            end
+        end
+        # Equal up to the (task dependent) summation order
+        @test Kc ≈ Ks rtol = 1.0e-14
+        @test fc ≈ fs rtol = 1.0e-14
     end
 
 end


### PR DESCRIPTION
Closes #1460 . I added some refactoring of the internal assembly and constraints paths to avoid excessive code duplication on the CSR/CSC/Block CSR/Block CSC paths.