### PR TITLE
Add dof functionals information for shape functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.7.0] - 2026-08-31
 
 ### Added
+ - Each local dof of an interpolation now has a queryable *dof functional* describing
+   its physical meaning (`PointValue`, `PointDerivative`, `NormalMoment`, ...), see
+   `Ferrite.dof_functionals`. `Dirichlet` accepts a new `functional` keyword to select
+   which dofs to constrain (default `PointValue`, i.e. unchanged behavior). ([#1493])
+ - Sharing a field name between `SubDofHandler`s whose interpolations put incompatible
+   dof functionals on shared entities (e.g. `Lagrange^2` vs `RaviartThomas`, or
+   `Lagrange` of order 2 vs 3) is now an error instead of silently assigning the same
+   dof numbers to unrelated dofs. ([#1493])
  - Added mesh-free [`AlgebraicVariable`s](https://ferrite-fem.github.io/Ferrite.jl/dev/topics/algebraic_variables/)
    and coupling descriptors for small global unknowns such as Lagrange multipliers and
    homogenized quantities. See the documentation for details. ([#1422])
@@ -1455,3 +1463,4 @@ poking into Ferrite internals:
 [#1481]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1481
 [#1489]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1489
 [#1490]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1490
+[#1493]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1493

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.7.0] - 2026-08-31
+## [Next] - xxxx-xx-xx
 
 ### Added
  - Each local dof of an interpolation now has a queryable *dof functional* describing
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    dof definitions on shared entities (different functionals, counts, or point locations;
    e.g. `Lagrange^2` vs `RaviartThomas`, or `Lagrange` of order 2 vs 3) is now an error
    instead of silently assigning the same dof numbers to unrelated dofs. ([#1493])
+
+## [v1.7.0] - 2026-08-31
+
+### Added
  - Added mesh-free [`AlgebraicVariable`s](https://ferrite-fem.github.io/Ferrite.jl/dev/topics/algebraic_variables/)
    and coupling descriptors for small global unknowns such as Lagrange multipliers and
    homogenized quantities. See the documentation for details. ([#1422])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Each local dof of an interpolation now has a queryable *dof functional* describing
    how it evaluates a function (`PointValue`, `PointDerivative`, `NormalMoment`, ...), see
-   `Ferrite.dof_functionals`. `Dirichlet` accepts a new `functional` keyword to select
-   which dofs to constrain (default `PointValue()`, i.e. unchanged behavior). ([#1493])
+   `Ferrite.dof_functionals`. Dofs of vectorized interpolations wrap the scalar functional
+   in `VectorizedFunctional` together with the direction. `Dirichlet` accepts a new
+   `functional` keyword to select which dofs to constrain (default `PointValue()`, i.e.
+   unchanged behavior); for vectorized interpolations `components` selects the direction
+   as before. ([#1493])
  - Sharing a field name between `SubDofHandler`s whose interpolations put incompatible
    dof definitions on shared entities (different functionals, counts, or point locations;
    e.g. `Lagrange^2` vs `RaviartThomas`, or `Lagrange` of order 2 vs 3) is now an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - Each local dof of an interpolation now has a queryable *dof functional* describing
-   its physical meaning (`PointValue`, `PointDerivative`, `NormalMoment`, ...), see
+   how it evaluates a function (`PointValue`, `PointDerivative`, `NormalMoment`, ...), see
    `Ferrite.dof_functionals`. `Dirichlet` accepts a new `functional` keyword to select
-   which dofs to constrain (default `PointValue`, i.e. unchanged behavior). ([#1493])
+   which dofs to constrain (default `PointValue()`, i.e. unchanged behavior). ([#1493])
  - Sharing a field name between `SubDofHandler`s whose interpolations put incompatible
-   dof functionals on shared entities (e.g. `Lagrange^2` vs `RaviartThomas`, or
-   `Lagrange` of order 2 vs 3) is now an error instead of silently assigning the same
-   dof numbers to unrelated dofs. ([#1493])
+   dof definitions on shared entities (different functionals, counts, or point locations;
+   e.g. `Lagrange^2` vs `RaviartThomas`, or `Lagrange` of order 2 vs 3) is now an error
+   instead of silently assigning the same dof numbers to unrelated dofs. ([#1493])
  - Added mesh-free [`AlgebraicVariable`s](https://ferrite-fem.github.io/Ferrite.jl/dev/topics/algebraic_variables/)
    and coupling descriptors for small global unknowns such as Lagrange multipliers and
    homogenized quantities. See the documentation for details. ([#1422])

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -47,6 +47,31 @@ Ferrite.mapping_type
 Ferrite.get_direction
 ```
 
+#### Implementing dof functionals
+Every local dof carries a [`Ferrite.DofFunctional`](@ref) describing its physical meaning,
+queryable with [`Ferrite.dof_functionals`](@ref). Scalar interpolations default to
+all-[`PointValue`](@ref) (correct for nodal bases) and MUST override the method if some
+dofs are not plain point evaluations; interpolations subtyping `VectorInterpolation`
+directly (e.g. `RaviartThomas`) have no fallback and must always define it.
+
+The functional identifies *what* a dof is, never *where* it is located -- geometry stays
+in `reference_coordinates` and the entity dof-index functions -- so that functionals can
+be compared between cells sharing an entity. This comparison is used when a field is
+shared between `SubDofHandler`s: entities that can be shared between cells (vertices,
+edges, and faces in 3D grids) must carry the same dof functional signature in all
+subdomains, otherwise `add!` errors instead of silently aliasing unrelated dofs. Note
+that the moment functionals do not encode the weight function or normalization
+convention, so equal signatures from different interpolation families do not guarantee
+identical functionals.
+
+```@docs; canonical=false
+Ferrite.DofFunctional
+Ferrite.dof_functionals
+```
+```@docs
+Ferrite.matches_functional
+```
+
 #### Interpolations that cannot be constructed from their type
 For interpolations, `ip`, for which `ip == typeof(ip)()` is false (or doesn't work), the following must be implemented manually
 ```@docs

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -54,9 +54,9 @@ all-[`PointValue`](@ref) (correct for nodal bases) and MUST override the method 
 dofs are not plain point evaluations; interpolations subtyping `VectorInterpolation`
 directly (e.g. `RaviartThomas`) have no fallback and must always define it.
 
-Point-supported functionals include their reference coordinate and, for vectorized
-interpolations, direction. Their owning entity is described by the entity dof-index
-functions. When a field is shared between `SubDofHandler`s, shared entities must carry
+Functionals describe only the kind of dof: the owning entity is described by the entity
+dof-index functions and the point of a point-supported dof `i` by
+`reference_coordinates(ip)[i]`. When a field is shared between `SubDofHandler`s, shared entities must carry
 compatible functional signatures and point-supported dofs must have the same entity-local
 coordinates. Otherwise, `add!` errors instead of silently aliasing unrelated dofs.
 Moment functionals do not encode their weight or normalization, so equal signatures from

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -48,21 +48,21 @@ Ferrite.get_direction
 ```
 
 #### Implementing dof functionals
-Every local dof carries a [`Ferrite.DofFunctional`](@ref) describing its physical meaning,
-queryable with [`Ferrite.dof_functionals`](@ref). Scalar interpolations default to
+Every local dof carries a [`Ferrite.DofFunctional`](@ref) describing how it evaluates a
+function, queryable with [`Ferrite.dof_functionals`](@ref). Scalar interpolations default to
 all-[`PointValue`](@ref) (correct for nodal bases) and MUST override the method if some
 dofs are not plain point evaluations; interpolations subtyping `VectorInterpolation`
 directly (e.g. `RaviartThomas`) have no fallback and must always define it.
 
-The functional identifies *what* a dof is, never *where* it is located -- geometry stays
-in `reference_coordinates` and the entity dof-index functions -- so that functionals can
-be compared between cells sharing an entity. This comparison is used when a field is
-shared between `SubDofHandler`s: entities that can be shared between cells (vertices,
-edges, and faces in 3D grids) must carry the same dof functional signature in all
-subdomains, otherwise `add!` errors instead of silently aliasing unrelated dofs. Note
-that the moment functionals do not encode the weight function or normalization
-convention, so equal signatures from different interpolation families do not guarantee
-identical functionals.
+Point-supported functionals include their reference coordinate and, for vectorized
+interpolations, direction. Their owning entity is described by the entity dof-index
+functions. When a field is shared between `SubDofHandler`s, shared entities must carry
+compatible functional signatures and point-supported dofs must have the same entity-local
+coordinates. Otherwise, `add!` errors instead of silently aliasing unrelated dofs.
+Moment functionals do not encode their weight or normalization, so equal signatures from
+different interpolation families do not guarantee identical functionals. A
+`VectorizedInterpolation` repeats each scalar-base functional with its vector direction
+in scalar-dof-major, direction-minor order.
 
 ```@docs; canonical=false
 Ferrite.DofFunctional

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -62,7 +62,8 @@ coordinates. Otherwise, `add!` errors instead of silently aliasing unrelated dof
 Moment functionals do not encode their weight or normalization, so equal signatures from
 different interpolation families do not guarantee identical functionals. A
 `VectorizedInterpolation` repeats each scalar-base functional with its vector direction
-in scalar-dof-major, direction-minor order.
+in scalar-dof-major, direction-minor order. Its `reference_coordinates` are stored once
+per scalar dof; vectorized dof `i` uses coordinate `fld1(i, n_components(ip))`.
 
 ```@docs; canonical=false
 Ferrite.DofFunctional

--- a/docs/src/reference/interpolations.md
+++ b/docs/src/reference/interpolations.md
@@ -23,3 +23,22 @@ BubbleEnrichedLagrange
 CrouzeixRaviart
 RannacherTurek
 ```
+
+## [Dof functionals](@id dof-functionals)
+
+Each local dof of an interpolation has a *dof functional* describing its physical
+meaning. Most interpolations have only [`PointValue`](@ref) dofs, but e.g. H(div)/H(curl)
+interpolations have integral moment dofs, and Hermite-type interpolations have derivative
+dofs. The functional can be used to select which dofs a [`Dirichlet`](@ref) condition
+constrains.
+
+```@docs
+Ferrite.DofFunctional
+PointValue
+PointDerivative
+IntegralMoment
+NormalMoment
+TangentialMoment
+InteriorMoment
+Ferrite.dof_functionals
+```

--- a/docs/src/reference/interpolations.md
+++ b/docs/src/reference/interpolations.md
@@ -40,5 +40,6 @@ IntegralMoment
 NormalMoment
 TangentialMoment
 InteriorMoment
+VectorizedFunctional
 Ferrite.dof_functionals
 ```

--- a/docs/src/reference/interpolations.md
+++ b/docs/src/reference/interpolations.md
@@ -26,8 +26,8 @@ RannacherTurek
 
 ## [Dof functionals](@id dof-functionals)
 
-Each local dof of an interpolation has a *dof functional* describing its physical
-meaning. Most interpolations have only [`PointValue`](@ref) dofs, but e.g. H(div)/H(curl)
+Each local dof of an interpolation has a *dof functional* describing how it evaluates a
+function. Most interpolations have only [`PointValue`](@ref) dofs, but e.g. H(div)/H(curl)
 interpolations have integral moment dofs, and Hermite-type interpolations have derivative
 dofs. The functional can be used to select which dofs a [`Dirichlet`](@ref) condition
 constrains.

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -93,6 +93,18 @@ end
     Most examples make use of Dirichlet boundary conditions, for example [Heat
     Equation](@ref tutorial-heat-equation).
 
+### Constraining dofs by kind
+
+Some interpolations have dofs representing more than one kind of quantity (see
+[Dof functionals](@ref dof-functionals)). By default a `Dirichlet` condition constrains the dofs
+representing function values ([`PointValue`](@ref)); the `functional` keyword selects
+other kinds. For example, for a Hermite-type interpolation with both value and derivative
+dofs, the derivative can be prescribed with
+
+```julia
+dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative)
+```
+
 ## ProjectedDirichlet
 Some interpolations don't have nodal support points:
 ``H(\mathrm{curl})`` interpolations, e.g., `Nedelec`, are associated to edges and faces,

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -99,11 +99,14 @@ Some interpolations have dofs representing more than one kind of quantity (see
 [Dof functionals](@ref dof-functionals)). By default a `Dirichlet` condition constrains the dofs
 representing function values ([`PointValue`](@ref)); the `functional` keyword selects
 other kinds. For example, for a Hermite-type interpolation with both value and derivative
-dofs, the derivative can be prescribed with
+dofs, the derivatives can be prescribed with
 
 ```julia
 dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative())
 ```
+
+and `PointDerivative(order = 1)` or `PointDerivative((1, 0))` narrow the selection to the
+first derivatives or to a single derivative.
 
 ## ProjectedDirichlet
 Some interpolations don't have nodal support points:

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -102,11 +102,13 @@ other kinds. For example, for a Hermite-type interpolation with both value and d
 dofs, the derivatives can be prescribed with
 
 ```julia
-dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative())
+dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative)
 ```
 
-and `PointDerivative(order = 1)` or `PointDerivative((1, 0))` narrow the selection to the
-first derivatives or to a single derivative.
+where the type `PointDerivative` selects every derivative dof. `PointDerivative{1}` or
+`PointDerivative((1, 0))` narrow the selection to the first derivatives or to a single
+derivative, and a tuple of selectors, e.g.
+`functional = (PointDerivative((2, 0)), PointDerivative((0, 2)))`, constrains the union.
 
 ## ProjectedDirichlet
 Some interpolations don't have nodal support points:

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -102,7 +102,7 @@ other kinds. For example, for a Hermite-type interpolation with both value and d
 dofs, the derivative can be prescribed with
 
 ```julia
-dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative)
+dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative())
 ```
 
 ## ProjectedDirichlet

--- a/docs/src/topics/boundary_conditions.md
+++ b/docs/src/topics/boundary_conditions.md
@@ -105,7 +105,8 @@ dofs, the derivatives can be prescribed with
 dbc = Dirichlet(:w, getfacetset(grid, "left"), Returns(0.0); functional = PointDerivative)
 ```
 
-where the type `PointDerivative` selects every derivative dof. `PointDerivative{1}` or
+Here `f` supplies the derivative value directly; Ferrite does not differentiate it.
+The type `PointDerivative` selects every derivative dof. `PointDerivative{1}` or
 `PointDerivative((1, 0))` narrow the selection to the first derivatives or to a single
 derivative, and a tuple of selectors, e.g.
 `functional = (PointDerivative((2, 0)), PointDerivative((0, 2)))`, constrains the union.

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -14,8 +14,9 @@ represent more than one kind of [`Ferrite.DofFunctional`](@ref) (cf.
 [`Ferrite.dof_functionals`](@ref)). The default, `PointValue()`, constrains the
 dofs whose value is the function value at the dof location. Omitted properties act as
 wildcards, e.g. `functional = PointDerivative()` selects all derivative dofs of a
-Hermite-type interpolation while `functional = PointDerivative((1, 0))` selects one
-derivative. For vectorized interpolations `functional` selects the kind of dof (the
+Hermite-type interpolation, `functional = PointDerivative(order = 1)` its first
+derivatives, and `functional = PointDerivative((1, 0))` one derivative. For vectorized
+interpolations `functional` selects the kind of dof (the
 scalar functional) and `components` selects the direction.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -12,12 +12,12 @@ of `u` are prescribed.
 `functional` selects which dofs the condition constrains, for interpolations whose dofs
 represent more than one kind of [`Ferrite.DofFunctional`](@ref) (cf.
 [`Ferrite.dof_functionals`](@ref)). The default, `PointValue()`, constrains the
-dofs whose value is the function value at the dof location. Omitted properties act as
-wildcards, e.g. `functional = PointDerivative()` selects all derivative dofs of a
-Hermite-type interpolation, `functional = PointDerivative(order = 1)` its first
-derivatives, and `functional = PointDerivative((1, 0))` one derivative. For vectorized
-interpolations `functional` selects the kind of dof (the
-scalar functional) and `components` selects the direction.
+dofs whose value is the function value at the dof location. A functional type acts as a
+wildcard, e.g. `functional = PointDerivative` selects all derivative dofs of a
+Hermite-type interpolation and `functional = PointDerivative{1}` its first derivatives,
+while `functional = PointDerivative((1, 0))` selects a single derivative and a tuple of
+selectors the union of its elements. For vectorized interpolations `functional` selects
+the kind of dof (the scalar functional) and `components` selects the direction.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -53,11 +53,13 @@ struct Dirichlet # <: Constraint
     facets::OrderedSet{T} where {T <: Union{Int, FacetIndex, FaceIndex, EdgeIndex, VertexIndex}}
     field_name::Symbol
     components::Vector{Int} # components of the field
-    functional::DofFunctional # which dofs to constrain (cf. dof_functionals)
+    functional::DofFunctionalSelector # which dofs to constrain (cf. dof_functionals)
     local_facet_dofs::Vector{Int}
     local_facet_dofs_offset::Vector{Int}
 end
-function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; functional::DofFunctional = PointValue())
+function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; functional::DofFunctionalSelector = PointValue())
+    all(_is_selector, _selector_tuple(functional)) ||
+        throw(ArgumentError("`functional` must be a `DofFunctional` instance, type, or tuple of those (got $functional)"))
     return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), functional, Int[], Int[])
 end
 
@@ -1232,7 +1234,7 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
         # The selector is matched against the scalar functionals of the base interpolation;
         # `components` selects the direction of a vectorized interpolation
-        if dbc.functional isa VectorizedFunctional
+        if any(s -> s isa VectorizedFunctional || (s isa Type && s <: VectorizedFunctional), _selector_tuple(dbc.functional))
             throw(ArgumentError("`functional` selects the scalar functional of a vectorized interpolation (got $(dbc.functional)); select the direction with `components` instead"))
         end
         fs = dof_functionals(interpolation)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1,6 +1,6 @@
 # abstract type Constraint end
 """
-    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing)
+    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing; functional = PointValue)
 
 Create a Dirichlet boundary condition on `u` on the `∂Ω` part of
 the boundary. `f` is a function of the form `f(x)` or `f(x, t)`
@@ -8,6 +8,18 @@ where `x` is the spatial coordinate and `t` is the current time,
 and returns the prescribed value. `components` specify the components
 of `u` that are prescribed by this condition. By default all components
 of `u` are prescribed.
+
+`functional` selects which dofs the condition constrains, for interpolations whose dofs
+represent more than one kind of [`Ferrite.DofFunctional`](@ref) (cf.
+[`Ferrite.dof_functionals`](@ref)). The default, [`PointValue`](@ref), constrains the
+dofs whose value is the function value at the dof location. Pass a `DofFunctional`
+subtype to constrain all dofs of that family, or an instance to constrain exactly
+matching dofs, e.g. `functional = PointDerivative` for all derivative dofs of a
+Hermite-type interpolation. Note that all matched dofs at a location are prescribed the
+same value `f(x, t)`, so a family selector matching several distinct dofs (e.g. both
+``\\partial_x`` and ``\\partial_y`` derivative dofs at a vertex) is typically only
+meaningful for homogeneous conditions; prescribe distinct values with one condition per
+exact functional, e.g. `functional = PointDerivative((1, 0))`.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -43,11 +55,12 @@ struct Dirichlet # <: Constraint
     facets::OrderedSet{T} where {T <: Union{Int, FacetIndex, FaceIndex, EdgeIndex, VertexIndex}}
     field_name::Symbol
     components::Vector{Int} # components of the field
+    functional::Union{Type{<:DofFunctional}, DofFunctional} # which dofs to constrain (cf. dof_functionals)
     local_facet_dofs::Vector{Int}
     local_facet_dofs_offset::Vector{Int}
 end
-function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing)
-    return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), Int[], Int[])
+function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; functional::Union{Type{<:DofFunctional}, DofFunctional} = PointValue)
+    return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), functional, Int[], Int[])
 end
 
 # components=nothing is default and means that all components should be constrained
@@ -275,6 +288,9 @@ function Base.show(io::IO, ::MIME"text/plain", ch::ConstraintHandler)
         print(io, "  BCs:")
         for dbc in ch.dbcs
             print(io, "\n    ", "Field: ", dbc.field_name, ", ", "Components: ", dbc.components)
+            if !(dbc.functional === PointValue || dbc.functional === PointValue())
+                print(io, ", ", "Functional: ", dbc.functional)
+            end
         end
     end
     return
@@ -403,7 +419,7 @@ end
 # Dirichlet on (facet|face|edge|vertex)set
 function _add!(ch::ConstraintHandler, dbc::Dirichlet, bcfacets::AbstractVecOrSet{Index}, interpolation::Interpolation, field_dim::Int, offset::Int, bcvalue::BCValues, _) where {Index <: BoundaryIndex}
     local_facet_dofs, local_facet_dofs_offset =
-        _local_facet_dofs_for_bc(interpolation, field_dim, dbc.components, offset, dirichlet_boundarydof_indices(eltype(bcfacets)))
+        _local_facet_dofs_for_bc(interpolation, field_dim, dbc.components, offset, dirichlet_boundarydof_indices(eltype(bcfacets)), dbc.functional)
     copy!(dbc.local_facet_dofs, local_facet_dofs)
     copy!(dbc.local_facet_dofs_offset, local_facet_dofs_offset)
 
@@ -428,14 +444,23 @@ end
 
 # Calculate which local dof index live on each facet:
 # facet `i` have dofs `local_facet_dofs[local_facet_dofs_offset[i]:local_facet_dofs_offset[i+1]-1]
-function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, boundaryfunc::F = dirichlet_facetdof_indices) where {F}
+function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, boundaryfunc::F = dirichlet_facetdof_indices, functional = nothing) where {F}
     @assert issorted(components)
+    # `functional === nothing` means no filtering (the PeriodicDirichlet and
+    # ProjectedDirichlet callers); the filter must mirror the one in `BCValues` to keep
+    # the dof list and the pseudo quadrature points index-aligned
+    functionals = functional === nothing ? nothing : dof_functionals(interpolation)
     local_facet_dofs = Int[]
     local_facet_dofs_offset = Int[1]
     for (_, facet) in enumerate(boundaryfunc(interpolation))
-        for fdof in facet, d in 1:field_dim
-            if d in components
-                push!(local_facet_dofs, (fdof - 1) * field_dim + d + offset)
+        for fdof in facet
+            if functionals !== nothing
+                matches_functional(functional, functionals[fdof]) || continue
+            end
+            for d in 1:field_dim
+                if d in components
+                    push!(local_facet_dofs, (fdof - 1) * field_dim + d + offset)
+                end
             end
         end
         push!(local_facet_dofs_offset, length(local_facet_dofs) + 1)
@@ -1210,14 +1235,33 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         end
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
+        fs = dof_functionals(interpolation)
         if EntityType <: Integer
+            # The node idx -> local dof idx assumption in the nodeset _add! below only
+            # holds for purely nodal interpolations
+            if !(all(f -> f isa PointValue, fs) && matches_functional(dbc.functional, PointValue()))
+                throw(ArgumentError("Dirichlet conditions on a nodeset are only supported for interpolations whose dofs are all point values (got $(interpolation) with functional = $(dbc.functional)); use a facetset or vertexset instead."))
+            end
             # BCValues are just dummy for nodesets so set to FacetIndex
             EntityType = FacetIndex
+        else
+            # Validate the selector against the dofs on the constrained boundary
+            # entities (the same enumeration BCValues and _add! use)
+            boundarydofs = dirichlet_boundarydof_indices(EntityType)(interpolation)
+            used_entities = unique(entityidx for (_, entityidx) in filtered_set)
+            matched = unique(fs[i] for e in used_entities for i in boundarydofs[e] if matches_functional(dbc.functional, fs[i]))
+            if isempty(matched)
+                available = unique(fs[i] for e in used_entities for i in boundarydofs[e])
+                error("interpolation $(interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) on the constrained boundary entities (available functionals: $(join(available, ", ")))")
+            end
+            if any(f -> f isa IntegralMoment, matched)
+                error("dofs with integral moment functionals cannot be prescribed with `Dirichlet`; use `ProjectedDirichlet` instead")
+            end
         end
         CT = getcelltype(sdh) # Same celltype enforced in SubDofHandler constructor
-        bcvalues = BCValues(Tv, Ti, interpolation, geometric_interpolation(CT), EntityType)
+        bcvalues = BCValues(Tv, Ti, interpolation, geometric_interpolation(CT), EntityType, dbc.functional)
         # Recreate the Dirichlet(...) struct with the filtered set and call internal add!
-        filtered_dbc = Dirichlet(dbc.field_name, filtered_set, dbc.f, components)
+        filtered_dbc = Dirichlet(dbc.field_name, filtered_set, dbc.f, components; functional = dbc.functional)
         _add!(
             ch, filtered_dbc, filtered_dbc.facets, interpolation, n_comp,
             field_offset(sdh, field_idx), bcvalues, sdh.cellset,

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -17,7 +17,8 @@ wildcard, e.g. `functional = PointDerivative` selects all derivative dofs of a
 Hermite-type interpolation and `functional = PointDerivative{1}` its first derivatives,
 while `functional = PointDerivative((1, 0))` selects a single derivative and a tuple of
 selectors the union of its elements. For vectorized interpolations `functional` selects
-the kind of dof (the scalar functional) and `components` selects the direction.
+the kind of dof (the scalar functional) and `components` selects the direction. For a
+derivative dof, `f` returns the prescribed derivative value; it is not differentiated.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -446,13 +447,11 @@ end
 # facet `i` have dofs `local_facet_dofs[local_facet_dofs_offset[i]:local_facet_dofs_offset[i+1]-1]
 function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, boundaryfunc::F = dirichlet_facetdof_indices, functional = nothing) where {F}
     @assert issorted(components)
-    # `functional === nothing` means no filtering (the PeriodicDirichlet and
-    # ProjectedDirichlet callers); the filter must mirror the one in `BCValues` to keep
-    # the dof list and the pseudo quadrature points index-aligned
+    # Keep filtering aligned with BCValues; `nothing` leaves dofs unfiltered.
     functionals = functional === nothing ? nothing : dof_functionals(interpolation)
     local_facet_dofs = Int[]
     local_facet_dofs_offset = Int[1]
-    for (_, facet) in enumerate(boundaryfunc(interpolation))
+    for facet in boundaryfunc(interpolation)
         for fdof in facet
             if functionals !== nothing
                 matches_functional(functional, functionals[fdof]) || continue
@@ -1232,15 +1231,12 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         end
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
-        # The selector is matched against the scalar functionals of the base interpolation;
-        # `components` selects the direction of a vectorized interpolation
         if any(s -> s isa VectorizedFunctional || (s isa Type && s <: VectorizedFunctional), _selector_tuple(dbc.functional))
             throw(ArgumentError("`functional` selects the scalar functional of a vectorized interpolation (got $(dbc.functional)); select the direction with `components` instead"))
         end
         fs = dof_functionals(interpolation)
         if EntityType <: Integer
-            # The node idx -> local dof idx assumption in the nodeset _add! below only
-            # holds for purely nodal interpolations
+            # The nodeset path assumes node indices correspond to local dof indices.
             all(f -> f isa PointValue, fs) ||
                 throw(ArgumentError("Dirichlet conditions on a nodeset are only supported for interpolations whose dofs are all point values (got $(field_interpolation)); use a facetset or vertexset instead."))
             if !any(f -> matches_functional(dbc.functional, f), fs)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -15,8 +15,8 @@ represent more than one kind of [`Ferrite.DofFunctional`](@ref) (cf.
 dofs whose value is the function value at the dof location. Omitted properties act as
 wildcards, e.g. `functional = PointDerivative()` selects all derivative dofs of a
 Hermite-type interpolation while `functional = PointDerivative((1, 0))` selects one
-derivative. For vectorized interpolations a direction can also be selected, e.g.
-`PointValue(2)`; this is equivalent to intersecting the selection with `components = [2]`.
+derivative. For vectorized interpolations `functional` selects the kind of dof (the
+scalar functional) and `components` selects the direction.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -446,7 +446,6 @@ function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, 
     # `functional === nothing` means no filtering (the PeriodicDirichlet and
     # ProjectedDirichlet callers); the filter must mirror the one in `BCValues` to keep
     # the dof list and the pseudo quadrature points index-aligned
-    functional = functional === nothing ? nothing : _base_functional(functional)
     functionals = functional === nothing ? nothing : dof_functionals(interpolation)
     local_facet_dofs = Int[]
     local_facet_dofs_offset = Int[1]
@@ -1230,43 +1229,32 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         end
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
-        fs = dof_functionals(field_interpolation)
+        # The selector is matched against the scalar functionals of the base interpolation;
+        # `components` selects the direction of a vectorized interpolation
+        if dbc.functional isa VectorizedFunctional
+            throw(ArgumentError("`functional` selects the scalar functional of a vectorized interpolation (got $(dbc.functional)); select the direction with `components` instead"))
+        end
+        fs = dof_functionals(interpolation)
         if EntityType <: Integer
             # The node idx -> local dof idx assumption in the nodeset _add! below only
             # holds for purely nodal interpolations
             all(f -> f isa PointValue, fs) ||
                 throw(ArgumentError("Dirichlet conditions on a nodeset are only supported for interpolations whose dofs are all point values (got $(field_interpolation)); use a facetset or vertexset instead."))
-            if dbc.functional isa PointValue && dbc.functional.x !== nothing
-                throw(ArgumentError("a point-specific functional selector is not supported for nodeset Dirichlet conditions; select nodes through the nodeset itself"))
+            if !any(f -> matches_functional(dbc.functional, f), fs)
+                error("interpolation $(field_interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional)")
             end
-            matched_components = if field_interpolation isa VectorizedInterpolation
-                [c for c in components if any(i -> matches_functional(dbc.functional, fs[i]), c:n_comp:length(fs))]
-            else
-                any(f -> matches_functional(dbc.functional, f), fs) ? components : Int[]
-            end
-            if isempty(matched_components)
-                error("interpolation $(field_interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) in components $(components)")
-            end
-            components = matched_components
             # BCValues are just dummy for nodesets so set to FacetIndex
             EntityType = FacetIndex
         else
             boundarydofs = dirichlet_boundarydof_indices(EntityType)(interpolation)
             used_entities = unique(entityidx for (_, entityidx) in filtered_set)
-            available = if field_interpolation isa VectorizedInterpolation
-                unique(fs[(i - 1) * n_comp + c] for e in used_entities for i in boundarydofs[e] for c in components)
-            else
-                unique(fs[i] for e in used_entities for i in boundarydofs[e])
-            end
+            available = unique(fs[i] for e in used_entities for i in boundarydofs[e])
             matched = filter(f -> matches_functional(dbc.functional, f), available)
             if isempty(matched)
                 error("interpolation $(field_interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) on the constrained boundary entities (available functionals: $(join(available, ", ")))")
             end
             if any(f -> f isa IntegralMoment, matched)
                 error("dofs with integral moment functionals cannot be prescribed with `Dirichlet`; use `ProjectedDirichlet` instead")
-            end
-            if field_interpolation isa VectorizedInterpolation
-                components = [c for c in components if any(f -> matches_functional(dbc.functional, f), fs[c:n_comp:length(fs)])]
             end
         end
         CT = getcelltype(sdh) # Same celltype enforced in SubDofHandler constructor

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1,6 +1,6 @@
 # abstract type Constraint end
 """
-    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing; functional = PointValue)
+    Dirichlet(u::Symbol, ∂Ω::AbstractVecOrSet, f::Function, components = nothing; functional = PointValue())
 
 Create a Dirichlet boundary condition on `u` on the `∂Ω` part of
 the boundary. `f` is a function of the form `f(x)` or `f(x, t)`
@@ -11,15 +11,12 @@ of `u` are prescribed.
 
 `functional` selects which dofs the condition constrains, for interpolations whose dofs
 represent more than one kind of [`Ferrite.DofFunctional`](@ref) (cf.
-[`Ferrite.dof_functionals`](@ref)). The default, [`PointValue`](@ref), constrains the
-dofs whose value is the function value at the dof location. Pass a `DofFunctional`
-subtype to constrain all dofs of that family, or an instance to constrain exactly
-matching dofs, e.g. `functional = PointDerivative` for all derivative dofs of a
-Hermite-type interpolation. Note that all matched dofs at a location are prescribed the
-same value `f(x, t)`, so a family selector matching several distinct dofs (e.g. both
-``\\partial_x`` and ``\\partial_y`` derivative dofs at a vertex) is typically only
-meaningful for homogeneous conditions; prescribe distinct values with one condition per
-exact functional, e.g. `functional = PointDerivative((1, 0))`.
+[`Ferrite.dof_functionals`](@ref)). The default, `PointValue()`, constrains the
+dofs whose value is the function value at the dof location. Omitted properties act as
+wildcards, e.g. `functional = PointDerivative()` selects all derivative dofs of a
+Hermite-type interpolation while `functional = PointDerivative((1, 0))` selects one
+derivative. For vectorized interpolations a direction can also be selected, e.g.
+`PointValue(2)`; this is equivalent to intersecting the selection with `components = [2]`.
 
 The set, `∂Ω`, can be an `AbstractSet` or `AbstractVector` with elements of
 type [`FacetIndex`](@ref), [`FaceIndex`](@ref), [`EdgeIndex`](@ref), [`VertexIndex`](@ref),
@@ -55,11 +52,11 @@ struct Dirichlet # <: Constraint
     facets::OrderedSet{T} where {T <: Union{Int, FacetIndex, FaceIndex, EdgeIndex, VertexIndex}}
     field_name::Symbol
     components::Vector{Int} # components of the field
-    functional::Union{Type{<:DofFunctional}, DofFunctional} # which dofs to constrain (cf. dof_functionals)
+    functional::DofFunctional # which dofs to constrain (cf. dof_functionals)
     local_facet_dofs::Vector{Int}
     local_facet_dofs_offset::Vector{Int}
 end
-function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; functional::Union{Type{<:DofFunctional}, DofFunctional} = PointValue)
+function Dirichlet(field_name::Symbol, facets::AbstractVecOrSet, f::Function, components = nothing; functional::DofFunctional = PointValue())
     return Dirichlet(f, convert_to_orderedset(facets), field_name, __to_components(components), functional, Int[], Int[])
 end
 
@@ -288,7 +285,7 @@ function Base.show(io::IO, ::MIME"text/plain", ch::ConstraintHandler)
         print(io, "  BCs:")
         for dbc in ch.dbcs
             print(io, "\n    ", "Field: ", dbc.field_name, ", ", "Components: ", dbc.components)
-            if !(dbc.functional === PointValue || dbc.functional === PointValue())
+            if dbc.functional != PointValue()
                 print(io, ", ", "Functional: ", dbc.functional)
             end
         end
@@ -449,6 +446,7 @@ function _local_facet_dofs_for_bc(interpolation, field_dim, components, offset, 
     # `functional === nothing` means no filtering (the PeriodicDirichlet and
     # ProjectedDirichlet callers); the filter must mirror the one in `BCValues` to keep
     # the dof list and the pseudo quadrature points index-aligned
+    functional = functional === nothing ? nothing : _base_functional(functional)
     functionals = functional === nothing ? nothing : dof_functionals(interpolation)
     local_facet_dofs = Int[]
     local_facet_dofs_offset = Int[1]
@@ -1221,13 +1219,10 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         isempty(filtered_set) && continue
         # Fetch information about the field on this SubDofHandler
         field_idx = find_field(sdh, dbc.field_name)
-        interpolation = getfieldinterpolation(sdh, field_idx)
-        # Internally we use the devectorized version
-        n_comp = n_dbc_components(interpolation)
-        if interpolation isa VectorizedInterpolation
-            interpolation = interpolation.ip
-        end
-        getorder(interpolation) == 0 && error("No dof prescribed for order 0 interpolations")
+        field_interpolation = getfieldinterpolation(sdh, field_idx)
+        n_comp = n_dbc_components(field_interpolation)
+        interpolation = get_base_interpolation(field_interpolation)
+        getorder(field_interpolation) == 0 && error("No dof prescribed for order 0 interpolations")
         # Set up components to prescribe (empty input means prescribe all components)
         components = isempty(dbc.components) ? collect(Int, 1:n_comp) : dbc.components
         if !all(c -> 0 < c <= n_comp, components)
@@ -1235,27 +1230,43 @@ function add!(ch::ConstraintHandler{<:Any, Tv, Ti}, dbc::Dirichlet) where {Tv, T
         end
         # Create BCValues for coordinate evaluation at dof-locations
         EntityType = eltype(dbc.facets) # (Facet|Face|Edge|Vertex)Index
-        fs = dof_functionals(interpolation)
+        fs = dof_functionals(field_interpolation)
         if EntityType <: Integer
             # The node idx -> local dof idx assumption in the nodeset _add! below only
             # holds for purely nodal interpolations
-            if !(all(f -> f isa PointValue, fs) && matches_functional(dbc.functional, PointValue()))
-                throw(ArgumentError("Dirichlet conditions on a nodeset are only supported for interpolations whose dofs are all point values (got $(interpolation) with functional = $(dbc.functional)); use a facetset or vertexset instead."))
+            all(f -> f isa PointValue, fs) ||
+                throw(ArgumentError("Dirichlet conditions on a nodeset are only supported for interpolations whose dofs are all point values (got $(field_interpolation)); use a facetset or vertexset instead."))
+            if dbc.functional isa PointValue && dbc.functional.x !== nothing
+                throw(ArgumentError("a point-specific functional selector is not supported for nodeset Dirichlet conditions; select nodes through the nodeset itself"))
             end
+            matched_components = if field_interpolation isa VectorizedInterpolation
+                [c for c in components if any(i -> matches_functional(dbc.functional, fs[i]), c:n_comp:length(fs))]
+            else
+                any(f -> matches_functional(dbc.functional, f), fs) ? components : Int[]
+            end
+            if isempty(matched_components)
+                error("interpolation $(field_interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) in components $(components)")
+            end
+            components = matched_components
             # BCValues are just dummy for nodesets so set to FacetIndex
             EntityType = FacetIndex
         else
-            # Validate the selector against the dofs on the constrained boundary
-            # entities (the same enumeration BCValues and _add! use)
             boundarydofs = dirichlet_boundarydof_indices(EntityType)(interpolation)
             used_entities = unique(entityidx for (_, entityidx) in filtered_set)
-            matched = unique(fs[i] for e in used_entities for i in boundarydofs[e] if matches_functional(dbc.functional, fs[i]))
+            available = if field_interpolation isa VectorizedInterpolation
+                unique(fs[(i - 1) * n_comp + c] for e in used_entities for i in boundarydofs[e] for c in components)
+            else
+                unique(fs[i] for e in used_entities for i in boundarydofs[e])
+            end
+            matched = filter(f -> matches_functional(dbc.functional, f), available)
             if isempty(matched)
-                available = unique(fs[i] for e in used_entities for i in boundarydofs[e])
-                error("interpolation $(interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) on the constrained boundary entities (available functionals: $(join(available, ", ")))")
+                error("interpolation $(field_interpolation) for field :$(dbc.field_name) has no dofs matching functional $(dbc.functional) on the constrained boundary entities (available functionals: $(join(available, ", ")))")
             end
             if any(f -> f isa IntegralMoment, matched)
                 error("dofs with integral moment functionals cannot be prescribed with `Dirichlet`; use `ProjectedDirichlet` instead")
+            end
+            if field_interpolation isa VectorizedInterpolation
+                components = [c for c in components if any(f -> matches_functional(dbc.functional, f), fs[c:n_comp:length(fs)])]
             end
         end
         CT = getcelltype(sdh) # Same celltype enforced in SubDofHandler constructor

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -418,8 +418,8 @@ function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, _ip::Int
             ("faces", 2, facedof_functionals),
         )
         entity_dim < max_rdim || continue
-        functional_layouts = map(fs -> map(_functional_signature, fs), entity_functionals(ip))
-        _functional_layouts = map(fs -> map(_functional_signature, fs), entity_functionals(_ip))
+        functional_layouts = entity_functionals(ip)
+        _functional_layouts = entity_functionals(_ip)
         sigs = unique(filter(!isempty, collect(functional_layouts)))
         _sigs = unique(filter(!isempty, collect(_functional_layouts)))
         # An entity carrying dofs from only one of the interpolations is never shared
@@ -434,7 +434,7 @@ function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, _ip::Int
         end
         if compatible
             positional = !(length(sigs) == 1 && length(_sigs) == 1)
-            compatible = _point_locations_compatible(ip, _ip, entity_dim, positional)
+            compatible = _point_locations_compatible(get_base_interpolation(ip), get_base_interpolation(_ip), entity_dim, positional)
         end
         if !compatible
             error(
@@ -445,13 +445,6 @@ function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, _ip::Int
         end
     end
     return
-end
-
-_functional_signature(f::DofFunctional) = f
-_functional_signature(f::PointValue) = f.direction === nothing ? PointValue() : PointValue(f.direction)
-function _functional_signature(f::PointDerivative)
-    f.α === nothing && return PointDerivative()
-    return f.direction === nothing ? PointDerivative(f.α) : PointDerivative(f.α, f.direction)
 end
 
 function _point_locations_compatible(ip::Interpolation, _ip::Interpolation, entity_dim::Int, positional::Bool)
@@ -472,13 +465,17 @@ function _point_locations_compatible(ip::Interpolation, _ip::Interpolation, enti
     return _same_point_locations(first(locations), first(_locations))
 end
 
+# Entity-local coordinates of the point-supported dofs (`nothing` for other dofs) of a
+# non-vectorized interpolation.
 function _entity_point_locations(ip::Interpolation, entity_dim::Int)
     functionals = entity_dim == 0 ? vertexdof_functionals(ip) :
         entity_dim == 1 ? edgedof_functionals(ip) : facedof_functionals(ip)
     all(all(f -> !(f isa Union{PointValue, PointDerivative}), fs) for fs in functionals) &&
         return map(fs -> ntuple(_ -> nothing, length(fs)), functionals)
 
-    dof_indices = _entity_dof_indices(ip, entity_dim)
+    dof_indices = entity_dim == 0 ? vertexdof_indices(ip) :
+        entity_dim == 1 ? edgedof_interior_indices(ip) : facedof_interior_indices(ip)
+    dof_coordinates = reference_coordinates(ip)
     vertex_coordinates = reference_coordinates(Lagrange{getrefshape(ip), 1}())
     reference_entities = entity_dim == 0 ? map(i -> (i,), reference_vertices(getrefshape(ip))) :
         entity_dim == 1 ? reference_edges(getrefshape(ip)) : reference_faces(getrefshape(ip))
@@ -486,20 +483,8 @@ function _entity_point_locations(ip::Interpolation, entity_dim::Int)
         entity_coordinates = vertex_coordinates[[entity_vertices...]]
         return map(fs, dofs) do f, dof
             f isa Union{PointValue, PointDerivative} || return nothing
-            x = f.x
-            x === nothing && error("dof_functionals must include the point of every point-supported dof (local dof $dof of $ip)")
-            return _entity_local_coordinate(x, entity_coordinates, entity_dim)
+            return _entity_local_coordinate(dof_coordinates[dof], entity_coordinates, entity_dim)
         end
-    end
-end
-
-function _entity_dof_indices(ip::Interpolation, entity_dim::Int)
-    return entity_dim == 0 ? vertexdof_indices(ip) :
-        entity_dim == 1 ? edgedof_interior_indices(ip) : facedof_interior_indices(ip)
-end
-function _entity_dof_indices(ip::VectorizedInterpolation{vdim}, entity_dim::Int) where {vdim}
-    return map(_entity_dof_indices(ip.ip, entity_dim)) do dofs
-        Tuple((dof - 1) * vdim + direction for dof in dofs for direction in 1:vdim)
     end
 end
 

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -389,10 +389,10 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
             if n_components(ip) != n_components(_ip)
                 error("Field :$name has a different number of components in another SubDofHandler. Use a different field name.")
             end
+            _check_shared_dof_functionals(name, ip, _ip)
             if getorder(ip) != getorder(_ip)
                 @warn "Field :$name uses a different interpolation order in another SubDofHandler."
             end
-            # TODO: warn if interpolation type is not the same?
         end
     end
 
@@ -406,6 +406,46 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
     push!(sdh.field_names, name)
     push!(sdh.field_interpolations, ip)
     return sdh
+end
+
+# Check that a field with the same name in two SubDofHandlers uses compatible dof
+# functionals on entity classes that can be shared between cells, i.e. classes with
+# dimension below the reference dimension of at least one of the cell types (this
+# includes the cell-interior "face" dofs of a 2D cell embedded in 3D, which share
+# facedict entries with a neighboring volume cell's face dofs). Dof distribution reuses
+# entity dofs positionally with the reusing cell's own layout, so mismatching functionals
+# or counts would silently alias unrelated dofs.
+function _check_shared_dof_functionals(name::Symbol, ip::Interpolation, _ip::Interpolation)
+    base, _base = get_base_interpolation(ip), get_base_interpolation(_ip)
+    n_copies = ip isa VectorizedInterpolation ? get_n_copies(ip) : 1
+    _n_copies = _ip isa VectorizedInterpolation ? get_n_copies(_ip) : 1
+    max_rdim = max(getrefdim(base), getrefdim(_base))
+    for (class, entity_dim, entity_functionals) in (
+            ("vertices", 0, vertexdof_functionals),
+            ("edges", 1, edgedof_functionals),
+            ("faces", 2, facedof_functionals),
+        )
+        entity_dim < max_rdim || continue
+        sigs = unique(filter(!isempty, collect(entity_functionals(base))))
+        _sigs = unique(filter(!isempty, collect(entity_functionals(_base))))
+        # An entity carrying dofs from only one of the interpolations is never shared
+        (isempty(sigs) || isempty(_sigs)) && continue
+        compatible = if length(sigs) == 1 && length(_sigs) == 1
+            n_copies == _n_copies && sigs[1] == _sigs[1]
+        else
+            # Entity-heterogeneous layouts can only be compared positionally
+            getrefshape(base) === getrefshape(_base) && n_copies == _n_copies &&
+                collect(entity_functionals(base)) == collect(entity_functionals(_base))
+        end
+        if !compatible
+            error(
+                "Field :$name is shared between SubDofHandlers with incompatible dof functionals " *
+                    "on $class: $(Tuple(sigs)) × $n_copies copies vs $(Tuple(_sigs)) × $_n_copies copies. " *
+                    "Shared entities would receive dofs with conflicting physical meaning. Use a different field name."
+            )
+        end
+    end
+    return
 end
 
 """

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -389,7 +389,7 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
             if n_components(ip) != n_components(_ip)
                 error("Field :$name has a different number of components in another SubDofHandler. Use a different field name.")
             end
-            _check_shared_dof_functionals(name, ip, _ip)
+            _check_shared_dof_definitions(name, ip, _ip, sdh, _sdh)
             if getorder(ip) != getorder(_ip)
                 @warn "Field :$name uses a different interpolation order in another SubDofHandler."
             end
@@ -408,45 +408,158 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
     return sdh
 end
 
-# Check that a field with the same name in two SubDofHandlers uses compatible dof
-# functionals on entity classes that can be shared between cells, i.e. classes with
-# dimension below the reference dimension of at least one of the cell types (this
-# includes the cell-interior "face" dofs of a 2D cell embedded in 3D, which share
-# facedict entries with a neighboring volume cell's face dofs). Dof distribution reuses
-# entity dofs positionally with the reusing cell's own layout, so mismatching functionals
-# or counts would silently alias unrelated dofs.
-function _check_shared_dof_functionals(name::Symbol, ip::Interpolation, _ip::Interpolation)
-    base, _base = get_base_interpolation(ip), get_base_interpolation(_ip)
-    n_copies = ip isa VectorizedInterpolation ? get_n_copies(ip) : 1
-    _n_copies = _ip isa VectorizedInterpolation ? get_n_copies(_ip) : 1
-    max_rdim = max(getrefdim(base), getrefdim(_base))
+# Dof distribution reuses entity dofs positionally. Check every entity class that may be
+# shared, including a 2D cell's interior face when coupled to a 3D cell.
+function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, _ip::Interpolation, sdh::SubDofHandler, _sdh::SubDofHandler)
+    max_rdim = max(getrefdim(ip), getrefdim(_ip))
     for (class, entity_dim, entity_functionals) in (
             ("vertices", 0, vertexdof_functionals),
             ("edges", 1, edgedof_functionals),
             ("faces", 2, facedof_functionals),
         )
         entity_dim < max_rdim || continue
-        sigs = unique(filter(!isempty, collect(entity_functionals(base))))
-        _sigs = unique(filter(!isempty, collect(entity_functionals(_base))))
+        functional_layouts = map(fs -> map(_functional_signature, fs), entity_functionals(ip))
+        _functional_layouts = map(fs -> map(_functional_signature, fs), entity_functionals(_ip))
+        sigs = unique(filter(!isempty, collect(functional_layouts)))
+        _sigs = unique(filter(!isempty, collect(_functional_layouts)))
         # An entity carrying dofs from only one of the interpolations is never shared
         (isempty(sigs) || isempty(_sigs)) && continue
+        _subdomains_share_entity(get_grid(sdh.dh), sdh.cellset, _sdh.cellset, entity_dim) || continue
         compatible = if length(sigs) == 1 && length(_sigs) == 1
-            n_copies == _n_copies && sigs[1] == _sigs[1]
+            sigs[1] == _sigs[1]
         else
             # Entity-heterogeneous layouts can only be compared positionally
-            getrefshape(base) === getrefshape(_base) && n_copies == _n_copies &&
-                collect(entity_functionals(base)) == collect(entity_functionals(_base))
+            getrefshape(ip) === getrefshape(_ip) &&
+                collect(functional_layouts) == collect(_functional_layouts)
+        end
+        if compatible
+            positional = !(length(sigs) == 1 && length(_sigs) == 1)
+            compatible = _point_locations_compatible(ip, _ip, entity_dim, positional)
         end
         if !compatible
             error(
-                "Field :$name is shared between SubDofHandlers with incompatible dof functionals " *
-                    "on $class: $(Tuple(sigs)) × $n_copies copies vs $(Tuple(_sigs)) × $_n_copies copies. " *
-                    "Shared entities would receive dofs with conflicting physical meaning. Use a different field name."
+                "Field :$name has incompatible dof definitions on shared $class: " *
+                    "$(Tuple(sigs)) vs $(Tuple(_sigs)). Point dofs must have matching " *
+                    "entity-local coordinates; use a different field name."
             )
         end
     end
     return
 end
+
+_functional_signature(f::DofFunctional) = f
+_functional_signature(f::PointValue) = f.direction === nothing ? PointValue() : PointValue(f.direction)
+function _functional_signature(f::PointDerivative)
+    f.α === nothing && return PointDerivative()
+    return f.direction === nothing ? PointDerivative(f.α) : PointDerivative(f.α, f.direction)
+end
+
+function _point_locations_compatible(ip::Interpolation, _ip::Interpolation, entity_dim::Int, positional::Bool)
+    locations = filter(!isempty, collect(_entity_point_locations(ip, entity_dim)))
+    _locations = filter(!isempty, collect(_entity_point_locations(_ip, entity_dim)))
+    # Moment weights and normalization are not modeled.
+    (
+        all(all(isnothing, location) for location in locations) &&
+            all(all(isnothing, location) for location in _locations)
+    ) && return true
+    if positional
+        length(locations) == length(_locations) || return false
+        return all(_same_point_locations(a, b) for (a, b) in zip(locations, _locations))
+    end
+    # Uniform layouts can be compared across different reference shapes.
+    all(_same_point_locations(first(locations), location) for location in locations) || return false
+    all(_same_point_locations(first(_locations), location) for location in _locations) || return false
+    return _same_point_locations(first(locations), first(_locations))
+end
+
+function _entity_point_locations(ip::Interpolation, entity_dim::Int)
+    functionals = entity_dim == 0 ? vertexdof_functionals(ip) :
+        entity_dim == 1 ? edgedof_functionals(ip) : facedof_functionals(ip)
+    all(all(f -> !(f isa Union{PointValue, PointDerivative}), fs) for fs in functionals) &&
+        return map(fs -> ntuple(_ -> nothing, length(fs)), functionals)
+
+    dof_indices = _entity_dof_indices(ip, entity_dim)
+    vertex_coordinates = reference_coordinates(Lagrange{getrefshape(ip), 1}())
+    reference_entities = entity_dim == 0 ? map(i -> (i,), reference_vertices(getrefshape(ip))) :
+        entity_dim == 1 ? reference_edges(getrefshape(ip)) : reference_faces(getrefshape(ip))
+    return map(functionals, dof_indices, reference_entities) do fs, dofs, entity_vertices
+        entity_coordinates = vertex_coordinates[[entity_vertices...]]
+        return map(fs, dofs) do f, dof
+            f isa Union{PointValue, PointDerivative} || return nothing
+            x = f.x
+            x === nothing && error("dof_functionals must include the point of every point-supported dof (local dof $dof of $ip)")
+            return _entity_local_coordinate(x, entity_coordinates, entity_dim)
+        end
+    end
+end
+
+function _entity_dof_indices(ip::Interpolation, entity_dim::Int)
+    return entity_dim == 0 ? vertexdof_indices(ip) :
+        entity_dim == 1 ? edgedof_interior_indices(ip) : facedof_interior_indices(ip)
+end
+function _entity_dof_indices(ip::VectorizedInterpolation{vdim}, entity_dim::Int) where {vdim}
+    return map(_entity_dof_indices(ip.ip, entity_dim)) do dofs
+        Tuple((dof - 1) * vdim + direction for dof in dofs for direction in 1:vdim)
+    end
+end
+
+function _entity_local_coordinate(x, vertices, entity_dim::Int)
+    if entity_dim == 0
+        isapprox(x, only(vertices)) || error("point-supported vertex dof is not located on its owning vertex")
+        return ()
+    elseif entity_dim == 1
+        a = vertices[2] - vertices[1]
+        t = ((x - vertices[1]) ⋅ a) / (a ⋅ a)
+        isapprox(x, vertices[1] + t * a) || error("point-supported edge dof is not located on its owning edge")
+        return (t,)
+    end
+    # Triangles and quadrilaterals use vertices (1, 2, 3) and (1, 2, 4) as affine axes.
+    a = vertices[2] - vertices[1]
+    b = vertices[length(vertices) == 3 ? 3 : 4] - vertices[1]
+    r = x - vertices[1]
+    aa, ab, bb = a ⋅ a, a ⋅ b, b ⋅ b
+    ar, br = a ⋅ r, b ⋅ r
+    denominator = aa * bb - ab * ab
+    u = (ar * bb - br * ab) / denominator
+    v = (br * aa - ar * ab) / denominator
+    isapprox(x, vertices[1] + u * a + v * b) || error("point-supported face dof is not located on its owning face")
+    return (u, v)
+end
+
+function _same_point_locations(a::Tuple, b::Tuple)
+    length(a) == length(b) || return false
+    return all(_same_point_coordinate(x, y) for (x, y) in zip(a, b))
+end
+_same_point_coordinate(x, y) = x === nothing || y === nothing ? x === y : isapprox(x, y)
+function _same_point_coordinate(x::Tuple, y::Tuple)
+    length(x) == length(y) || return false
+    return all(isapprox(a, b) for (a, b) in zip(x, y))
+end
+
+# Only an actual shared entity can alias global dofs between two cellsets.
+function _subdomains_share_entity(grid::AbstractGrid, cellset, _cellset, entity_dim::Int)
+    entities = Set{Any}()
+    for cellid in cellset
+        for entity in _cell_entities(getcells(grid, cellid), entity_dim)
+            push!(entities, _canonical_entity(entity, entity_dim))
+        end
+    end
+    for cellid in _cellset
+        for entity in _cell_entities(getcells(grid, cellid), entity_dim)
+            _canonical_entity(entity, entity_dim) in entities && return true
+        end
+    end
+    return false
+end
+
+_cell_entities(cell, ::Val{0}) = vertices(cell)
+_cell_entities(cell, ::Val{1}) = edges(cell)
+_cell_entities(cell, ::Val{2}) = faces(cell)
+_cell_entities(cell, entity_dim::Int) = _cell_entities(cell, Val(entity_dim))
+_canonical_entity(entity, ::Val{0}) = entity
+_canonical_entity(entity, ::Val{1}) = first(sortedge(entity))
+_canonical_entity(entity, ::Val{2}) = first(sortface(entity))
+_canonical_entity(entity, entity_dim::Int) = _canonical_entity(entity, Val(entity_dim))
 
 """
     add!(dh::DofHandler, name::Symbol, ip::Interpolation)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -445,8 +445,18 @@ end
 function _entity_point_locations(ip::Interpolation, entity_dim::Int)
     entity_functionals = (vertexdof_functionals, edgedof_functionals, facedof_functionals)[entity_dim + 1]
     functionals = entity_functionals(ip)
-    all(all(f -> !(f isa Union{PointValue, PointDerivative}), fs) for fs in functionals) &&
-        return map(fs -> ntuple(_ -> nothing, length(fs)), functionals)
+    has_point_dofs = false
+    for entity_dofs in functionals, functional in entity_dofs
+        if functional isa Union{PointValue, PointDerivative}
+            has_point_dofs = true
+            break
+        end
+    end
+    if !has_point_dofs
+        return map(functionals) do entity_dofs
+            return map(_ -> nothing, entity_dofs)
+        end
+    end
 
     entity_indices = (vertexdof_indices, edgedof_interior_indices, facedof_interior_indices)[entity_dim + 1]
     dof_indices = entity_indices(ip)

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -380,6 +380,12 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
     if name in sdh.dh.algebraic_names
         error("an algebraic variable with the name :$name already exists in the DofHandler; spatial fields and algebraic variables share one namespace")
     end
+    # Check the cell shape before comparing entity layouts.
+    refshape_sdh = getrefshape(getcells(sdh.dh.grid, first(sdh.cellset)))
+    if refshape_sdh !== getrefshape(ip)
+        error("The refshape of the interpolation $(getrefshape(ip)) is incompatible with the refshape $refshape_sdh of the cells.")
+    end
+
     # Verify that fields with the same name in other SubDofHandler have compatible
     # interpolation
     for _sdh in sdh.dh.subdofhandlers
@@ -396,91 +402,67 @@ function add!(sdh::SubDofHandler, name::Symbol, ip::Interpolation)
         end
     end
 
-    # Check that interpolation is compatible with cells it it added to
-    refshape_sdh = getrefshape(getcells(sdh.dh.grid, first(sdh.cellset)))
-    if refshape_sdh !== getrefshape(ip)
-        error("The refshape of the interpolation $(getrefshape(ip)) is incompatible with the refshape $refshape_sdh of the cells.")
-    end
-
     # Store in the SubDofHandler, it is collected to the parent DofHandler in close!.
     push!(sdh.field_names, name)
     push!(sdh.field_interpolations, ip)
     return sdh
 end
 
-# Dof distribution reuses entity dofs positionally. Check every entity class that may be
-# shared, including a 2D cell's interior face when coupled to a 3D cell.
-function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, _ip::Interpolation, sdh::SubDofHandler, _sdh::SubDofHandler)
-    max_rdim = max(getrefdim(ip), getrefdim(_ip))
-    for (class, entity_dim, entity_functionals) in (
-            ("vertices", 0, vertexdof_functionals),
-            ("edges", 1, edgedof_functionals),
-            ("faces", 2, facedof_functionals),
+# Compare local entity layouts first; inspect the mesh only for potentially incompatible pairs.
+function _check_shared_dof_definitions(name::Symbol, ip::Interpolation, other_ip::Interpolation, sdh::SubDofHandler, other_sdh::SubDofHandler)
+    max_rdim = max(getrefdim(ip), getrefdim(other_ip))
+    for (entity_dim, entity_functionals) in (
+            (0, vertexdof_functionals), (1, edgedof_functionals), (2, facedof_functionals),
         )
         entity_dim < max_rdim || continue
-        functional_layouts = entity_functionals(ip)
-        _functional_layouts = entity_functionals(_ip)
-        sigs = unique(filter(!isempty, collect(functional_layouts)))
-        _sigs = unique(filter(!isempty, collect(_functional_layouts)))
-        # An entity carrying dofs from only one of the interpolations is never shared
-        (isempty(sigs) || isempty(_sigs)) && continue
-        _subdomains_share_entity(get_grid(sdh.dh), sdh.cellset, _sdh.cellset, entity_dim) || continue
-        compatible = if length(sigs) == 1 && length(_sigs) == 1
-            sigs[1] == _sigs[1]
-        else
-            # Entity-heterogeneous layouts can only be compared positionally
-            getrefshape(ip) === getrefshape(_ip) &&
-                collect(functional_layouts) == collect(_functional_layouts)
-        end
-        if compatible
-            positional = !(length(sigs) == 1 && length(_sigs) == 1)
-            compatible = _point_locations_compatible(get_base_interpolation(ip), get_base_interpolation(_ip), entity_dim, positional)
-        end
-        if !compatible
-            error(
-                "Field :$name has incompatible dof definitions on shared $class: " *
-                    "$(Tuple(sigs)) vs $(Tuple(_sigs)). Point dofs must have matching " *
-                    "entity-local coordinates; use a different field name."
-            )
-        end
+        layouts = entity_functionals(ip)
+        other_layouts = entity_functionals(other_ip)
+        (all(isempty, layouts) || all(isempty, other_layouts)) && continue
+
+        locations = _entity_point_locations(get_base_interpolation(ip), entity_dim)
+        other_locations = _entity_point_locations(get_base_interpolation(other_ip), entity_dim)
+        # An entity with dofs on only one side does not share any dof numbers.
+        compatible = [
+            isempty(a) || isempty(b) || (a == b && _same_point_locations(locations[i], other_locations[j]))
+                for (i, a) in pairs(layouts), (j, b) in pairs(other_layouts)
+        ]
+        all(compatible) && continue
+        pair = _incompatible_shared_entity(get_grid(sdh.dh), sdh.cellset, other_sdh.cellset, Val(entity_dim), compatible)
+        pair === nothing && continue
+        i, j = pair
+        entity_name = ("vertices", "edges", "faces")[entity_dim + 1]
+        error(
+            "Field :$name has incompatible dof definitions on shared $entity_name: " *
+                "$(layouts[i]) vs $(other_layouts[j]). Point dofs must have matching " *
+                "entity-local coordinates; use a different field name."
+        )
     end
     return
-end
-
-function _point_locations_compatible(ip::Interpolation, _ip::Interpolation, entity_dim::Int, positional::Bool)
-    locations = filter(!isempty, collect(_entity_point_locations(ip, entity_dim)))
-    _locations = filter(!isempty, collect(_entity_point_locations(_ip, entity_dim)))
-    # Moment weights and normalization are not modeled.
-    (
-        all(all(isnothing, location) for location in locations) &&
-            all(all(isnothing, location) for location in _locations)
-    ) && return true
-    if positional
-        length(locations) == length(_locations) || return false
-        return all(_same_point_locations(a, b) for (a, b) in zip(locations, _locations))
-    end
-    # Uniform layouts can be compared across different reference shapes.
-    all(_same_point_locations(first(locations), location) for location in locations) || return false
-    all(_same_point_locations(first(_locations), location) for location in _locations) || return false
-    return _same_point_locations(first(locations), first(_locations))
 end
 
 # Entity-local coordinates of the point-supported dofs (`nothing` for other dofs) of a
 # non-vectorized interpolation.
 function _entity_point_locations(ip::Interpolation, entity_dim::Int)
-    functionals = entity_dim == 0 ? vertexdof_functionals(ip) :
-        entity_dim == 1 ? edgedof_functionals(ip) : facedof_functionals(ip)
+    entity_functionals = (vertexdof_functionals, edgedof_functionals, facedof_functionals)[entity_dim + 1]
+    functionals = entity_functionals(ip)
     all(all(f -> !(f isa Union{PointValue, PointDerivative}), fs) for fs in functionals) &&
         return map(fs -> ntuple(_ -> nothing, length(fs)), functionals)
 
-    dof_indices = entity_dim == 0 ? vertexdof_indices(ip) :
-        entity_dim == 1 ? edgedof_interior_indices(ip) : facedof_interior_indices(ip)
+    entity_indices = (vertexdof_indices, edgedof_interior_indices, facedof_interior_indices)[entity_dim + 1]
+    dof_indices = entity_indices(ip)
     dof_coordinates = reference_coordinates(ip)
+    # Linear Lagrange nodes are the reference shape's vertices, regardless of the field interpolation.
     vertex_coordinates = reference_coordinates(Lagrange{getrefshape(ip), 1}())
-    reference_entities = entity_dim == 0 ? map(i -> (i,), reference_vertices(getrefshape(ip))) :
-        entity_dim == 1 ? reference_edges(getrefshape(ip)) : reference_faces(getrefshape(ip))
+    refshape = getrefshape(ip)
+    reference_entities = if entity_dim == 0
+        map(i -> (i,), reference_vertices(refshape))
+    elseif entity_dim == 1
+        reference_edges(refshape)
+    else
+        reference_faces(refshape)
+    end
     return map(functionals, dof_indices, reference_entities) do fs, dofs, entity_vertices
-        entity_coordinates = vertex_coordinates[[entity_vertices...]]
+        entity_coordinates = map(i -> vertex_coordinates[i], entity_vertices)
         return map(fs, dofs) do f, dof
             f isa Union{PointValue, PointDerivative} || return nothing
             return _entity_local_coordinate(dof_coordinates[dof], entity_coordinates, entity_dim)
@@ -521,30 +503,39 @@ function _same_point_coordinate(x::Tuple, y::Tuple)
     return all(isapprox(a, b) for (a, b) in zip(x, y))
 end
 
-# Only an actual shared entity can alias global dofs between two cellsets.
-function _subdomains_share_entity(grid::AbstractGrid, cellset, _cellset, entity_dim::Int)
-    entities = Set{Any}()
+# Keep all local entity indices: the same global vertex can have different local indices
+# in different cells of a subdomain.
+function _incompatible_shared_entity(grid::AbstractGrid, cellset, other_cellset, entity_dim::Val, compatible)
+    first_entity = first(_cell_entities(getcells(grid, first(cellset)), entity_dim))
+    Key = typeof(_canonical_entity(first_entity, entity_dim))
+    entities = Dict{Key, BitSet}()
     for cellid in cellset
-        for entity in _cell_entities(getcells(grid, cellid), entity_dim)
-            push!(entities, _canonical_entity(entity, entity_dim))
+        for (i, entity) in pairs(_cell_entities(getcells(grid, cellid), entity_dim))
+            all(@view compatible[i, :]) && continue
+            key = _canonical_entity(entity, entity_dim)
+            indices = get!(BitSet, entities, key)
+            push!(indices, i)
         end
     end
-    for cellid in _cellset
-        for entity in _cell_entities(getcells(grid, cellid), entity_dim)
-            _canonical_entity(entity, entity_dim) in entities && return true
+    for cellid in other_cellset
+        for (j, entity) in pairs(_cell_entities(getcells(grid, cellid), entity_dim))
+            key = _canonical_entity(entity, entity_dim)
+            indices = get(entities, key, nothing)
+            indices === nothing && continue
+            for i in indices
+                compatible[i, j] || return (i, j)
+            end
         end
     end
-    return false
+    return nothing
 end
 
 _cell_entities(cell, ::Val{0}) = vertices(cell)
 _cell_entities(cell, ::Val{1}) = edges(cell)
 _cell_entities(cell, ::Val{2}) = faces(cell)
-_cell_entities(cell, entity_dim::Int) = _cell_entities(cell, Val(entity_dim))
 _canonical_entity(entity, ::Val{0}) = entity
 _canonical_entity(entity, ::Val{1}) = first(sortedge(entity))
 _canonical_entity(entity, ::Val{2}) = first(sortface(entity))
-_canonical_entity(entity, entity_dim::Int) = _canonical_entity(entity, Val(entity_dim))
 
 """
     add!(dh::DofHandler, name::Symbol, ip::Interpolation)

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -47,7 +47,7 @@ function apply_analytical!(
             intersect(BitSet(sdh.cellset), BitSet(cellset))
         end
         isempty(set_intersection) && continue
-        if !all(fl -> fl isa PointValue, dof_functionals(ip_fun))
+        if !all(fl -> Ferrite._base_functional(fl) isa PointValue, dof_functionals(ip_fun))
             error("apply_analytical! is only supported for interpolations whose dofs are all point values (writing f at the dof location), got $(ip_fun).")
         end
         _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -47,7 +47,7 @@ function apply_analytical!(
             intersect(BitSet(sdh.cellset), BitSet(cellset))
         end
         isempty(set_intersection) && continue
-        if !all(fl -> fl isa PointValue, dof_functionals(get_base_interpolation(ip_fun)))
+        if !all(fl -> fl isa PointValue, dof_functionals(ip_fun))
             error("apply_analytical! is only supported for interpolations whose dofs are all point values (writing f at the dof location), got $(ip_fun).")
         end
         _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -47,6 +47,9 @@ function apply_analytical!(
             intersect(BitSet(sdh.cellset), BitSet(cellset))
         end
         isempty(set_intersection) && continue
+        if !all(fl -> fl isa PointValue, dof_functionals(get_base_interpolation(ip_fun)))
+            error("apply_analytical! is only supported for interpolations whose dofs are all point values (writing f at the dof location), got $(ip_fun).")
+        end
         _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)
     end
     return a

--- a/src/Dofs/apply_analytical.jl
+++ b/src/Dofs/apply_analytical.jl
@@ -47,8 +47,8 @@ function apply_analytical!(
             intersect(BitSet(sdh.cellset), BitSet(cellset))
         end
         isempty(set_intersection) && continue
-        if !all(fl -> Ferrite._base_functional(fl) isa PointValue, dof_functionals(ip_fun))
-            error("apply_analytical! is only supported for interpolations whose dofs are all point values (writing f at the dof location), got $(ip_fun).")
+        if !all(fl -> _base_functional(fl) isa PointValue, dof_functionals(ip_fun))
+            error("apply_analytical! is only supported for interpolations whose dofs are all point values, got $(ip_fun).")
         end
         _apply_analytical!(a, dh, celldofinds, field_dim, ip_fun, ip_geo, f, set_intersection)
     end

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -198,7 +198,6 @@ function BCValues(::Type{Tv}, ::Type{Ti}, func_interpol::Interpolation{refshape}
     interpolation_coords = reference_coordinates(func_interpol)
     # `functional === nothing` means no filtering; the filter must mirror the one in
     # `_local_facet_dofs_for_bc` to keep dof lists and quadrature points index-aligned
-    functional = functional === nothing ? nothing : _base_functional(functional)
     functionals = functional === nothing ? nothing : dof_functionals(func_interpol)
 
     qrs = QuadratureRule{refshape, Vector{Tv}, Vector{Vec{dim, Tv}}}[]

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -188,19 +188,25 @@ mutable struct BCValues{Tv, Ti}
     current_entity::Ti
 end
 
-BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex}) =
-    BCValues(Float64, func_interpol, geom_interpol, boundary_type)
-BCValues(::Type{Tv}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}) where {Tv, dim, refshape <: AbstractRefShape{dim}} =
-    BCValues(Tv, Int64, func_interpol, geom_interpol, boundary_type)
-function BCValues(::Type{Tv}, ::Type{Ti}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}) where {Tv, Ti, dim, refshape <: AbstractRefShape{dim}}
+BCValues(func_interpol::Interpolation, geom_interpol::Interpolation, boundary_type::Type{<:BoundaryIndex}, functional = nothing) =
+    BCValues(Float64, func_interpol, geom_interpol, boundary_type, functional)
+BCValues(::Type{Tv}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}, functional = nothing) where {Tv, dim, refshape <: AbstractRefShape{dim}} =
+    BCValues(Tv, Int64, func_interpol, geom_interpol, boundary_type, functional)
+function BCValues(::Type{Tv}, ::Type{Ti}, func_interpol::Interpolation{refshape}, geom_interpol::Interpolation{refshape}, boundary_type::Type{<:BoundaryIndex}, functional = nothing) where {Tv, Ti, dim, refshape <: AbstractRefShape{dim}}
     # set up quadrature rules for each boundary entity with dof-positions
     # (determined by func_interpol) as the quadrature points
     interpolation_coords = reference_coordinates(func_interpol)
+    # `functional === nothing` means no filtering; the filter must mirror the one in
+    # `_local_facet_dofs_for_bc` to keep dof lists and quadrature points index-aligned
+    functionals = functional === nothing ? nothing : dof_functionals(func_interpol)
 
     qrs = QuadratureRule{refshape, Vector{Tv}, Vector{Vec{dim, Tv}}}[]
     for boundarydofs in dirichlet_boundarydof_indices(boundary_type)(func_interpol)
         dofcoords = Vec{dim, Tv}[]
         for boundarydof in boundarydofs
+            if functionals !== nothing
+                matches_functional(functional, functionals[boundarydof]) || continue
+            end
             push!(dofcoords, interpolation_coords[boundarydof])
         end
         qrf = QuadratureRule{refshape}(fill(Tv(NaN), length(dofcoords)), dofcoords) # weights will not be used

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -198,6 +198,7 @@ function BCValues(::Type{Tv}, ::Type{Ti}, func_interpol::Interpolation{refshape}
     interpolation_coords = reference_coordinates(func_interpol)
     # `functional === nothing` means no filtering; the filter must mirror the one in
     # `_local_facet_dofs_for_bc` to keep dof lists and quadrature points index-aligned
+    functional = functional === nothing ? nothing : _base_functional(functional)
     functionals = functional === nothing ? nothing : dof_functionals(func_interpol)
 
     qrs = QuadratureRule{refshape, Vector{Tv}, Vector{Vec{dim, Tv}}}[]

--- a/src/FEValues/FacetValues.jl
+++ b/src/FEValues/FacetValues.jl
@@ -196,8 +196,7 @@ function BCValues(::Type{Tv}, ::Type{Ti}, func_interpol::Interpolation{refshape}
     # set up quadrature rules for each boundary entity with dof-positions
     # (determined by func_interpol) as the quadrature points
     interpolation_coords = reference_coordinates(func_interpol)
-    # `functional === nothing` means no filtering; the filter must mirror the one in
-    # `_local_facet_dofs_for_bc` to keep dof lists and quadrature points index-aligned
+    # Use the same filtering as `_local_facet_dofs_for_bc`.
     functionals = functional === nothing ? nothing : dof_functionals(func_interpol)
 
     qrs = QuadratureRule{refshape, Vector{Tv}, Vector{Vec{dim, Tv}}}[]

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -23,6 +23,15 @@ export
     getnbasefunctions,
     getrefshape,
 
+    # Dof functionals
+    DofFunctional,
+    PointValue,
+    PointDerivative,
+    IntegralMoment,
+    NormalMoment,
+    TangentialMoment,
+    InteriorMoment,
+
     # Quadrature
     QuadratureRule,
     FacetQuadratureRule,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -31,6 +31,7 @@ export
     NormalMoment,
     TangentialMoment,
     InteriorMoment,
+    VectorizedFunctional,
 
     # Quadrature
     QuadratureRule,

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -129,53 +129,37 @@ end
     IntegralMoment
 
 Supertype for dof functionals defined as integral moments over the entity owning the dof:
-[`NormalMoment`](@ref), [`TangentialMoment`](@ref), and [`InteriorMoment`](@ref). `nr`
-enumerates the moments on one entity in local entity-dof order. The identity does not
-encode the weight function or normalization, so equal moment signatures from different
-interpolation families do not guarantee identical functionals.
+[`NormalMoment`](@ref), [`TangentialMoment`](@ref), and [`InteriorMoment`](@ref). The
+identity does not encode the weight function or normalization, so equal moment signatures
+from different interpolation families do not guarantee identical functionals.
 """
 abstract type IntegralMoment <: DofFunctional end
 
 """
-    NormalMoment([nr::Int])
+    NormalMoment()
 
-Moment nr `nr` of the normal trace, ℓ(v) = ∫ (v ⋅ n) q dS, over the entity owning the dof
+Moment of the normal trace, ℓ(v) = ∫ (v ⋅ n) q dS, over the entity owning the dof
 (H(div) interpolations).
-`NormalMoment()` is a selector matching every normal moment.
 """
-struct NormalMoment{N} <: IntegralMoment
-    nr::N
-end
-NormalMoment() = NormalMoment(nothing)
-NormalMoment(nr::Integer) = NormalMoment{Int}(Int(nr))
-Base.show(io::IO, f::NormalMoment) = print(io, "NormalMoment(", f.nr === nothing ? "" : f.nr, ")")
+struct NormalMoment <: IntegralMoment end
+Base.show(io::IO, ::NormalMoment) = print(io, "NormalMoment()")
 
 """
-    TangentialMoment([nr::Int])
+    TangentialMoment()
 
-Moment nr `nr` of the tangential trace, ℓ(v) = ∫ (v ⋅ t) q dS, over the entity owning the
-dof (H(curl) interpolations).
-`TangentialMoment()` is a selector matching every tangential moment.
+Moment of the tangential trace, ℓ(v) = ∫ (v ⋅ t) q dS, over the entity owning the dof
+(H(curl) interpolations).
 """
-struct TangentialMoment{N} <: IntegralMoment
-    nr::N
-end
-TangentialMoment() = TangentialMoment(nothing)
-TangentialMoment(nr::Integer) = TangentialMoment{Int}(Int(nr))
-Base.show(io::IO, f::TangentialMoment) = print(io, "TangentialMoment(", f.nr === nothing ? "" : f.nr, ")")
+struct TangentialMoment <: IntegralMoment end
+Base.show(io::IO, ::TangentialMoment) = print(io, "TangentialMoment()")
 
 """
-    InteriorMoment([nr::Int])
+    InteriorMoment()
 
-Cell-interior moment nr `nr`, ℓ(v) = ∫ v ⋅ q dV, for dofs interior to the cell.
-`InteriorMoment()` is a selector matching every interior moment.
+Cell-interior moment, ℓ(v) = ∫ v ⋅ q dV, for dofs interior to the cell.
 """
-struct InteriorMoment{N} <: IntegralMoment
-    nr::N
-end
-InteriorMoment() = InteriorMoment(nothing)
-InteriorMoment(nr::Integer) = InteriorMoment{Int}(Int(nr))
-Base.show(io::IO, f::InteriorMoment) = print(io, "InteriorMoment(", f.nr === nothing ? "" : f.nr, ")")
+struct InteriorMoment <: IntegralMoment end
+Base.show(io::IO, ::InteriorMoment) = print(io, "InteriorMoment()")
 
 """
     VectorizedFunctional(functional::DofFunctional, direction::Int)
@@ -218,9 +202,6 @@ while `PointDerivative((1,))` matches only that derivative. A scalar selector ma
 matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
 _matches_property(selector, value) = selector === nothing || selector == value
 matches_functional(selector::PointDerivative, f::PointDerivative) = _matches_property(selector.α, f.α)
-matches_functional(selector::NormalMoment, f::NormalMoment) = _matches_property(selector.nr, f.nr)
-matches_functional(selector::TangentialMoment, f::TangentialMoment) = _matches_property(selector.nr, f.nr)
-matches_functional(selector::InteriorMoment, f::InteriorMoment) = _matches_property(selector.nr, f.nr)
 matches_functional(selector::DofFunctional, f::VectorizedFunctional) = matches_functional(selector, f.functional)
 matches_functional(selector::VectorizedFunctional, f::VectorizedFunctional) =
     selector.direction == f.direction && matches_functional(selector.functional, f.functional)
@@ -2056,7 +2037,7 @@ end
 
 getnbasefunctions(::RaviartThomas{RefTriangle, 1}) = 3
 edgedof_interior_indices(::RaviartThomas{RefTriangle, 1}) = ((1,), (2,), (3,))
-dof_functionals(::RaviartThomas{RefTriangle, 1}) = ntuple(_ -> NormalMoment(1), 3)
+dof_functionals(::RaviartThomas{RefTriangle, 1}) = ntuple(_ -> NormalMoment(), 3)
 facedof_interior_indices(::RaviartThomas{RefTriangle, 1}) = ((),)
 adjust_dofs_during_distribution(::RaviartThomas) = false
 
@@ -2087,7 +2068,7 @@ getnbasefunctions(::RaviartThomas{RefTriangle, 2}) = 8
 edgedof_interior_indices(::RaviartThomas{RefTriangle, 2}) = ((1, 2), (3, 4), (5, 6))
 facedof_interior_indices(::RaviartThomas{RefTriangle, 2}) = ((7, 8),)
 function dof_functionals(::RaviartThomas{RefTriangle, 2})
-    return (ntuple(i -> NormalMoment(mod1(i, 2)), 6)..., InteriorMoment(1), InteriorMoment(2))
+    return (ntuple(_ -> NormalMoment(), 6)..., InteriorMoment(), InteriorMoment())
 end
 adjust_dofs_during_distribution(::RaviartThomas{RefTriangle, 2}) = true
 
@@ -2113,7 +2094,7 @@ end
 getnbasefunctions(::RaviartThomas{RefQuadrilateral, 1}) = 4
 edgedof_interior_indices(::RaviartThomas{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
 facedof_interior_indices(::RaviartThomas{RefQuadrilateral, 1}) = ((),)
-dof_functionals(::RaviartThomas{RefQuadrilateral, 1}) = ntuple(_ -> NormalMoment(1), 4)
+dof_functionals(::RaviartThomas{RefQuadrilateral, 1}) = ntuple(_ -> NormalMoment(), 4)
 adjust_dofs_during_distribution(::RaviartThomas{RefQuadrilateral, 1}) = false
 
 function get_direction(::RaviartThomas{RefQuadrilateral, 1}, shape_nr, cell)
@@ -2134,7 +2115,7 @@ end
 getnbasefunctions(::RaviartThomas{RefTetrahedron, 1}) = 4
 edgedof_interior_indices(::RaviartThomas{RefTetrahedron, 1}) = ntuple(_ -> (), 6)
 facedof_interior_indices(::RaviartThomas{RefTetrahedron, 1}) = ((1,), (2,), (3,), (4,))
-dof_functionals(::RaviartThomas{RefTetrahedron, 1}) = ntuple(_ -> NormalMoment(1), 4)
+dof_functionals(::RaviartThomas{RefTetrahedron, 1}) = ntuple(_ -> NormalMoment(), 4)
 adjust_dofs_during_distribution(::RaviartThomas{RefTetrahedron, 1}) = false
 
 function get_direction(::RaviartThomas{RefTetrahedron, 1}, shape_nr, cell)
@@ -2160,7 +2141,7 @@ end
 getnbasefunctions(::RaviartThomas{RefHexahedron, 1}) = 6
 edgedof_interior_indices(::RaviartThomas{RefHexahedron, 1}) = ntuple(_ -> (), 12)
 facedof_interior_indices(::RaviartThomas{RefHexahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,))
-dof_functionals(::RaviartThomas{RefHexahedron, 1}) = ntuple(_ -> NormalMoment(1), 6)
+dof_functionals(::RaviartThomas{RefHexahedron, 1}) = ntuple(_ -> NormalMoment(), 6)
 adjust_dofs_during_distribution(::RaviartThomas{RefHexahedron, 1}) = false
 
 function get_direction(::RaviartThomas{RefHexahedron, 1}, shape_nr, cell)
@@ -2199,7 +2180,7 @@ end
 
 getnbasefunctions(::BrezziDouglasMarini{RefTriangle, 1}) = 6
 edgedof_interior_indices(::BrezziDouglasMarini{RefTriangle, 1}) = ((1, 2), (3, 4), (5, 6))
-dof_functionals(::BrezziDouglasMarini{RefTriangle, 1}) = ntuple(i -> NormalMoment(mod1(i, 2)), 6)
+dof_functionals(::BrezziDouglasMarini{RefTriangle, 1}) = ntuple(_ -> NormalMoment(), 6)
 adjust_dofs_during_distribution(::BrezziDouglasMarini{RefTriangle, 1}) = true
 
 function get_direction(::BrezziDouglasMarini{RefTriangle, 1}, shape_nr, cell)
@@ -2233,7 +2214,7 @@ end
 
 getnbasefunctions(::Nedelec{RefTriangle, 1}) = 3
 edgedof_interior_indices(::Nedelec{RefTriangle, 1}) = ((1,), (2,), (3,))
-dof_functionals(::Nedelec{RefTriangle, 1}) = ntuple(_ -> TangentialMoment(1), 3)
+dof_functionals(::Nedelec{RefTriangle, 1}) = ntuple(_ -> TangentialMoment(), 3)
 adjust_dofs_during_distribution(::Nedelec{RefTriangle, 1}) = false
 
 function get_direction(::Nedelec{RefTriangle, 1}, shape_nr, cell)
@@ -2265,7 +2246,7 @@ getnbasefunctions(::Nedelec{RefTriangle, 2}) = 8
 edgedof_interior_indices(::Nedelec{RefTriangle, 2}) = ((1, 2), (3, 4), (5, 6))
 facedof_interior_indices(::Nedelec{RefTriangle, 2}) = ((7, 8),)
 function dof_functionals(::Nedelec{RefTriangle, 2})
-    return (ntuple(i -> TangentialMoment(mod1(i, 2)), 6)..., InteriorMoment(1), InteriorMoment(2))
+    return (ntuple(_ -> TangentialMoment(), 6)..., InteriorMoment(), InteriorMoment())
 end
 adjust_dofs_during_distribution(::Nedelec{RefTriangle, 2}) = true
 
@@ -2291,7 +2272,7 @@ end
 
 getnbasefunctions(::Nedelec{RefQuadrilateral, 1}) = 4
 edgedof_interior_indices(::Nedelec{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
-dof_functionals(::Nedelec{RefQuadrilateral, 1}) = ntuple(_ -> TangentialMoment(1), 4)
+dof_functionals(::Nedelec{RefQuadrilateral, 1}) = ntuple(_ -> TangentialMoment(), 4)
 adjust_dofs_during_distribution(::Nedelec{RefQuadrilateral, 1}) = false
 
 function get_direction(::Nedelec{RefQuadrilateral, 1}, shape_nr, cell)
@@ -2315,7 +2296,7 @@ end
 
 getnbasefunctions(::Nedelec{RefTetrahedron, 1}) = 6
 edgedof_interior_indices(::Nedelec{RefTetrahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,))
-dof_functionals(::Nedelec{RefTetrahedron, 1}) = ntuple(_ -> TangentialMoment(1), 6)
+dof_functionals(::Nedelec{RefTetrahedron, 1}) = ntuple(_ -> TangentialMoment(), 6)
 adjust_dofs_during_distribution(::Nedelec{RefTetrahedron, 1}) = false
 
 function get_direction(::Nedelec{RefTetrahedron, 1}, shape_nr, cell)
@@ -2345,7 +2326,7 @@ end
 
 getnbasefunctions(::Nedelec{RefHexahedron, 1}) = 12
 edgedof_interior_indices(::Nedelec{RefHexahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,), (10,), (11,), (12,))
-dof_functionals(::Nedelec{RefHexahedron, 1}) = ntuple(_ -> TangentialMoment(1), 12)
+dof_functionals(::Nedelec{RefHexahedron, 1}) = ntuple(_ -> TangentialMoment(), 12)
 adjust_dofs_during_distribution(::Nedelec{RefHexahedron, 1}) = false
 
 function get_direction(::Nedelec{RefHexahedron, 1}, shape_nr, cell)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -85,71 +85,43 @@ function conformity end
     DofFunctional
 
 Supertype for the dof functional ℓᵢ of local shape function `i` of an interpolation,
-queryable with [`Ferrite.dof_functionals`](@ref). Point-supported functionals include
-their reference point and vector direction; the owning topological entity is given by the
-entity dof-index functions. Point coordinates are also available collectively through
-[`Ferrite.reference_coordinates`](@ref).
+queryable with [`Ferrite.dof_functionals`](@ref). The functional describes only the kind
+of dof; the owning topological entity is given by the entity dof-index functions and the
+point of a point-supported dof `i` by `reference_coordinates(ip)[i]`.
 
-Subtypes: [`PointValue`](@ref), [`PointDerivative`](@ref), and the
-[`IntegralMoment`](@ref) family ([`NormalMoment`](@ref), [`TangentialMoment`](@ref),
-[`InteriorMoment`](@ref)). Not to be confused with [`PointValues`](@ref) (plural).
+Subtypes: [`PointValue`](@ref), [`PointDerivative`](@ref), the [`IntegralMoment`](@ref)
+family ([`NormalMoment`](@ref), [`TangentialMoment`](@ref), [`InteriorMoment`](@ref)),
+and [`VectorizedFunctional`](@ref) wrapping a scalar functional for the dofs of a
+`VectorizedInterpolation`. Not to be confused with [`PointValues`](@ref) (plural).
 """
 abstract type DofFunctional end
 
 """
     PointValue()
-    PointValue(direction)
-    PointValue(x [, direction])
 
 Dof functional for a point evaluation: ℓ(f) = f(xᵢ), where xᵢ is given by
-`reference_coordinates`. `direction` is the component selected from a vector-valued
-function and is omitted for scalar-valued interpolations. `PointValue()` and
-`PointValue(direction)` omit the point and can be used as selectors matching every point
-with the requested direction.
+`reference_coordinates`.
 """
-struct PointValue{X, D} <: DofFunctional
-    x::X
-    direction::D
-end
-PointValue() = PointValue(nothing, nothing)
-PointValue(x::Vec) = PointValue(x, nothing)
-PointValue(direction::Integer) = PointValue{Nothing, Int}(nothing, Int(direction))
-PointValue(x::Vec, direction::Integer) = PointValue{typeof(x), Int}(x, Int(direction))
-function Base.show(io::IO, f::PointValue)
-    print(io, "PointValue(")
-    f.x === nothing || show(io, f.x)
-    f.direction === nothing || print(io, f.x === nothing ? "" : ", ", f.direction)
-    return print(io, ")")
-end
+struct PointValue <: DofFunctional end
+Base.show(io::IO, ::PointValue) = print(io, "PointValue()")
 
 """
     PointDerivative()
-    PointDerivative(α [, direction])
-    PointDerivative(x, α [, direction])
+    PointDerivative(α)
 
 Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
 multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
-for ∂²u/∂x∂y. The point `x` is a reference coordinate, but the derivative is with respect
-to physical coordinates so that the dof is cell-invariant on shared entities. `direction`
-has the same meaning as for [`PointValue`](@ref).
-`PointDerivative()` is a selector matching every point-derivative functional, while
-`PointDerivative(α)` matches the derivative `α` at every point and in every direction.
+for ∂²u/∂x∂y. The point xᵢ is given by `reference_coordinates`, but the derivative is with
+respect to physical coordinates so that the dof is cell-invariant on shared entities.
+`PointDerivative()` is a selector matching every point-derivative functional.
 """
-struct PointDerivative{X, A, D} <: DofFunctional
-    x::X
+struct PointDerivative{A} <: DofFunctional
     α::A
-    direction::D
 end
-PointDerivative() = PointDerivative(nothing, nothing, nothing)
-PointDerivative(α::NTuple{N, Int}) where {N} = PointDerivative(nothing, α, nothing)
-PointDerivative(α::NTuple{N, Int}, direction::Integer) where {N} = PointDerivative{Nothing, typeof(α), Int}(nothing, α, Int(direction))
-PointDerivative(x::Vec, α::NTuple{N, Int}) where {N} = PointDerivative(x, α, nothing)
-PointDerivative(x::Vec, α::NTuple{N, Int}, direction::Integer) where {N} = PointDerivative{typeof(x), typeof(α), Int}(x, α, Int(direction))
+PointDerivative() = PointDerivative(nothing)
 function Base.show(io::IO, f::PointDerivative)
     print(io, "PointDerivative(")
-    f.x === nothing || (show(io, f.x); print(io, ", "))
     f.α === nothing || show(io, f.α)
-    f.direction === nothing || print(io, f.α === nothing ? "nothing, " : ", ", f.direction)
     return print(io, ")")
 end
 
@@ -206,44 +178,56 @@ InteriorMoment(nr::Integer) = InteriorMoment{Int}(Int(nr))
 Base.show(io::IO, f::InteriorMoment) = print(io, "InteriorMoment(", f.nr === nothing ? "" : f.nr, ")")
 
 """
+    VectorizedFunctional(functional::DofFunctional, direction::Int)
+
+Dof functional of a `VectorizedInterpolation` dof: the scalar `functional` applied to
+component `direction` of a vector-valued function, ℓ(v) = ℓₛ(v ⋅ e_direction). Scalar
+selectors such as `PointValue()` match through the wrapper, so a [`Dirichlet`](@ref)
+condition selects the kind of dof with `functional` and the direction with `components`.
+"""
+struct VectorizedFunctional{F <: DofFunctional} <: DofFunctional
+    functional::F
+    direction::Int
+end
+Base.show(io::IO, f::VectorizedFunctional) = print(io, "VectorizedFunctional(", f.functional, ", ", f.direction, ")")
+
+"""
     dof_functionals(ip::Interpolation)
 
 Return a tuple of length `getnbasefunctions(ip)` with the [`DofFunctional`](@ref) of each
-local dof. Functionals for a `VectorizedInterpolation` include their vector direction and
-follow the same scalar-dof-major, direction-minor ordering as its shape functions.
+local dof. Functionals for a `VectorizedInterpolation` are the scalar functionals wrapped
+in [`VectorizedFunctional`](@ref), in the same scalar-dof-major, direction-minor ordering
+as its shape functions.
 
 The `ScalarInterpolation` fallback returns all-[`PointValue`](@ref), correct for nodal
 interpolations; scalar interpolations with other kinds of dofs (e.g. derivative dofs)
 must override this method. Interpolations subtyping `VectorInterpolation` directly (e.g.
-`RaviartThomas`) have no fallback and must always define it.
+`RaviartThomas`) have no fallback and must always define it. The point of every
+point-supported dof `i` must be given by `reference_coordinates(ip)[i]`.
 """
-dof_functionals(ip::ScalarInterpolation) = Tuple(PointValue(x) for x in reference_coordinates(ip))
+dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefunctions(ip))
 
 """
     matches_functional(selector::DofFunctional, f::DofFunctional)
 
 Return `true` if the dof functional `f` matches `selector`. Omitted properties in selector
-instances act as wildcards; for example, `PointValue()` matches every point and direction,
-`PointValue(2)` matches every point in direction 2, and `PointDerivative((1,))` matches
-that derivative at every point and in every direction.
+instances act as wildcards; for example, `PointDerivative()` matches every derivative
+while `PointDerivative((1,))` matches only that derivative. A scalar selector matches a
+[`VectorizedFunctional`](@ref) if it matches the wrapped functional, in every direction.
 """
 matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
 _matches_property(selector, value) = selector === nothing || selector == value
-matches_functional(selector::PointValue, f::PointValue) =
-    _matches_property(selector.x, f.x) && _matches_property(selector.direction, f.direction)
-matches_functional(selector::PointDerivative, f::PointDerivative) =
-    _matches_property(selector.x, f.x) && _matches_property(selector.α, f.α) &&
-    _matches_property(selector.direction, f.direction)
+matches_functional(selector::PointDerivative, f::PointDerivative) = _matches_property(selector.α, f.α)
 matches_functional(selector::NormalMoment, f::NormalMoment) = _matches_property(selector.nr, f.nr)
 matches_functional(selector::TangentialMoment, f::TangentialMoment) = _matches_property(selector.nr, f.nr)
 matches_functional(selector::InteriorMoment, f::InteriorMoment) = _matches_property(selector.nr, f.nr)
+matches_functional(selector::DofFunctional, f::VectorizedFunctional) = matches_functional(selector, f.functional)
+matches_functional(selector::VectorizedFunctional, f::VectorizedFunctional) =
+    selector.direction == f.direction && matches_functional(selector.functional, f.functional)
 
+# The scalar functional underlying a `VectorizedFunctional` (cf. `get_base_interpolation`).
 _base_functional(f::DofFunctional) = f
-_base_functional(f::PointValue) = f.x === nothing ? PointValue() : PointValue(f.x)
-function _base_functional(f::PointDerivative)
-    f.α === nothing && return PointDerivative()
-    return f.x === nothing ? PointDerivative(f.α) : PointDerivative(f.x, f.α)
-end
+_base_functional(f::VectorizedFunctional) = f.functional
 
 # Per-entity functionals in local entity-dof order.
 function _entity_functionals(ip::Interpolation, entity_indices::Tuple)
@@ -1948,10 +1932,8 @@ struct VectorizedInterpolation{vdim, refshape, order, SI <: ScalarInterpolation{
 end
 conformity(ip::VectorizedInterpolation) = conformity(ip.ip)
 function dof_functionals(ip::VectorizedInterpolation{vdim}) where {vdim}
-    return Tuple(_with_direction(f, d) for f in dof_functionals(ip.ip) for d in 1:vdim)
+    return Tuple(VectorizedFunctional(f, d) for f in dof_functionals(ip.ip) for d in 1:vdim)
 end
-_with_direction(f::PointValue, direction::Int) = PointValue(f.x, direction)
-_with_direction(f::PointDerivative, direction::Int) = PointDerivative(f.x, f.α, direction)
 
 function _vectorized_entity_functionals(ip::VectorizedInterpolation{vdim}, entity_indices) where {vdim}
     fs = dof_functionals(ip)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -85,10 +85,10 @@ function conformity end
     DofFunctional
 
 Supertype for the dof functional ℓᵢ of local shape function `i` of an interpolation,
-queryable with [`Ferrite.dof_functionals`](@ref). The functional describes *what* a dof
-means physically (point value, point derivative, integral moment), but not *where* it is
-located -- geometry lives in [`Ferrite.reference_coordinates`](@ref) and the entity
-dof-index functions -- so functionals can be compared between cells sharing an entity.
+queryable with [`Ferrite.dof_functionals`](@ref). Point-supported functionals include
+their reference point and vector direction; the owning topological entity is given by the
+entity dof-index functions. Point coordinates are also available collectively through
+[`Ferrite.reference_coordinates`](@ref).
 
 Subtypes: [`PointValue`](@ref), [`PointDerivative`](@ref), and the
 [`IntegralMoment`](@ref) family ([`NormalMoment`](@ref), [`TangentialMoment`](@ref),
@@ -98,22 +98,59 @@ abstract type DofFunctional end
 
 """
     PointValue()
+    PointValue(direction)
+    PointValue(x [, direction])
 
 Dof functional for a point evaluation: ℓ(f) = f(xᵢ), where xᵢ is given by
-`reference_coordinates`.
+`reference_coordinates`. `direction` is the component selected from a vector-valued
+function and is omitted for scalar-valued interpolations. `PointValue()` and
+`PointValue(direction)` omit the point and can be used as selectors matching every point
+with the requested direction.
 """
-struct PointValue <: DofFunctional end
+struct PointValue{X, D} <: DofFunctional
+    x::X
+    direction::D
+end
+PointValue() = PointValue(nothing, nothing)
+PointValue(x::Vec) = PointValue(x, nothing)
+PointValue(direction::Integer) = PointValue{Nothing, Int}(nothing, Int(direction))
+PointValue(x::Vec, direction::Integer) = PointValue{typeof(x), Int}(x, Int(direction))
+function Base.show(io::IO, f::PointValue)
+    print(io, "PointValue(")
+    f.x === nothing || show(io, f.x)
+    f.direction === nothing || print(io, f.x === nothing ? "" : ", ", f.direction)
+    return print(io, ")")
+end
 
 """
-    PointDerivative(α::NTuple{D, Int})
+    PointDerivative()
+    PointDerivative(α [, direction])
+    PointDerivative(x, α [, direction])
 
 Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
 multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
-for ∂²u/∂x∂y. The derivative is with respect to *physical* coordinates, so that the dof
-value is cell-invariant on shared entities (a reference-coordinate derivative is not).
+for ∂²u/∂x∂y. The point `x` is a reference coordinate, but the derivative is with respect
+to physical coordinates so that the dof is cell-invariant on shared entities. `direction`
+has the same meaning as for [`PointValue`](@ref).
+`PointDerivative()` is a selector matching every point-derivative functional, while
+`PointDerivative(α)` matches the derivative `α` at every point and in every direction.
 """
-struct PointDerivative{D} <: DofFunctional
-    α::NTuple{D, Int}
+struct PointDerivative{X, A, D} <: DofFunctional
+    x::X
+    α::A
+    direction::D
+end
+PointDerivative() = PointDerivative(nothing, nothing, nothing)
+PointDerivative(α::NTuple{N, Int}) where {N} = PointDerivative(nothing, α, nothing)
+PointDerivative(α::NTuple{N, Int}, direction::Integer) where {N} = PointDerivative{Nothing, typeof(α), Int}(nothing, α, Int(direction))
+PointDerivative(x::Vec, α::NTuple{N, Int}) where {N} = PointDerivative(x, α, nothing)
+PointDerivative(x::Vec, α::NTuple{N, Int}, direction::Integer) where {N} = PointDerivative{typeof(x), typeof(α), Int}(x, α, Int(direction))
+function Base.show(io::IO, f::PointDerivative)
+    print(io, "PointDerivative(")
+    f.x === nothing || (show(io, f.x); print(io, ", "))
+    f.α === nothing || show(io, f.α)
+    f.direction === nothing || print(io, f.α === nothing ? "nothing, " : ", ", f.direction)
+    return print(io, ")")
 end
 
 """
@@ -128,60 +165,87 @@ interpolation families do not guarantee identical functionals.
 abstract type IntegralMoment <: DofFunctional end
 
 """
-    NormalMoment(nr::Int)
+    NormalMoment([nr::Int])
 
 Moment nr `nr` of the normal trace, ℓ(v) = ∫ (v ⋅ n) q dS, over the entity owning the dof
 (H(div) interpolations).
+`NormalMoment()` is a selector matching every normal moment.
 """
-struct NormalMoment <: IntegralMoment
-    nr::Int
+struct NormalMoment{N} <: IntegralMoment
+    nr::N
 end
+NormalMoment() = NormalMoment(nothing)
+NormalMoment(nr::Integer) = NormalMoment{Int}(Int(nr))
+Base.show(io::IO, f::NormalMoment) = print(io, "NormalMoment(", f.nr === nothing ? "" : f.nr, ")")
 
 """
-    TangentialMoment(nr::Int)
+    TangentialMoment([nr::Int])
 
 Moment nr `nr` of the tangential trace, ℓ(v) = ∫ (v ⋅ t) q dS, over the entity owning the
 dof (H(curl) interpolations).
+`TangentialMoment()` is a selector matching every tangential moment.
 """
-struct TangentialMoment <: IntegralMoment
-    nr::Int
+struct TangentialMoment{N} <: IntegralMoment
+    nr::N
 end
+TangentialMoment() = TangentialMoment(nothing)
+TangentialMoment(nr::Integer) = TangentialMoment{Int}(Int(nr))
+Base.show(io::IO, f::TangentialMoment) = print(io, "TangentialMoment(", f.nr === nothing ? "" : f.nr, ")")
 
 """
-    InteriorMoment(nr::Int)
+    InteriorMoment([nr::Int])
 
 Cell-interior moment nr `nr`, ℓ(v) = ∫ v ⋅ q dV, for dofs interior to the cell.
+`InteriorMoment()` is a selector matching every interior moment.
 """
-struct InteriorMoment <: IntegralMoment
-    nr::Int
+struct InteriorMoment{N} <: IntegralMoment
+    nr::N
 end
+InteriorMoment() = InteriorMoment(nothing)
+InteriorMoment(nr::Integer) = InteriorMoment{Int}(Int(nr))
+Base.show(io::IO, f::InteriorMoment) = print(io, "InteriorMoment(", f.nr === nothing ? "" : f.nr, ")")
 
 """
     dof_functionals(ip::Interpolation)
 
 Return a tuple of length `getnbasefunctions(ip)` with the [`DofFunctional`](@ref) of each
-local dof. For a `VectorizedInterpolation` the tuple is indexed by *base* (scalar) dof
-number, matching the other per-dof queries.
+local dof. Functionals for a `VectorizedInterpolation` include their vector direction and
+follow the same scalar-dof-major, direction-minor ordering as its shape functions.
 
 The `ScalarInterpolation` fallback returns all-[`PointValue`](@ref), correct for nodal
 interpolations; scalar interpolations with other kinds of dofs (e.g. derivative dofs)
 must override this method. Interpolations subtyping `VectorInterpolation` directly (e.g.
 `RaviartThomas`) have no fallback and must always define it.
 """
-dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefunctions(ip))
+dof_functionals(ip::ScalarInterpolation) = Tuple(PointValue(x) for x in reference_coordinates(ip))
 
 """
-    matches_functional(selector, f::DofFunctional)
+    matches_functional(selector::DofFunctional, f::DofFunctional)
 
-Return `true` if the dof functional `f` matches `selector`, which is either a
-`DofFunctional` subtype (matching the whole family, e.g. `PointDerivative`) or a concrete
-instance (matching exactly, e.g. `PointDerivative((1,))`).
+Return `true` if the dof functional `f` matches `selector`. Omitted properties in selector
+instances act as wildcards; for example, `PointValue()` matches every point and direction,
+`PointValue(2)` matches every point in direction 2, and `PointDerivative((1,))` matches
+that derivative at every point and in every direction.
 """
-matches_functional(selector::Type{<:DofFunctional}, f::DofFunctional) = f isa selector
 matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
+_matches_property(selector, value) = selector === nothing || selector == value
+matches_functional(selector::PointValue, f::PointValue) =
+    _matches_property(selector.x, f.x) && _matches_property(selector.direction, f.direction)
+matches_functional(selector::PointDerivative, f::PointDerivative) =
+    _matches_property(selector.x, f.x) && _matches_property(selector.α, f.α) &&
+    _matches_property(selector.direction, f.direction)
+matches_functional(selector::NormalMoment, f::NormalMoment) = _matches_property(selector.nr, f.nr)
+matches_functional(selector::TangentialMoment, f::TangentialMoment) = _matches_property(selector.nr, f.nr)
+matches_functional(selector::InteriorMoment, f::InteriorMoment) = _matches_property(selector.nr, f.nr)
 
-# Per-entity dof functional signatures of (the base of) an interpolation: a tuple over
-# entities, each element the tuple of DofFunctionals in local entity-dof order.
+_base_functional(f::DofFunctional) = f
+_base_functional(f::PointValue) = f.x === nothing ? PointValue() : PointValue(f.x)
+function _base_functional(f::PointDerivative)
+    f.α === nothing && return PointDerivative()
+    return f.x === nothing ? PointDerivative(f.α) : PointDerivative(f.x, f.α)
+end
+
+# Per-entity functionals in local entity-dof order.
 function _entity_functionals(ip::Interpolation, entity_indices::Tuple)
     fs = dof_functionals(ip)
     return map(dofs -> map(i -> fs[i], dofs), entity_indices)
@@ -189,6 +253,7 @@ end
 vertexdof_functionals(ip::Interpolation) = _entity_functionals(ip, vertexdof_indices(ip))
 edgedof_functionals(ip::Interpolation) = _entity_functionals(ip, edgedof_interior_indices(ip))
 facedof_functionals(ip::Interpolation) = _entity_functionals(ip, facedof_interior_indices(ip))
+facetdof_functionals(ip::Interpolation) = _entity_functionals(ip, facetdof_interior_indices(ip))
 
 # Number of components for the interpolation.
 n_components(::ScalarInterpolation) = 1
@@ -1741,8 +1806,6 @@ struct CrouzeixRaviart{shape, order} <: ScalarInterpolation{shape, order}
     CrouzeixRaviart{RefTetrahedron, 1}() = new{RefTetrahedron, 1}()
 end
 conformity(::CrouzeixRaviart) = L2Conformity()
-# The implemented basis is nodal at the facet midpoints, so the PointValue fallback of
-# dof_functionals applies (the classical facet-mean dofs coincide with midpoint values).
 
 # CR elements are characterized by not having vertex dofs
 vertexdof_indices(ip::CrouzeixRaviart) = ntuple(i -> (), nvertices(ip))
@@ -1809,8 +1872,6 @@ hypercubes. For details see the original paper [RanTur:1992:snq](@cite).
 """
 struct RannacherTurek{shape, order} <: ScalarInterpolation{shape, order} end
 conformity(::RannacherTurek) = L2Conformity()
-# Nodal at facet midpoints like CrouzeixRaviart, so the PointValue fallback of
-# dof_functionals applies.
 
 # CR-type elements are characterized by not having vertex dofs
 vertexdof_indices(ip::RannacherTurek) = ntuple(i -> (), nvertices(ip))
@@ -1886,7 +1947,22 @@ struct VectorizedInterpolation{vdim, refshape, order, SI <: ScalarInterpolation{
     end
 end
 conformity(ip::VectorizedInterpolation) = conformity(ip.ip)
-dof_functionals(ip::VectorizedInterpolation) = dof_functionals(ip.ip) # indexed by base dof number
+function dof_functionals(ip::VectorizedInterpolation{vdim}) where {vdim}
+    return Tuple(_with_direction(f, d) for f in dof_functionals(ip.ip) for d in 1:vdim)
+end
+_with_direction(f::PointValue, direction::Int) = PointValue(f.x, direction)
+_with_direction(f::PointDerivative, direction::Int) = PointDerivative(f.x, f.α, direction)
+
+function _vectorized_entity_functionals(ip::VectorizedInterpolation{vdim}, entity_indices) where {vdim}
+    fs = dof_functionals(ip)
+    return map(entity_indices(ip.ip)) do dofs
+        Tuple(fs[(dof - 1) * vdim + direction] for dof in dofs for direction in 1:vdim)
+    end
+end
+vertexdof_functionals(ip::VectorizedInterpolation) = _vectorized_entity_functionals(ip, vertexdof_indices)
+edgedof_functionals(ip::VectorizedInterpolation) = _vectorized_entity_functionals(ip, edgedof_interior_indices)
+facedof_functionals(ip::VectorizedInterpolation) = _vectorized_entity_functionals(ip, facedof_interior_indices)
+facetdof_functionals(ip::VectorizedInterpolation) = _vectorized_entity_functionals(ip, facetdof_interior_indices)
 
 adjust_dofs_during_distribution(ip::VectorizedInterpolation) = adjust_dofs_during_distribution(ip.ip)
 interior_facedofs_on_lattice(ip::VectorizedInterpolation) = interior_facedofs_on_lattice(ip.ip)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -81,6 +81,115 @@ or `H1Conformity()`, for the interpolation.
 """
 function conformity end
 
+"""
+    DofFunctional
+
+Supertype for the dof functional ℓᵢ of local shape function `i` of an interpolation,
+queryable with [`Ferrite.dof_functionals`](@ref). The functional describes *what* a dof
+means physically (point value, point derivative, integral moment), but not *where* it is
+located -- geometry lives in [`Ferrite.reference_coordinates`](@ref) and the entity
+dof-index functions -- so functionals can be compared between cells sharing an entity.
+
+Subtypes: [`PointValue`](@ref), [`PointDerivative`](@ref), and the
+[`IntegralMoment`](@ref) family ([`NormalMoment`](@ref), [`TangentialMoment`](@ref),
+[`InteriorMoment`](@ref)). Not to be confused with [`PointValues`](@ref) (plural).
+"""
+abstract type DofFunctional end
+
+"""
+    PointValue()
+
+Dof functional for a point evaluation: ℓ(f) = f(xᵢ), where xᵢ is given by
+`reference_coordinates`.
+"""
+struct PointValue <: DofFunctional end
+
+"""
+    PointDerivative(α::NTuple{D, Int})
+
+Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
+multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
+for ∂²u/∂x∂y. The derivative is with respect to *physical* coordinates, so that the dof
+value is cell-invariant on shared entities (a reference-coordinate derivative is not).
+"""
+struct PointDerivative{D} <: DofFunctional
+    α::NTuple{D, Int}
+end
+
+"""
+    IntegralMoment
+
+Supertype for dof functionals defined as integral moments over the entity owning the dof:
+[`NormalMoment`](@ref), [`TangentialMoment`](@ref), and [`InteriorMoment`](@ref). `nr`
+enumerates the moments on one entity in local entity-dof order. The identity does not
+encode the weight function or normalization, so equal moment signatures from different
+interpolation families do not guarantee identical functionals.
+"""
+abstract type IntegralMoment <: DofFunctional end
+
+"""
+    NormalMoment(nr::Int)
+
+Moment nr `nr` of the normal trace, ℓ(v) = ∫ (v ⋅ n) q dS, over the entity owning the dof
+(H(div) interpolations).
+"""
+struct NormalMoment <: IntegralMoment
+    nr::Int
+end
+
+"""
+    TangentialMoment(nr::Int)
+
+Moment nr `nr` of the tangential trace, ℓ(v) = ∫ (v ⋅ t) q dS, over the entity owning the
+dof (H(curl) interpolations).
+"""
+struct TangentialMoment <: IntegralMoment
+    nr::Int
+end
+
+"""
+    InteriorMoment(nr::Int)
+
+Cell-interior moment nr `nr`, ℓ(v) = ∫ v ⋅ q dV, for dofs interior to the cell.
+"""
+struct InteriorMoment <: IntegralMoment
+    nr::Int
+end
+
+"""
+    dof_functionals(ip::Interpolation)
+
+Return a tuple of length `getnbasefunctions(ip)` with the [`DofFunctional`](@ref) of each
+local dof. For a `VectorizedInterpolation` the tuple is indexed by *base* (scalar) dof
+number, matching the other per-dof queries.
+
+The `ScalarInterpolation` fallback returns all-[`PointValue`](@ref), correct for nodal
+interpolations; scalar interpolations with other kinds of dofs (e.g. derivative dofs)
+must override this method. Interpolations subtyping `VectorInterpolation` directly (e.g.
+`RaviartThomas`) have no fallback and must always define it.
+"""
+dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefunctions(ip))
+
+"""
+    matches_functional(selector, f::DofFunctional)
+
+Return `true` if the dof functional `f` matches `selector`, which is either a
+`DofFunctional` subtype (matching the whole family, e.g. `PointDerivative`) or a concrete
+instance (matching exactly, e.g. `PointDerivative((1,))`).
+"""
+matches_functional(selector::Type{<:DofFunctional}, f::DofFunctional) = f isa selector
+matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
+
+# Per-entity dof functional signatures of (the base of) an interpolation: a tuple over
+# entities, each element the tuple of DofFunctionals in local entity-dof order.
+function _entity_functionals(ip::Interpolation, entity_indices::Tuple)
+    fs = dof_functionals(ip)
+    return map(dofs -> map(i -> fs[i], dofs), entity_indices)
+end
+vertexdof_functionals(ip::Interpolation) = _entity_functionals(ip, vertexdof_indices(ip))
+edgedof_functionals(ip::Interpolation) = _entity_functionals(ip, edgedof_interior_indices(ip))
+facedof_functionals(ip::Interpolation) = _entity_functionals(ip, facedof_interior_indices(ip))
+
 # Number of components for the interpolation.
 n_components(::ScalarInterpolation) = 1
 n_components(::VectorInterpolation{vdim}) where {vdim} = vdim
@@ -1632,6 +1741,8 @@ struct CrouzeixRaviart{shape, order} <: ScalarInterpolation{shape, order}
     CrouzeixRaviart{RefTetrahedron, 1}() = new{RefTetrahedron, 1}()
 end
 conformity(::CrouzeixRaviart) = L2Conformity()
+# The implemented basis is nodal at the facet midpoints, so the PointValue fallback of
+# dof_functionals applies (the classical facet-mean dofs coincide with midpoint values).
 
 # CR elements are characterized by not having vertex dofs
 vertexdof_indices(ip::CrouzeixRaviart) = ntuple(i -> (), nvertices(ip))
@@ -1698,6 +1809,8 @@ hypercubes. For details see the original paper [RanTur:1992:snq](@cite).
 """
 struct RannacherTurek{shape, order} <: ScalarInterpolation{shape, order} end
 conformity(::RannacherTurek) = L2Conformity()
+# Nodal at facet midpoints like CrouzeixRaviart, so the PointValue fallback of
+# dof_functionals applies.
 
 # CR-type elements are characterized by not having vertex dofs
 vertexdof_indices(ip::RannacherTurek) = ntuple(i -> (), nvertices(ip))
@@ -1773,6 +1886,7 @@ struct VectorizedInterpolation{vdim, refshape, order, SI <: ScalarInterpolation{
     end
 end
 conformity(ip::VectorizedInterpolation) = conformity(ip.ip)
+dof_functionals(ip::VectorizedInterpolation) = dof_functionals(ip.ip) # indexed by base dof number
 
 adjust_dofs_during_distribution(ip::VectorizedInterpolation) = adjust_dofs_during_distribution(ip.ip)
 interior_facedofs_on_lattice(ip::VectorizedInterpolation) = interior_facedofs_on_lattice(ip.ip)
@@ -1884,6 +1998,7 @@ end
 
 getnbasefunctions(::RaviartThomas{RefTriangle, 1}) = 3
 edgedof_interior_indices(::RaviartThomas{RefTriangle, 1}) = ((1,), (2,), (3,))
+dof_functionals(::RaviartThomas{RefTriangle, 1}) = ntuple(_ -> NormalMoment(1), 3)
 facedof_interior_indices(::RaviartThomas{RefTriangle, 1}) = ((),)
 adjust_dofs_during_distribution(::RaviartThomas) = false
 
@@ -1913,6 +2028,9 @@ end
 getnbasefunctions(::RaviartThomas{RefTriangle, 2}) = 8
 edgedof_interior_indices(::RaviartThomas{RefTriangle, 2}) = ((1, 2), (3, 4), (5, 6))
 facedof_interior_indices(::RaviartThomas{RefTriangle, 2}) = ((7, 8),)
+function dof_functionals(::RaviartThomas{RefTriangle, 2})
+    return (ntuple(i -> NormalMoment(mod1(i, 2)), 6)..., InteriorMoment(1), InteriorMoment(2))
+end
 adjust_dofs_during_distribution(::RaviartThomas{RefTriangle, 2}) = true
 
 function get_direction(::RaviartThomas{RefTriangle, 2}, shape_nr, cell)
@@ -1937,6 +2055,7 @@ end
 getnbasefunctions(::RaviartThomas{RefQuadrilateral, 1}) = 4
 edgedof_interior_indices(::RaviartThomas{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
 facedof_interior_indices(::RaviartThomas{RefQuadrilateral, 1}) = ((),)
+dof_functionals(::RaviartThomas{RefQuadrilateral, 1}) = ntuple(_ -> NormalMoment(1), 4)
 adjust_dofs_during_distribution(::RaviartThomas{RefQuadrilateral, 1}) = false
 
 function get_direction(::RaviartThomas{RefQuadrilateral, 1}, shape_nr, cell)
@@ -1957,6 +2076,7 @@ end
 getnbasefunctions(::RaviartThomas{RefTetrahedron, 1}) = 4
 edgedof_interior_indices(::RaviartThomas{RefTetrahedron, 1}) = ntuple(_ -> (), 6)
 facedof_interior_indices(::RaviartThomas{RefTetrahedron, 1}) = ((1,), (2,), (3,), (4,))
+dof_functionals(::RaviartThomas{RefTetrahedron, 1}) = ntuple(_ -> NormalMoment(1), 4)
 adjust_dofs_during_distribution(::RaviartThomas{RefTetrahedron, 1}) = false
 
 function get_direction(::RaviartThomas{RefTetrahedron, 1}, shape_nr, cell)
@@ -1982,6 +2102,7 @@ end
 getnbasefunctions(::RaviartThomas{RefHexahedron, 1}) = 6
 edgedof_interior_indices(::RaviartThomas{RefHexahedron, 1}) = ntuple(_ -> (), 12)
 facedof_interior_indices(::RaviartThomas{RefHexahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,))
+dof_functionals(::RaviartThomas{RefHexahedron, 1}) = ntuple(_ -> NormalMoment(1), 6)
 adjust_dofs_during_distribution(::RaviartThomas{RefHexahedron, 1}) = false
 
 function get_direction(::RaviartThomas{RefHexahedron, 1}, shape_nr, cell)
@@ -2020,6 +2141,7 @@ end
 
 getnbasefunctions(::BrezziDouglasMarini{RefTriangle, 1}) = 6
 edgedof_interior_indices(::BrezziDouglasMarini{RefTriangle, 1}) = ((1, 2), (3, 4), (5, 6))
+dof_functionals(::BrezziDouglasMarini{RefTriangle, 1}) = ntuple(i -> NormalMoment(mod1(i, 2)), 6)
 adjust_dofs_during_distribution(::BrezziDouglasMarini{RefTriangle, 1}) = true
 
 function get_direction(::BrezziDouglasMarini{RefTriangle, 1}, shape_nr, cell)
@@ -2053,6 +2175,7 @@ end
 
 getnbasefunctions(::Nedelec{RefTriangle, 1}) = 3
 edgedof_interior_indices(::Nedelec{RefTriangle, 1}) = ((1,), (2,), (3,))
+dof_functionals(::Nedelec{RefTriangle, 1}) = ntuple(_ -> TangentialMoment(1), 3)
 adjust_dofs_during_distribution(::Nedelec{RefTriangle, 1}) = false
 
 function get_direction(::Nedelec{RefTriangle, 1}, shape_nr, cell)
@@ -2083,6 +2206,9 @@ end
 getnbasefunctions(::Nedelec{RefTriangle, 2}) = 8
 edgedof_interior_indices(::Nedelec{RefTriangle, 2}) = ((1, 2), (3, 4), (5, 6))
 facedof_interior_indices(::Nedelec{RefTriangle, 2}) = ((7, 8),)
+function dof_functionals(::Nedelec{RefTriangle, 2})
+    return (ntuple(i -> TangentialMoment(mod1(i, 2)), 6)..., InteriorMoment(1), InteriorMoment(2))
+end
 adjust_dofs_during_distribution(::Nedelec{RefTriangle, 2}) = true
 
 function get_direction(::Nedelec{RefTriangle, 2}, shape_nr, cell)
@@ -2107,6 +2233,7 @@ end
 
 getnbasefunctions(::Nedelec{RefQuadrilateral, 1}) = 4
 edgedof_interior_indices(::Nedelec{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
+dof_functionals(::Nedelec{RefQuadrilateral, 1}) = ntuple(_ -> TangentialMoment(1), 4)
 adjust_dofs_during_distribution(::Nedelec{RefQuadrilateral, 1}) = false
 
 function get_direction(::Nedelec{RefQuadrilateral, 1}, shape_nr, cell)
@@ -2130,6 +2257,7 @@ end
 
 getnbasefunctions(::Nedelec{RefTetrahedron, 1}) = 6
 edgedof_interior_indices(::Nedelec{RefTetrahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,))
+dof_functionals(::Nedelec{RefTetrahedron, 1}) = ntuple(_ -> TangentialMoment(1), 6)
 adjust_dofs_during_distribution(::Nedelec{RefTetrahedron, 1}) = false
 
 function get_direction(::Nedelec{RefTetrahedron, 1}, shape_nr, cell)
@@ -2159,6 +2287,7 @@ end
 
 getnbasefunctions(::Nedelec{RefHexahedron, 1}) = 12
 edgedof_interior_indices(::Nedelec{RefHexahedron, 1}) = ((1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,), (10,), (11,), (12,))
+dof_functionals(::Nedelec{RefHexahedron, 1}) = ntuple(_ -> TangentialMoment(1), 12)
 adjust_dofs_during_distribution(::Nedelec{RefHexahedron, 1}) = false
 
 function get_direction(::Nedelec{RefHexahedron, 1}, shape_nr, cell)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -107,30 +107,20 @@ Base.show(io::IO, ::PointValue) = print(io, "PointValue()")
 
 """
     PointDerivative(α)
-    PointDerivative(; order)
 
 Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
 multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
 for ∂²u/∂x∂y. The point xᵢ is given by `reference_coordinates`, but the derivative is with
 respect to physical coordinates so that the dof is cell-invariant on shared entities.
-`PointDerivative()` is a selector matching every point-derivative functional and
-`PointDerivative(order = 1)` one matching every derivative of order |α| = 1.
+The first type parameter is the derivative order |α|, so the types `PointDerivative` and
+`PointDerivative{1}` can be used as selectors for every derivative and every first
+derivative, respectively (cf. [`Ferrite.matches_functional`](@ref)).
 """
-struct PointDerivative{A} <: DofFunctional
-    α::A
-    order::Union{Nothing, Int}
+struct PointDerivative{order, N} <: DofFunctional
+    α::NTuple{N, Int}
+    PointDerivative(α::NTuple{N, Int}) where {N} = new{sum(α), N}(α)
 end
-PointDerivative(α::NTuple{N, Int}) where {N} = PointDerivative(α, sum(α))
-PointDerivative(; order::Union{Nothing, Integer} = nothing) = PointDerivative(nothing, order === nothing ? nothing : Int(order))
-function Base.show(io::IO, f::PointDerivative)
-    print(io, "PointDerivative(")
-    if f.α !== nothing
-        show(io, f.α)
-    elseif f.order !== nothing
-        print(io, "order = ", f.order)
-    end
-    return print(io, ")")
-end
+Base.show(io::IO, f::PointDerivative) = print(io, "PointDerivative(", f.α, ")")
 
 """
     IntegralMoment
@@ -198,20 +188,30 @@ point-supported dof `i` must be given by `reference_coordinates(ip)[i]`.
 """
 dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefunctions(ip))
 
-"""
-    matches_functional(selector::DofFunctional, f::DofFunctional)
+# Selectors accepted by e.g. the `functional` keyword of `Dirichlet`: a functional
+# instance, a functional type acting as a wildcard, or a tuple of either. Tuple elements
+# must be checked with `_is_selector` at runtime, since e.g. `typeof((PointValue,))` is
+# `Tuple{DataType}` which no `Tuple{Vararg{Type{<:DofFunctional}}}` constraint covers.
+const DofFunctionalSelector = Union{DofFunctional, Type{<:DofFunctional}, Tuple}
+_is_selector(s) = s isa DofFunctional || (s isa Type && s <: DofFunctional)
+_selector_tuple(selector::Union{DofFunctional, Type{<:DofFunctional}}) = (selector,)
+_selector_tuple(selectors::Tuple) = selectors
 
-Return `true` if the dof functional `f` matches `selector`. Omitted properties in selector
-instances act as wildcards; for example, `PointDerivative()` matches every derivative,
-`PointDerivative(order = 1)` every first derivative, and `PointDerivative((1,))` only that
-derivative. A scalar selector matches a
+"""
+    matches_functional(selector, f::DofFunctional)
+
+Return `true` if the dof functional `f` matches `selector`. A `DofFunctional` instance
+matches by equality and a `DofFunctional` type by `isa`, so types act as wildcards, e.g.
+`PointDerivative` matches every derivative and `PointDerivative{1}` every first
+derivative. A tuple of selectors matches if any element does. A scalar selector matches a
 [`VectorizedFunctional`](@ref) if it matches the wrapped functional, in every direction.
 """
 matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
-_matches_property(selector, value) = selector === nothing || selector == value
-matches_functional(selector::PointDerivative, f::PointDerivative) =
-    _matches_property(selector.α, f.α) && _matches_property(selector.order, f.order)
+matches_functional(selector::Type{<:DofFunctional}, f::DofFunctional) = f isa selector
+matches_functional(selectors::Tuple, f::DofFunctional) = any(s -> matches_functional(s, f), selectors)
 matches_functional(selector::DofFunctional, f::VectorizedFunctional) = matches_functional(selector, f.functional)
+matches_functional(selector::Type{<:DofFunctional}, f::VectorizedFunctional) =
+    f isa selector || matches_functional(selector, f.functional)
 matches_functional(selector::VectorizedFunctional, f::VectorizedFunctional) =
     selector.direction == f.direction && matches_functional(selector.functional, f.functional)
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -106,22 +106,29 @@ struct PointValue <: DofFunctional end
 Base.show(io::IO, ::PointValue) = print(io, "PointValue()")
 
 """
-    PointDerivative()
     PointDerivative(α)
+    PointDerivative(; order)
 
 Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
 multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
 for ∂²u/∂x∂y. The point xᵢ is given by `reference_coordinates`, but the derivative is with
 respect to physical coordinates so that the dof is cell-invariant on shared entities.
-`PointDerivative()` is a selector matching every point-derivative functional.
+`PointDerivative()` is a selector matching every point-derivative functional and
+`PointDerivative(order = 1)` one matching every derivative of order |α| = 1.
 """
 struct PointDerivative{A} <: DofFunctional
     α::A
+    order::Union{Nothing, Int}
 end
-PointDerivative() = PointDerivative(nothing)
+PointDerivative(α::NTuple{N, Int}) where {N} = PointDerivative(α, sum(α))
+PointDerivative(; order::Union{Nothing, Integer} = nothing) = PointDerivative(nothing, order === nothing ? nothing : Int(order))
 function Base.show(io::IO, f::PointDerivative)
     print(io, "PointDerivative(")
-    f.α === nothing || show(io, f.α)
+    if f.α !== nothing
+        show(io, f.α)
+    elseif f.order !== nothing
+        print(io, "order = ", f.order)
+    end
     return print(io, ")")
 end
 
@@ -195,13 +202,15 @@ dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefun
     matches_functional(selector::DofFunctional, f::DofFunctional)
 
 Return `true` if the dof functional `f` matches `selector`. Omitted properties in selector
-instances act as wildcards; for example, `PointDerivative()` matches every derivative
-while `PointDerivative((1,))` matches only that derivative. A scalar selector matches a
+instances act as wildcards; for example, `PointDerivative()` matches every derivative,
+`PointDerivative(order = 1)` every first derivative, and `PointDerivative((1,))` only that
+derivative. A scalar selector matches a
 [`VectorizedFunctional`](@ref) if it matches the wrapped functional, in every direction.
 """
 matches_functional(selector::DofFunctional, f::DofFunctional) = f == selector
 _matches_property(selector, value) = selector === nothing || selector == value
-matches_functional(selector::PointDerivative, f::PointDerivative) = _matches_property(selector.α, f.α)
+matches_functional(selector::PointDerivative, f::PointDerivative) =
+    _matches_property(selector.α, f.α) && _matches_property(selector.order, f.order)
 matches_functional(selector::DofFunctional, f::VectorizedFunctional) = matches_functional(selector, f.functional)
 matches_functional(selector::VectorizedFunctional, f::VectorizedFunctional) =
     selector.direction == f.direction && matches_functional(selector.functional, f.functional)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -87,7 +87,7 @@ function conformity end
 Supertype for the dof functional ℓᵢ of local shape function `i` of an interpolation,
 queryable with [`Ferrite.dof_functionals`](@ref). The functional describes only the kind
 of dof; the owning topological entity is given by the entity dof-index functions and the
-point of a point-supported dof `i` by `reference_coordinates(ip)[i]`.
+point of a point-supported scalar dof `i` by `reference_coordinates(ip)[i]`.
 
 Subtypes: [`PointValue`](@ref), [`PointDerivative`](@ref), the [`IntegralMoment`](@ref)
 family ([`NormalMoment`](@ref), [`TangentialMoment`](@ref), [`InteriorMoment`](@ref)),
@@ -109,16 +109,21 @@ Base.show(io::IO, ::PointValue) = print(io, "PointValue()")
     PointDerivative(α)
 
 Dof functional for a point evaluation of a derivative: ℓ(f) = ∂^|α|f/∂x^α at xᵢ, with
-multi-index `α`, e.g. `PointDerivative((1,))` for du/dx in 1D or `PointDerivative((1, 1))`
-for ∂²u/∂x∂y. The point xᵢ is given by `reference_coordinates`, but the derivative is with
-respect to physical coordinates so that the dof is cell-invariant on shared entities.
+nonnegative multi-index `α` of positive total order, e.g. `PointDerivative((1,))` for
+du/dx in 1D or `PointDerivative((1, 1))` for ∂²u/∂x∂y. The point xᵢ is given by
+`reference_coordinates`, but the derivative is with respect to physical coordinates so
+that the dof is cell-invariant on shared entities.
 The first type parameter is the derivative order |α|, so the types `PointDerivative` and
 `PointDerivative{1}` can be used as selectors for every derivative and every first
 derivative, respectively (cf. [`Ferrite.matches_functional`](@ref)).
 """
-struct PointDerivative{order, N} <: DofFunctional
-    α::NTuple{N, Int}
-    PointDerivative(α::NTuple{N, Int}) where {N} = new{sum(α), N}(α)
+struct PointDerivative{order, dim} <: DofFunctional
+    α::NTuple{dim, Int}
+    function PointDerivative(α::NTuple{dim, Int}) where {dim}
+        all(>=(0), α) && any(>(0), α) ||
+            throw(ArgumentError("a derivative multi-index must be nonnegative with positive total order"))
+        return new{sum(α), dim}(α)
+    end
 end
 Base.show(io::IO, f::PointDerivative) = print(io, "PointDerivative(", f.α, ")")
 
@@ -184,14 +189,13 @@ The `ScalarInterpolation` fallback returns all-[`PointValue`](@ref), correct for
 interpolations; scalar interpolations with other kinds of dofs (e.g. derivative dofs)
 must override this method. Interpolations subtyping `VectorInterpolation` directly (e.g.
 `RaviartThomas`) have no fallback and must always define it. The point of every
-point-supported dof `i` must be given by `reference_coordinates(ip)[i]`.
+point-supported dof `i` must be given by `reference_coordinates(ip)[i]`. For a
+`VectorizedInterpolation`, reference coordinates are stored once per scalar dof, so dof
+`i` uses `reference_coordinates(ip)[fld1(i, n_components(ip))]`.
 """
 dof_functionals(ip::ScalarInterpolation) = ntuple(_ -> PointValue(), getnbasefunctions(ip))
 
-# Selectors accepted by e.g. the `functional` keyword of `Dirichlet`: a functional
-# instance, a functional type acting as a wildcard, or a tuple of either. Tuple elements
-# must be checked with `_is_selector` at runtime, since e.g. `typeof((PointValue,))` is
-# `Tuple{DataType}` which no `Tuple{Vararg{Type{<:DofFunctional}}}` constraint covers.
+# Tuple elements need runtime validation: tuples of types have element type `DataType`.
 const DofFunctionalSelector = Union{DofFunctional, Type{<:DofFunctional}, Tuple}
 _is_selector(s) = s isa DofFunctional || (s isa Type && s <: DofFunctional)
 _selector_tuple(selector::Union{DofFunctional, Type{<:DofFunctional}}) = (selector,)

--- a/test/interpolation_test_utils.jl
+++ b/test/interpolation_test_utils.jl
@@ -68,6 +68,26 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
         # Test that property functions are defined, runs, and, if possible, give expected type
         Ferrite.mapping_type(ip) # Dry-run just to catch if it isn't defined
         @test Ferrite.conformity(ip) isa Union{Ferrite.L2Conformity, Ferrite.HdivConformity, Ferrite.HcurlConformity, Ferrite.H1Conformity}
+
+        # Test F: dof functionals
+        fs = Ferrite.dof_functionals(ip)
+        @test fs isa NTuple{getnbasefunctions(ip), DofFunctional}
+        if all(f -> f isa PointValue, fs)
+            # Point-value dofs must satisfy the Kronecker delta property at their
+            # reference coordinates
+            coords = Ferrite.reference_coordinates(ip)
+            for j in 1:getnbasefunctions(ip), i in 1:getnbasefunctions(ip)
+                Nij = Ferrite.reference_shape_value(ip, coords[j], i)
+                @test isapprox(Nij, i == j ? one(Nij) : zero(Nij); atol = 200 * eps(Float64))
+            end
+        else
+            # Moment-type layouts must have uniform per-entity signatures so that dof
+            # distribution can compare them entity-wise
+            for entity_functionals in (Ferrite.vertexdof_functionals, Ferrite.edgedof_functionals, Ferrite.facedof_functionals)
+                sigs = unique(filter(!isempty, collect(entity_functionals(ip))))
+                @test length(sigs) <= 1
+            end
+        end
     end
 end
 

--- a/test/interpolation_test_utils.jl
+++ b/test/interpolation_test_utils.jl
@@ -76,6 +76,7 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
             # Point-value dofs must satisfy the Kronecker delta property at their
             # reference coordinates
             coords = Ferrite.reference_coordinates(ip)
+            @test map(f -> f.x, fs) == Tuple(coords)
             for j in 1:getnbasefunctions(ip), i in 1:getnbasefunctions(ip)
                 Nij = Ferrite.reference_shape_value(ip, coords[j], i)
                 @test isapprox(Nij, i == j ? one(Nij) : zero(Nij); atol = 200 * eps(Float64))
@@ -83,7 +84,7 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
         else
             # Moment-type layouts must have uniform per-entity signatures so that dof
             # distribution can compare them entity-wise
-            for entity_functionals in (Ferrite.vertexdof_functionals, Ferrite.edgedof_functionals, Ferrite.facedof_functionals)
+            for entity_functionals in (Ferrite.vertexdof_functionals, Ferrite.edgedof_functionals, Ferrite.facedof_functionals, Ferrite.facetdof_functionals)
                 sigs = unique(filter(!isempty, collect(entity_functionals(ip))))
                 @test length(sigs) <= 1
             end

--- a/test/interpolation_test_utils.jl
+++ b/test/interpolation_test_utils.jl
@@ -76,7 +76,7 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
             # Point-value dofs must satisfy the Kronecker delta property at their
             # reference coordinates
             coords = Ferrite.reference_coordinates(ip)
-            @test map(f -> f.x, fs) == Tuple(coords)
+            @test length(coords) == length(fs)
             for j in 1:getnbasefunctions(ip), i in 1:getnbasefunctions(ip)
                 Nij = Ferrite.reference_shape_value(ip, coords[j], i)
                 @test isapprox(Nij, i == j ? one(Nij) : zero(Nij); atol = 200 * eps(Float64))

--- a/test/interpolation_test_utils.jl
+++ b/test/interpolation_test_utils.jl
@@ -69,7 +69,7 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
         Ferrite.mapping_type(ip) # Dry-run just to catch if it isn't defined
         @test Ferrite.conformity(ip) isa Union{Ferrite.L2Conformity, Ferrite.HdivConformity, Ferrite.HcurlConformity, Ferrite.H1Conformity}
 
-        # Test F: dof functionals
+        # Dof functionals and point-value duality
         fs = Ferrite.dof_functionals(ip)
         @test fs isa NTuple{getnbasefunctions(ip), DofFunctional}
         if all(f -> f isa PointValue, fs)
@@ -80,13 +80,6 @@ function test_interpolation_properties(ip::Interpolation{RefShape, FunOrder}) wh
             for j in 1:getnbasefunctions(ip), i in 1:getnbasefunctions(ip)
                 Nij = Ferrite.reference_shape_value(ip, coords[j], i)
                 @test isapprox(Nij, i == j ? one(Nij) : zero(Nij); atol = 200 * eps(Float64))
-            end
-        else
-            # Moment-type layouts must have uniform per-entity signatures so that dof
-            # distribution can compare them entity-wise
-            for entity_functionals in (Ferrite.vertexdof_functionals, Ferrite.edgedof_functionals, Ferrite.facedof_functionals, Ferrite.facetdof_functionals)
-                sigs = unique(filter(!isempty, collect(entity_functionals(ip))))
-                @test length(sigs) <= 1
             end
         end
     end

--- a/test/test_apply_analytical.jl
+++ b/test/test_apply_analytical.jl
@@ -167,5 +167,11 @@ using LinearAlgebra
         mdh = testdh_subdomains(2, 1, 1)
         @test_throws ErrorException apply_analytical!(zeros(ndofs(mdh)), mdh, :v, x -> 0.0)  # Missing field
         @test_throws ErrorException apply_analytical!(zeros(ndofs(mdh)), mdh, :u, x -> 0.0)  # Should be f(x)::Vec{2}
+
+        # Non-nodal interpolations (dofs that are not point values) are not supported
+        rtdh = DofHandler(generate_grid(Triangle, (2, 2)))
+        add!(rtdh, :q, RaviartThomas{RefTriangle, 1}())
+        close!(rtdh)
+        @test_throws ErrorException apply_analytical!(zeros(ndofs(rtdh)), rtdh, :q, x -> zero(Vec{2}))
     end
 end

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -131,7 +131,7 @@ end
     @test all(ch.inhomogeneities .== 1.0)
     # The selector must match a boundary dof.
     ch = ConstraintHandler(dh)
-    @test_throws ErrorException add!(ch, Dirichlet(:s, Γ, x -> 0.0; functional = PointDerivative()))
+    @test_throws ErrorException add!(ch, Dirichlet(:s, Γ, x -> 0.0; functional = PointDerivative))
     # Moment dofs require projection.
     dhq = DofHandler(grid)
     add!(dhq, :q, RaviartThomas{RefTriangle, 1}())
@@ -154,11 +154,13 @@ end
     @test all(ch.inhomogeneities .== 2.0)
     @test ch.dbcs[1].components == [2]
     ch = ConstraintHandler(dhv)
-    @test_throws ErrorException add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = PointDerivative()))
+    @test_throws ErrorException add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = PointDerivative))
     ch = ConstraintHandler(dhv)
     @test_throws ArgumentError add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = VectorizedFunctional(PointValue(), 2)))
     ch = ConstraintHandler(dhv)
-    @test_throws ErrorException add!(ch, Dirichlet(:u, Set(1:3), x -> 0.0; functional = PointDerivative()))
+    @test_throws ArgumentError add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = (PointValue(), VectorizedFunctional)))
+    ch = ConstraintHandler(dhv)
+    @test_throws ErrorException add!(ch, Dirichlet(:u, Set(1:3), x -> 0.0; functional = PointDerivative))
 end
 
 @testset "node bc" begin

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -122,25 +122,40 @@ end
     dh = DofHandler(grid)
     add!(dh, :s, Lagrange{RefTriangle, 1}())
     close!(dh)
-    # default functional (PointValue) gives unchanged behavior
+    # The default preserves the existing behavior.
     ch = ConstraintHandler(dh)
     add!(ch, Dirichlet(:s, Γ, x -> 1.0))
     close!(ch)
     update!(ch, 0.0)
     @test length(ch.prescribed_dofs) == 3
     @test all(ch.inhomogeneities .== 1.0)
-    # selecting a functional the boundary dofs do not have
+    # The selector must match a boundary dof.
     ch = ConstraintHandler(dh)
-    @test_throws ErrorException add!(ch, Dirichlet(:s, Γ, x -> 0.0; functional = PointDerivative))
-    # moment dofs cannot be prescribed with Dirichlet
+    @test_throws ErrorException add!(ch, Dirichlet(:s, Γ, x -> 0.0; functional = PointDerivative()))
+    # Moment dofs require projection.
     dhq = DofHandler(grid)
     add!(dhq, :q, RaviartThomas{RefTriangle, 1}())
     close!(dhq)
     ch = ConstraintHandler(dhq)
-    @test_throws ErrorException add!(ch, Dirichlet(:q, Γ, x -> 0.0; functional = NormalMoment))
-    # nodesets require purely nodal interpolations
+    @test_throws ErrorException add!(ch, Dirichlet(:q, Γ, x -> 0.0; functional = NormalMoment()))
+    # Nodesets require purely nodal interpolations.
     ch = ConstraintHandler(dhq)
     @test_throws ArgumentError add!(ch, Dirichlet(:q, Set(1:3), x -> 0.0))
+
+    # Functional directions intersect with `components`.
+    dhv = DofHandler(grid)
+    add!(dhv, :u, Lagrange{RefTriangle, 1}()^2)
+    close!(dhv)
+    ch = ConstraintHandler(dhv)
+    add!(ch, Dirichlet(:u, Γ, x -> 2.0; functional = PointValue(2)))
+    close!(ch)
+    @test length(ch.prescribed_dofs) == 3
+    @test all(ch.inhomogeneities .== 2.0)
+    @test ch.dbcs[1].components == [2]
+    ch = ConstraintHandler(dhv)
+    @test_throws ErrorException add!(ch, Dirichlet(:u, Γ, x -> 0.0, [1]; functional = PointValue(2)))
+    ch = ConstraintHandler(dhv)
+    @test_throws ArgumentError add!(ch, Dirichlet(:u, Set(1:3), x -> 0.0; functional = PointValue(Vec{2}((1.0, 0.0)))))
 end
 
 @testset "node bc" begin

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -116,6 +116,49 @@ end
     @test_throws ErrorException("components [2, 3] not within range of field :v (2 dimension(s))") add!(ConstraintHandler(dh), pdbc)
 end
 
+# Hermite dof layout; shape evaluation is unnecessary for prescribing the dofs.
+struct HermiteLineLayout <: ScalarInterpolation{RefLine, 3} end
+Ferrite.getnbasefunctions(::HermiteLineLayout) = 4
+Ferrite.vertexdof_indices(::HermiteLineLayout) = ((1, 2), (3, 4))
+Ferrite.edgedof_interior_indices(::HermiteLineLayout) = ((),)
+Ferrite.facedof_interior_indices(::HermiteLineLayout) = ()
+Ferrite.adjust_dofs_during_distribution(::HermiteLineLayout) = false
+Ferrite.reference_coordinates(::HermiteLineLayout) = [Vec((-1.0,)), Vec((-1.0,)), Vec((1.0,)), Vec((1.0,))]
+Ferrite.dof_functionals(::HermiteLineLayout) = (PointValue(), PointDerivative((1,)), PointValue(), PointDerivative((1,)))
+
+@testset "Dirichlet on value and derivative dofs" begin
+    grid = generate_grid(Line, (2,))
+    boundary = union(getfacetset(grid, "left"), getfacetset(grid, "right"))
+    for ncomponents in (1, 2)
+        dh = DofHandler(grid)
+        add!(dh, :offset, Lagrange{RefLine, 1}())
+        ip = ncomponents == 1 ? HermiteLineLayout() : HermiteLineLayout()^ncomponents
+        add!(dh, :u, ip)
+        close!(dh)
+        for selector in (PointDerivative, PointDerivative{1}, PointDerivative((1,)))
+            ch = ConstraintHandler(dh)
+            add!(ch, Dirichlet(:u, boundary, (x, t) -> x[1] + t, [ncomponents]; functional = selector))
+            close!(ch)
+            update!(ch, 2.0)
+            a = zeros(ndofs(dh))
+            apply!(a, ch)
+            left_dof = celldofs(dh, 1)[2 + 2ncomponents]
+            right_dof = celldofs(dh, 2)[2 + 4ncomponents]
+            @test Set(ch.prescribed_dofs) == Set((left_dof, right_dof))
+            @test a[left_dof] == 1.0
+            @test a[right_dof] == 3.0
+            @test count(!iszero, a) == 2
+        end
+        ch = ConstraintHandler(dh)
+        add!(ch, Dirichlet(:u, boundary, x -> x[1], [ncomponents]; functional = (PointValue(), PointDerivative{1})))
+        close!(ch)
+        @test length(ch.prescribed_dofs) == 4
+        @test sort(ch.inhomogeneities) == [-1.0, -1.0, 1.0, 1.0]
+        @test_throws ArgumentError add!(ConstraintHandler(dh), Dirichlet(:u, Set(1:3), Returns(0.0)))
+        @test_throws "all point values" apply_analytical!(zeros(ndofs(dh)), dh, :u, Returns(0.0))
+    end
+end
+
 @testset "Dirichlet functional selector" begin
     grid = generate_grid(Triangle, (2, 2))
     Γ = getfacetset(grid, "left")

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -116,6 +116,33 @@ end
     @test_throws ErrorException("components [2, 3] not within range of field :v (2 dimension(s))") add!(ConstraintHandler(dh), pdbc)
 end
 
+@testset "Dirichlet functional selector" begin
+    grid = generate_grid(Triangle, (2, 2))
+    Γ = getfacetset(grid, "left")
+    dh = DofHandler(grid)
+    add!(dh, :s, Lagrange{RefTriangle, 1}())
+    close!(dh)
+    # default functional (PointValue) gives unchanged behavior
+    ch = ConstraintHandler(dh)
+    add!(ch, Dirichlet(:s, Γ, x -> 1.0))
+    close!(ch)
+    update!(ch, 0.0)
+    @test length(ch.prescribed_dofs) == 3
+    @test all(ch.inhomogeneities .== 1.0)
+    # selecting a functional the boundary dofs do not have
+    ch = ConstraintHandler(dh)
+    @test_throws ErrorException add!(ch, Dirichlet(:s, Γ, x -> 0.0; functional = PointDerivative))
+    # moment dofs cannot be prescribed with Dirichlet
+    dhq = DofHandler(grid)
+    add!(dhq, :q, RaviartThomas{RefTriangle, 1}())
+    close!(dhq)
+    ch = ConstraintHandler(dhq)
+    @test_throws ErrorException add!(ch, Dirichlet(:q, Γ, x -> 0.0; functional = NormalMoment))
+    # nodesets require purely nodal interpolations
+    ch = ConstraintHandler(dhq)
+    @test_throws ArgumentError add!(ch, Dirichlet(:q, Set(1:3), x -> 0.0))
+end
+
 @testset "node bc" begin
     grid = generate_grid(Triangle, (1, 1))
     addnodeset!(grid, "nodeset", x -> x[2] == -1 || x[1] == -1)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -142,20 +142,23 @@ end
     ch = ConstraintHandler(dhq)
     @test_throws ArgumentError add!(ch, Dirichlet(:q, Set(1:3), x -> 0.0))
 
-    # Functional directions intersect with `components`.
+    # For vectorized interpolations the selector picks the scalar functional and
+    # `components` picks the direction.
     dhv = DofHandler(grid)
     add!(dhv, :u, Lagrange{RefTriangle, 1}()^2)
     close!(dhv)
     ch = ConstraintHandler(dhv)
-    add!(ch, Dirichlet(:u, Γ, x -> 2.0; functional = PointValue(2)))
+    add!(ch, Dirichlet(:u, Γ, x -> 2.0, [2]; functional = PointValue()))
     close!(ch)
     @test length(ch.prescribed_dofs) == 3
     @test all(ch.inhomogeneities .== 2.0)
     @test ch.dbcs[1].components == [2]
     ch = ConstraintHandler(dhv)
-    @test_throws ErrorException add!(ch, Dirichlet(:u, Γ, x -> 0.0, [1]; functional = PointValue(2)))
+    @test_throws ErrorException add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = PointDerivative()))
     ch = ConstraintHandler(dhv)
-    @test_throws ArgumentError add!(ch, Dirichlet(:u, Set(1:3), x -> 0.0; functional = PointValue(Vec{2}((1.0, 0.0)))))
+    @test_throws ArgumentError add!(ch, Dirichlet(:u, Γ, x -> 0.0; functional = VectorizedFunctional(PointValue(), 2)))
+    ch = ConstraintHandler(dhv)
+    @test_throws ErrorException add!(ch, Dirichlet(:u, Set(1:3), x -> 0.0; functional = PointDerivative()))
 end
 
 @testset "node bc" begin

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -30,6 +30,51 @@ import Metis
     @test_throws ErrorException add!(sdh2, :u, Lagrange{RefQuadrilateral, 1}()^2)
     # different interpolation order in different sdh
     @test_logs (:warn,) add!(sdh2, :u, Lagrange{RefQuadrilateral, 2}())
+
+    # incompatible dof functionals on shared entities across SubDofHandlers
+    tgrid = generate_grid(Triangle, (2, 2))
+    dh = DofHandler(tgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1:4))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(5:8))
+    # point-value edge dofs vs normal-moment edge dofs (same n_components, same order)
+    add!(sdh1, :u, Lagrange{RefTriangle, 2}()^2)
+    @test_throws ErrorException add!(sdh2, :u, RaviartThomas{RefTriangle, 2}())
+    # different edge dof counts (previously only a warning, but aliases dofs)
+    dh = DofHandler(tgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1:4))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(5:8))
+    add!(sdh1, :u, Lagrange{RefTriangle, 2}())
+    @test_throws ErrorException add!(sdh2, :u, Lagrange{RefTriangle, 3}())
+    # incompatible face dofs in 3D (point values vs normal moments)
+    hgrid = generate_grid(Hexahedron, (2, 1, 1))
+    dh = DofHandler(hgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(2))
+    add!(sdh1, :q, Lagrange{RefHexahedron, 2}()^3)
+    @test_throws ErrorException add!(sdh2, :q, RaviartThomas{RefHexahedron, 1}())
+    # mixed refshapes with matching functionals close cleanly (2D cell-interior dofs
+    # are never shared, so the quad face bubble is not compared)
+    cells = [Quadrilateral((1, 2, 5, 4)), Triangle((2, 3, 5)), Triangle((3, 6, 5))]
+    nodes = [Node(Vec{2}((x, y))) for (x, y) in ((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (0.0, 1.0), (1.0, 1.0), (2.0, 1.0))]
+    mgrid = Grid(cells, nodes)
+    dh = DofHandler(mgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(2:3))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 2}())
+    @test_logs add!(sdh2, :u, Lagrange{RefTriangle, 2}())
+    close!(dh)
+    @test ndofs(dh) == 6 + 8 + 1 # 6 vertices, 8 edges, 1 quad interior
+    # same mixed surface mesh embedded in 3D: 2D cell interiors are still never shared,
+    # so the differing interior signatures must not be flagged
+    snodes = [Node(Vec{3}((x, y, 0.0))) for (x, y) in ((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (0.0, 1.0), (1.0, 1.0), (2.0, 1.0))]
+    sgrid = Grid(copy(cells), snodes)
+    dh = DofHandler(sgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(2:3))
+    add!(sdh1, :u, Lagrange{RefQuadrilateral, 2}())
+    @test_logs add!(sdh2, :u, Lagrange{RefTriangle, 2}())
+    close!(dh)
+    @test ndofs(dh) == 6 + 8 + 1
 end
 
 

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -3,6 +3,17 @@ using LinearAlgebra
 using SparseArrays
 import Metis
 
+# Quadratic layout with off-center edge points.
+struct OffCenterQuadraticTriangle <: ScalarInterpolation{RefTriangle, 2} end
+Ferrite.getnbasefunctions(::OffCenterQuadraticTriangle) = 6
+Ferrite.vertexdof_indices(::OffCenterQuadraticTriangle) = ((1,), (2,), (3,))
+Ferrite.edgedof_interior_indices(::OffCenterQuadraticTriangle) = ((4,), (5,), (6,))
+Ferrite.facedof_interior_indices(::OffCenterQuadraticTriangle) = ((),)
+function Ferrite.reference_coordinates(::OffCenterQuadraticTriangle)
+    vertices = Ferrite.reference_coordinates(Lagrange{RefTriangle, 1}())
+    return [vertices; [vertices[a] + (vertices[b] - vertices[a]) / 3 for (a, b) in Ferrite.reference_edges(RefTriangle)]]
+end
+
 @testset "DofHandler construction" begin
     grid = generate_grid(Quadrilateral, (2, 1))
     dh = DofHandler(grid)
@@ -31,21 +42,30 @@ import Metis
     # different interpolation order in different sdh
     @test_logs (:warn,) add!(sdh2, :u, Lagrange{RefQuadrilateral, 2}())
 
-    # incompatible dof functionals on shared entities across SubDofHandlers
     tgrid = generate_grid(Triangle, (2, 2))
     dh = DofHandler(tgrid)
     sdh1 = Ferrite.SubDofHandler(dh, Set(1:4))
     sdh2 = Ferrite.SubDofHandler(dh, Set(5:8))
-    # point-value edge dofs vs normal-moment edge dofs (same n_components, same order)
     add!(sdh1, :u, Lagrange{RefTriangle, 2}()^2)
     @test_throws ErrorException add!(sdh2, :u, RaviartThomas{RefTriangle, 2}())
-    # different edge dof counts (previously only a warning, but aliases dofs)
     dh = DofHandler(tgrid)
     sdh1 = Ferrite.SubDofHandler(dh, Set(1:4))
     sdh2 = Ferrite.SubDofHandler(dh, Set(5:8))
     add!(sdh1, :u, Lagrange{RefTriangle, 2}())
     @test_throws ErrorException add!(sdh2, :u, Lagrange{RefTriangle, 3}())
-    # incompatible face dofs in 3D (point values vs normal moments)
+    dh = DofHandler(tgrid)
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1:4))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(5:8))
+    add!(sdh1, :u, Lagrange{RefTriangle, 2}())
+    @test_throws ErrorException add!(sdh2, :u, OffCenterQuadraticTriangle())
+    dcells = [Triangle((1, 2, 3)), Triangle((4, 5, 6))]
+    dnodes = [Node(Vec{2}((x, y))) for (x, y) in ((0, 0), (1, 0), (0, 1), (2, 0), (3, 0), (2, 1))]
+    dh = DofHandler(Grid(dcells, dnodes))
+    sdh1 = Ferrite.SubDofHandler(dh, Set(1))
+    sdh2 = Ferrite.SubDofHandler(dh, Set(2))
+    add!(sdh1, :u, Lagrange{RefTriangle, 2}())
+    @test_logs (:warn,) add!(sdh2, :u, Lagrange{RefTriangle, 3}())
+    close!(dh)
     hgrid = generate_grid(Hexahedron, (2, 1, 1))
     dh = DofHandler(hgrid)
     sdh1 = Ferrite.SubDofHandler(dh, Set(1))

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -14,6 +14,40 @@ function Ferrite.reference_coordinates(::OffCenterQuadraticTriangle)
     return [vertices; [vertices[a] + (vertices[b] - vertices[a]) / 3 for (a, b) in Ferrite.reference_edges(RefTriangle)]]
 end
 
+# A nodal layout with a different functional at each vertex.
+struct VertexFunctionalTriangle{F} <: ScalarInterpolation{RefTriangle, 1}
+    functionals::F
+end
+Ferrite.getnbasefunctions(::VertexFunctionalTriangle) = 3
+Ferrite.vertexdof_indices(::VertexFunctionalTriangle) = ((1,), (2,), (3,))
+Ferrite.edgedof_interior_indices(::VertexFunctionalTriangle) = ((), (), ())
+Ferrite.facedof_interior_indices(::VertexFunctionalTriangle) = ((),)
+Ferrite.reference_coordinates(::VertexFunctionalTriangle) = Ferrite.reference_coordinates(Lagrange{RefTriangle, 1}())
+Ferrite.dof_functionals(ip::VertexFunctionalTriangle) = ip.functionals
+Ferrite.adjust_dofs_during_distribution(::VertexFunctionalTriangle) = false
+
+@testset "Functionals on actual shared vertices" begin
+    nodes = [Node(Vec(x)) for x in ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0))]
+    grid = Grid([Triangle((1, 2, 3)), Triangle((2, 4, 3))], nodes)
+    value, derivative = PointValue(), PointDerivative((1, 0))
+
+    # Identical local layouts can disagree at a shared vertex with different local indices.
+    ip = VertexFunctionalTriangle((value, derivative, value))
+    dh = DofHandler(grid)
+    left, right = SubDofHandler(dh, Set(1)), SubDofHandler(dh, Set(2))
+    add!(left, :u, ip)
+    @test_throws "incompatible dof definitions on shared vertices" add!(right, :u, ip)
+
+    # Differences at the two unshared vertices do not prevent sharing the other dofs.
+    dh = DofHandler(grid)
+    left, right = SubDofHandler(dh, Set(1)), SubDofHandler(dh, Set(2))
+    add!(left, :u, VertexFunctionalTriangle((derivative, value, value)))
+    add!(right, :u, VertexFunctionalTriangle((value, derivative, value)))
+    close!(dh)
+    @test ndofs(dh) == 4
+    @test celldofs(dh, 1)[2:3] == celldofs(dh, 2)[[1, 3]]
+end
+
 @testset "DofHandler construction" begin
     grid = generate_grid(Quadrilateral, (2, 1))
     dh = DofHandler(grid)

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -264,6 +264,10 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         @test Ferrite.matches_functional(PointDerivative(), VectorizedFunctional(PointDerivative((1, 0)), 2))
         @test Ferrite.matches_functional(PointDerivative((1, 0)), VectorizedFunctional(PointDerivative((1, 0)), 2))
         @test !Ferrite.matches_functional(PointDerivative((0, 1)), VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test Ferrite.matches_functional(PointDerivative(order = 1), PointDerivative((0, 1)))
+        @test Ferrite.matches_functional(PointDerivative(order = 2), PointDerivative((1, 1)))
+        @test !Ferrite.matches_functional(PointDerivative(order = 1), PointDerivative((1, 1)))
+        @test !Ferrite.matches_functional(PointDerivative(order = 1), PointValue())
         @test Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), fs[2])
         @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 1), fs[2])
         @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), PointValue())
@@ -272,6 +276,7 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         @test repr(PointValue()) == "PointValue()"
         @test repr(PointDerivative()) == "PointDerivative()"
         @test repr(PointDerivative((1, 0))) == "PointDerivative((1, 0))"
+        @test repr(PointDerivative(order = 2)) == "PointDerivative(order = 2)"
         @test repr(fs[2]) == "VectorizedFunctional(PointValue(), 2)"
         @test repr(NormalMoment()) == "NormalMoment()"
     end

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -244,6 +244,37 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         end
     end
 
+    @testset "Dof functionals of vectorized interpolations" begin
+        ip = Lagrange{RefTriangle, 1}()^2
+        fs = Ferrite.dof_functionals(ip)
+        base_coords = Ferrite.reference_coordinates(ip.ip)
+        @test length(fs) == getnbasefunctions(ip)
+        @test fs == (
+            PointValue(base_coords[1], 1), PointValue(base_coords[1], 2),
+            PointValue(base_coords[2], 1), PointValue(base_coords[2], 2),
+            PointValue(base_coords[3], 1), PointValue(base_coords[3], 2),
+        )
+        coords = Ferrite.reference_coordinates(ip)
+        @test coords == base_coords
+        for j in eachindex(fs), i in eachindex(fs)
+            Nij = Ferrite.reference_shape_value(ip, fs[j].x, i)
+            @test Nij[fs[j].direction] == (i == j)
+        end
+        @test Ferrite.vertexdof_functionals(ip) == ntuple(i -> (PointValue(base_coords[i], 1), PointValue(base_coords[i], 2)), 3)
+        @test Ferrite.facetdof_functionals(ip) == ((), (), ())
+        @test Ferrite.matches_functional(PointValue(), PointValue(2))
+        @test !Ferrite.matches_functional(PointValue(1), PointValue(2))
+        @test Ferrite.matches_functional(PointDerivative(), PointDerivative((1, 0), 2))
+        @test Ferrite.matches_functional(PointDerivative((1, 0)), PointDerivative((1, 0), 2))
+        @test !Ferrite.matches_functional(PointDerivative((0, 1)), PointDerivative((1, 0), 2))
+        @test Ferrite._base_functional(PointDerivative()) == PointDerivative()
+        @test repr(PointValue()) == "PointValue()"
+        @test repr(PointValue(2)) == "PointValue(2)"
+        @test repr(PointValue(base_coords[1], 2)) == "PointValue([1.0, 0.0], 2)"
+        @test repr(PointDerivative((1, 0), 2)) == "PointDerivative((1, 0), 2)"
+        @test repr(NormalMoment()) == "NormalMoment()"
+    end
+
     @testset "Errors for entitydof_indices on VectorizedInterpolations" begin
         ip = Lagrange{RefQuadrilateral, 2}()^2
         @test_throws ArgumentError Ferrite.vertexdof_indices(ip)

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -249,29 +249,30 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         fs = Ferrite.dof_functionals(ip)
         base_coords = Ferrite.reference_coordinates(ip.ip)
         @test length(fs) == getnbasefunctions(ip)
-        @test fs == (
-            PointValue(base_coords[1], 1), PointValue(base_coords[1], 2),
-            PointValue(base_coords[2], 1), PointValue(base_coords[2], 2),
-            PointValue(base_coords[3], 1), PointValue(base_coords[3], 2),
-        )
+        @test fs == Tuple(VectorizedFunctional(PointValue(), d) for i in 1:3 for d in 1:2)
         coords = Ferrite.reference_coordinates(ip)
         @test coords == base_coords
         for j in eachindex(fs), i in eachindex(fs)
-            Nij = Ferrite.reference_shape_value(ip, fs[j].x, i)
+            Nij = Ferrite.reference_shape_value(ip, coords[fld1(j, 2)], i)
             @test Nij[fs[j].direction] == (i == j)
         end
-        @test Ferrite.vertexdof_functionals(ip) == ntuple(i -> (PointValue(base_coords[i], 1), PointValue(base_coords[i], 2)), 3)
+        @test Ferrite.vertexdof_functionals(ip) == ntuple(i -> (VectorizedFunctional(PointValue(), 1), VectorizedFunctional(PointValue(), 2)), 3)
         @test Ferrite.facetdof_functionals(ip) == ((), (), ())
-        @test Ferrite.matches_functional(PointValue(), PointValue(2))
-        @test !Ferrite.matches_functional(PointValue(1), PointValue(2))
-        @test Ferrite.matches_functional(PointDerivative(), PointDerivative((1, 0), 2))
-        @test Ferrite.matches_functional(PointDerivative((1, 0)), PointDerivative((1, 0), 2))
-        @test !Ferrite.matches_functional(PointDerivative((0, 1)), PointDerivative((1, 0), 2))
+        # Scalar selectors match through the wrapper, in every direction
+        @test Ferrite.matches_functional(PointValue(), fs[2])
+        @test !Ferrite.matches_functional(PointDerivative(), fs[2])
+        @test Ferrite.matches_functional(PointDerivative(), VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test Ferrite.matches_functional(PointDerivative((1, 0)), VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test !Ferrite.matches_functional(PointDerivative((0, 1)), VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), fs[2])
+        @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 1), fs[2])
+        @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), PointValue())
+        @test Ferrite._base_functional(fs[2]) == PointValue()
         @test Ferrite._base_functional(PointDerivative()) == PointDerivative()
         @test repr(PointValue()) == "PointValue()"
-        @test repr(PointValue(2)) == "PointValue(2)"
-        @test repr(PointValue(base_coords[1], 2)) == "PointValue([1.0, 0.0], 2)"
-        @test repr(PointDerivative((1, 0), 2)) == "PointDerivative((1, 0), 2)"
+        @test repr(PointDerivative()) == "PointDerivative()"
+        @test repr(PointDerivative((1, 0))) == "PointDerivative((1, 0))"
+        @test repr(fs[2]) == "VectorizedFunctional(PointValue(), 2)"
         @test repr(NormalMoment()) == "NormalMoment()"
     end
 

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -260,23 +260,26 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         @test Ferrite.facetdof_functionals(ip) == ((), (), ())
         # Scalar selectors match through the wrapper, in every direction
         @test Ferrite.matches_functional(PointValue(), fs[2])
-        @test !Ferrite.matches_functional(PointDerivative(), fs[2])
-        @test Ferrite.matches_functional(PointDerivative(), VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test !Ferrite.matches_functional(PointDerivative, fs[2])
+        @test Ferrite.matches_functional(PointDerivative, VectorizedFunctional(PointDerivative((1, 0)), 2))
         @test Ferrite.matches_functional(PointDerivative((1, 0)), VectorizedFunctional(PointDerivative((1, 0)), 2))
         @test !Ferrite.matches_functional(PointDerivative((0, 1)), VectorizedFunctional(PointDerivative((1, 0)), 2))
-        @test Ferrite.matches_functional(PointDerivative(order = 1), PointDerivative((0, 1)))
-        @test Ferrite.matches_functional(PointDerivative(order = 2), PointDerivative((1, 1)))
-        @test !Ferrite.matches_functional(PointDerivative(order = 1), PointDerivative((1, 1)))
-        @test !Ferrite.matches_functional(PointDerivative(order = 1), PointValue())
+        # Types select by order, tuples by union
+        @test Ferrite.matches_functional(PointDerivative{1}, PointDerivative((0, 1)))
+        @test Ferrite.matches_functional(PointDerivative{2}, PointDerivative((1, 1)))
+        @test !Ferrite.matches_functional(PointDerivative{1}, PointDerivative((1, 1)))
+        @test !Ferrite.matches_functional(PointDerivative{1}, PointValue())
+        @test Ferrite.matches_functional(PointDerivative{1}, VectorizedFunctional(PointDerivative((1, 0)), 2))
+        @test Ferrite.matches_functional((PointValue(), PointDerivative{1}), PointDerivative((0, 1)))
+        @test Ferrite.matches_functional((PointValue(), PointDerivative{1}), fs[2])
+        @test !Ferrite.matches_functional((PointDerivative((1, 0)), PointDerivative((0, 1))), PointDerivative((1, 1)))
         @test Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), fs[2])
         @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 1), fs[2])
         @test !Ferrite.matches_functional(VectorizedFunctional(PointValue(), 2), PointValue())
         @test Ferrite._base_functional(fs[2]) == PointValue()
-        @test Ferrite._base_functional(PointDerivative()) == PointDerivative()
+        @test Ferrite._base_functional(PointDerivative((1, 0))) == PointDerivative((1, 0))
         @test repr(PointValue()) == "PointValue()"
-        @test repr(PointDerivative()) == "PointDerivative()"
         @test repr(PointDerivative((1, 0))) == "PointDerivative((1, 0))"
-        @test repr(PointDerivative(order = 2)) == "PointDerivative(order = 2)"
         @test repr(fs[2]) == "VectorizedFunctional(PointValue(), 2)"
         @test repr(NormalMoment()) == "NormalMoment()"
     end

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -244,6 +244,14 @@ using Ferrite: reference_shape_value, reference_shape_gradient
         end
     end
 
+    @testset "Derivative multi-indices" begin
+        @test PointDerivative((1, 0)) isa PointDerivative{1, 2}
+        @test PointDerivative((1, 1)) isa PointDerivative{2, 2}
+        @test_throws ArgumentError PointDerivative((-1, 2))
+        @test_throws ArgumentError PointDerivative((0, 0))
+        @test_throws ArgumentError PointDerivative(())
+    end
+
     @testset "Dof functionals of vectorized interpolations" begin
         ip = Lagrange{RefTriangle, 1}()^2
         fs = Ferrite.dof_functionals(ip)


### PR DESCRIPTION
Adds `Ferrite.dof_functionals(ip)` so boundary conditions and dof distribution can distinguish point values, derivatives, and integral moments. This supports interpolations with several kinds of dofs, including the Hermite elements discussed in [#1391](https://github.com/Ferrite-FEM/Ferrite.jl/pull/1391#discussion_r3647764861).

### Dof descriptions

The query returns one descriptor per local dof, in shape-function order:

- `PointValue()` for function values at a point.
- `PointDerivative(α)` for derivatives in physical coordinates, with multi-index `α` and total derivative order stored in the type.
- `NormalMoment()`, `TangentialMoment()`, and `InteriorMoment()` for integral moments.

For vectorized interpolations, each scalar descriptor is wrapped in `VectorizedFunctional(functional, direction)`. Coordinates and owning entities remain available through the existing coordinate and dof-index queries; vectorized interpolations continue to store coordinates once per scalar dof. Per-entity functional queries are also provided, including `facetdof_functionals`.

### Boundary conditions

`Dirichlet` gains a `functional` keyword. Its default, `PointValue()`, preserves the usual nodal boundary conditions. For an interpolation with derivative dofs, for example:

```julia
Dirichlet(:u, boundary, f; functional = PointDerivative{1})
```

This prescribes all first derivatives. `PointDerivative` selects every derivative, `PointDerivative((1, 0))` selects one derivative, and a tuple of selectors selects their union. The function `f` supplies the prescribed derivative value directly. For vectorized fields, `components` continues to select the vector components.

Selecting integral moments with `Dirichlet` reports an error directing users to `ProjectedDirichlet`. Nodeset constraints and `apply_analytical!` require interpolations whose dofs are all point values.

### Sharing dofs between subdomains

When a field is added to multiple `SubDofHandler`s, the dofs on shared vertices, edges, and faces must have compatible functional layouts and point locations. Only entities carrying dofs on both sides are compared; differences on unshared entities are allowed. When every possible entity pairing is compatible, validation skips the mesh scan.

This changes some previously accepted combinations into errors. For example, sharing edge dofs between quadratic and cubic Lagrange interpolations now errors instead of warning and assigning overlapping global dof numbers. Equal dof counts with different functionals or support points are also rejected.

Moment descriptors do not encode weights or normalization, so matching descriptors alone cannot establish equivalence between different moment bases. Entity-relative derivatives, such as the normal derivatives needed by Argyris elements (#1270), will need a separate descriptor.

### Validation

The interpolation, H(curl)/H(div) moment-duality, dof-distribution, constraint, analytical-assignment, mixed-dof, facet-value, and export tests pass. Regression tests cover mismatches at actual shared vertices, compatible differences at unshared vertices, and scalar/vector derivative boundary conditions. Runic and repository hygiene checks pass.
