### PR TITLE
Conflict-aware grid coloring for DG assembly and constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    both keyword arguments behave exactly as before. ([#1468])
 
 ### Added
+ - `create_coloring` can now account for conflicts beyond node-sharing, making colored
+   multithreaded assembly safe for more problem types: interface (DG) assembly via the
+   `interface_coupling` keyword argument, constraint condensation during assembly (e.g.
+   `PeriodicDirichlet`/`AffineConstraint` with `apply_assemble!`, where mesh-distant
+   cells conflict through the master dofs) via a new `create_coloring(dh, ch)` method,
+   and arbitrary user-known conflicts via the `extra_conflicts` keyword argument. The
+   `DofHandler` method mirrors the keyword arguments of `add_sparsity_entries!` so the
+   arguments used for matrix allocation can be forwarded as-is, and uses the
+   interpolations to pick the sharpest safe conflict graph (e.g. fewer colors for purely
+   discontinuous discretizations). Default behavior (and its determinism guarantee) is
+   unchanged. ([#1493])
  - Added mesh-free [`AlgebraicVariable`s](https://ferrite-fem.github.io/Ferrite.jl/dev/topics/algebraic_variables/)
    and coupling descriptors for small global unknowns such as Lagrange multipliers and
    homogenized quantities. See the documentation for details. ([#1422])
@@ -1435,3 +1446,4 @@ poking into Ferrite internals:
 [#1475]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1475
 [#1481]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1481
 [#1490]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1490
+[#1493]: https://github.com/Ferrite-FEM/Ferrite.jl/issues/1493

--- a/IMPROVED_COLORING.md
+++ b/IMPROVED_COLORING.md
@@ -1,0 +1,380 @@
+# Plan: DG- and constraint-aware grid coloring
+
+**Status: IMPLEMENTED 2026-08-15** (uncommitted, on `master`). One refinement was made
+during implementation: the "sharp" tier as planned (`A_n ∪ A_f ∪ A_f²`) was internally
+inconsistent — `A_n` *is* what contains the 3D vertex diagonals, and it is only needed
+when a continuous field exists. The implementation therefore has three DG modes, each
+exact for its field configuration: `:facet` (`A_f ∪ A_f²`, purely discontinuous
+discretization — vertex diagonals excluded), `:sharp` (`A_n ∪ A_f²`, continuous fields
+exist but only discontinuous ones cross interfaces), `:product` (a continuous field
+crosses, or grid-only API). Mode selection is automatic in `create_coloring(dh, ...)`.
+
+*Draft for iteration — now implemented. Companion to the WorkStream exploration
+(see `WORKSTREAM.md`); coloring is the only threading strategy that needs conflict
+analysis at all (atomic and the pipeline are immune).*
+
+## Context
+
+`create_coloring` currently defines "conflict" as "shares a node", which is only valid
+for continuous fields assembled cell-locally. Two cases need a larger conflict graph:
+
+1. **DG/interface assembly**: an item also writes dofs of its *facet* neighbors. The
+   exact conflict graph depends on which fields appear in the interface term:
+   - **Only discontinuous (L2) fields cross interfaces** (standard DG): dofs are
+     cell-interior, so the graph is `A_n ∪ A_f ∪ A_f²` (node graph for cell terms of
+     any CG fields + facet neighbors + cells sharing a facet neighbor). 2D corner
+     neighbors are included implicitly via the shared facet neighbor's diagonal block;
+     3D vertex-only diagonals share no facet neighbor and provably no written entry —
+     correctly excluded.
+   - **A continuous field crosses interfaces** (combined case): items write CG dofs of
+     facet neighbors, and those are shared onward — the exact graph is the closure
+     product `(I ∪ A_f)·(I ∪ A_n)·(I ∪ A_f)`. This includes 3D vertex diagonals *and*
+     node-distance-3 chains (A—X—Y—D with X ∈ Nf(A), Y ∈ Nf(D), X/Y node-adjacent:
+     e.g. quads (0,0) and (3,0) in a row conflict through the shared edge dofs of
+     (1,0)/(2,0)). **Node-distance-2 is insufficient here.**
+   The grid-based API has no field information, so `interface_coupling = true` there
+   must always use the conservative product graph. The dof-based API inspects the
+   interpolations and the `interface_coupling` matrix (which fields cross interfaces)
+   and uses the sharp graph when all crossing fields are discontinuous — this is what
+   makes mirroring the sparsity kwargs load-bearing, not just convenient.
+2. **Constraint condensation** (`apply_assemble!`/`apply_local!`, e.g.
+   `PeriodicDirichlet` or `AffineConstraint`): verified in `_condense_local!`
+   (`src/Dofs/ConstraintHandler.jl:1835-1921`) — an item with dofs `S` writes global
+   entries only within `S ∪ M(S)`, where `M(S)` = masters of nontrivially-constrained
+   dofs in `S` (**plain Dirichlet causes no global writes**, hence no conflicts). Cells
+   conflict when their expanded sets intersect — possibly mesh-distant cells (opposite
+   periodic faces). Only master-mediated intersections are new edges; the node graph
+   already covers `S_A ∩ S_B` on conforming grids.
+
+Design principles (settled):
+
+- **CG and DG use node/vertex-level structures only** (node-sharing graph; facet
+  neighbors classified by shared-vertex counting — no `ExclusiveTopology`, no dof data).
+- **Only the constraint source needs dof↔cell mapping**, and only *affine* constraints.
+  Even there the map is restricted: per-cell lists only for the small dof set
+  {constrained dofs ∪ masters}, built in one pass over `celldofs` (an `ndofs`-sized Int
+  scratch array for O(1) lookup; no full dof→cells structure).
+- The coloring algorithms (greedy/workstream) stay untouched — they only consume the
+  incidence matrix; all new edges are unioned into it before partitioning/coloring.
+- Explicitly rejected: running the machinery "with dofs instead of nodes" as the index
+  space. It would be marginally sharper (subdomain fields; pure-L2 fields share
+  nothing), but costs `ndofs`-sized structures and still would not cover DG or
+  constraints by itself (interface conflicts involve *unshared* neighbor dofs, constraint
+  conflicts involve masters) — both expansions are needed regardless.
+
+**Correctness note (validated)**: workstream's odd/even zone merge requires edges to
+span at most one BFS zone — automatically true for *any* edge present in the matrix
+during BFS partitioning (a BFS edge never skips a level, even a periodic long-range
+one). Invariant to document in a comment: never add conflict edges after partitioning;
+matrix build and coloring must use identical options (single call site does this).
+
+## Changes
+
+### 1. `src/Grid/coloring.jl` — refactor (no behavior change)
+
+Extract the node→cells CSR build (current lines 54-73 of `create_incidence_matrix`) into
+`_build_node_to_cell_map(grid, cellvec) -> (nodeptr, nodecells)`. Keep
+`_gather_neighbor_chunk!` untouched so the default path stays byte-identical (CHANGELOG
+documents determinism independent of thread count).
+
+### 2. `src/Grid/coloring.jl` — facet adjacency `A_f`
+
+- `_facet_conflict_threshold(a, b) = min(getrefdim(a), getrefdim(b))` — facet iff
+  shared-vertex count ≥ threshold (rdim 1: vertex = 1, rdim 2: edge = 2, rdim 3:
+  tri/quad face ≥ 3). Conservative (over-inclusive) for mixed-rdim grids, which is safe
+  (only adds colors, never misses a conflict). Count via existing
+  `Ferrite._num_shared_vertices` (`src/Grid/topology.jl:175-184`) — corner **vertices**,
+  not node run-lengths (a `QuadraticTetrahedron` edge neighbor shares 3 *nodes* but only
+  2 vertices — run-length counting would misclassify it as a facet neighbor).
+- `_build_facet_adjacency(grid, cellvec, nodeptr, nodecells) -> (facetptr, facetadj)`:
+  same chunked gather/sort/dedup + count/prefix-sum/copyto pattern as the existing
+  incidence build (contiguous chunks → deterministic, thread-count independent). For
+  each unique node-sharing candidate, keep it iff `_num_shared_vertices ≥ threshold`.
+  Must be fully built (own `@sync`) before step 3, which reads other cells' lists.
+
+### 3. `src/Grid/coloring.jl` — union gather
+
+`_gather_conflict_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodecells, facetptr,
+facetadj, extras, mode)` — per cell, concatenate candidates from:
+(a) node sharing (as today);
+(b) DG **sharp mode** (`A_f²`): for each facet neighbor `j`, append `j`'s facet list
+    (`A_f ⊆ A_n` already);
+(b′) DG **product mode** (`(I ∪ A_f)(I ∪ A_n)(I ∪ A_f)`, combined CG+DG case): for each
+    `X ∈ {i} ∪ Nf(i)`, for each `Y ∈ {X} ∪ Nn(X)`, append `Y` and `Nf(Y)`. Requires the
+    node adjacency `A_n` materialized as CSR first — build it with the existing
+    incidence machinery, then run this second composition pass over `A_n` + `facetadj`
+    (both read-only, per-cell independent → same chunked/deterministic pattern);
+(c) `get(extras, cellid, nothing)` constraint edges.
+One sort/dedup as today, plus skipping `candidate == cellid` in the dedup loop (the
+closure lists contain self). Output keeps all invariants: sorted contiguous per-column
+buffers, symmetric matrix (each edge source is symmetric — the product graph because
+`A_f`, `A_n` are and the middle factor is sandwiched symmetrically), no diagonal,
+deterministic in thread count.
+
+Field-continuity detection for mode selection (dof-based method): a field crosses
+interfaces if `interface_coupling` is `true` or its matrix row/col has any `true`;
+a crossing field forces product mode unless its interpolation is discontinuous
+(no vertex/edge/face dofs — check for an existing predicate à la
+`is_discontinuous`/conformity traits on `DiscontinuousLagrange`; add a small helper
+otherwise).
+
+### 4. `src/Dofs/ConstraintHandler.jl` — constraint extras
+
+Include-order constraint: `coloring.jl` (`src/Ferrite.jl` L129) is included before
+`src/Dofs`, so `coloring.jl` holds an untyped `ch` kwarg and a stub
+`_incidence_constraint_extras(::Nothing, grid, cellvec, facetptr, facetadj) = nothing`;
+the `::ConstraintHandler` method lives at the bottom of `ConstraintHandler.jl`.
+
+That method:
+1. Require `isclosed(ch)` and `get_grid(ch.dh) === grid`, error otherwise.
+2. Collect nontrivial affine constraints (skip `dofcoefficients === nothing`/empty);
+   none → return `nothing` (Dirichlet-only `ch` reproduces the default coloring
+   exactly).
+3. `master_id = zeros(Int, ndofs(dh))` scratch, ids assigned in deterministic iteration
+   order.
+4. Build per-master cell lists in one pass over `sdh.cellset ∩ cellset` and `celldofs`:
+   cell contains master `m` directly, or contains a constrained dof with master `m`;
+   `sort!`/`unique!` each list.
+5. If DG mode is also active, expand each list with facet neighbors of its members
+   (interface items condense the neighbor's constrained dofs too — write closure).
+6. Emit `Dict{Int, Vector{Int}}` with all ordered pairs of each list (dedup happens in
+   the final gather).
+
+Cost: negligible (lists are a handful of boundary cells for periodic BCs).
+
+### 5a. Public API — option space (**decided**: Option 1 with grid sub-choice (c) —
+one-shot methods; grid method conservative-only, sharpness only via the dof method
+which detects it. Two-layer graph API shelved until custom conflict sources
+materialize. Analysis kept for the record.)
+
+**What each input can provide:**
+
+| input | provides | cannot provide |
+|---|---|---|
+| grid | `A_n`; `A_f` via shared-**vertex** counting (threshold = refdim: 1D vertex, 2D edge ≥2, 3D face ≥3 — ">1 node" suffices only in 2D, and counting *nodes* instead of vertices misclassifies quadratic cells); hence `A_f²` and the product graph | what assembly *writes* — field continuity is not in the mesh, so "sharp" is only available as a **user assertion** |
+| dh | interpolations → per-field discontinuity detection; with the `interface_coupling` matrix → *automatic* sharp/product mode selection | — |
+| ch | affine-constraint edges | — |
+| topology (optional) | exact facet adjacency via `create_cell_to_neighbors`, provably consistent with the sparsity pattern | — |
+
+**Option 1 — one-shot methods with kwargs** (current plan). Sub-choice for the grid
+method's DG knob:
+  - (a) tri-state kwarg, e.g. enum `InterfaceConflicts.None / .Discontinuous / .Continuous`
+    (with `false`/`true` as aliases for None/Continuous). One knob, self-documenting,
+    `.Discontinuous` = the sharp assertion. EnumX style matches `ColoringAlgorithm`.
+  - (b) two Bools: `interface_coupling::Bool` + `discontinuous::Bool = false` assertion.
+    Simple but kwarg-soup; the assertion silently means nothing without the first flag.
+  - (c) no sharp option on the grid method at all: grid = always conservative, sharp
+    requires the dof method (which detects it). Cleanest docs story ("pass your dh to
+    get a better coloring"), zero assertion footguns; pure-DG users always have a dh
+    in practice.
+
+**Option 2 — two-layer API**: make the conflict graph a public object:
+`g = create_conflict_graph(grid|dh, ch; kwargs...)` → `create_coloring(g; alg)`, with
+one-shot wrappers kept for the common cases. Pros: inspectable/visualizable, testable,
+composable, and users can add custom edges (the deal.II `get_conflict_indices` analog)
+for couplings we did not predict — the escape hatch the WorkStream API discussion
+wanted. Cons: new public type and vocabulary to maintain; two calls for the common case.
+
+**Option 3 — conflict callback** (deal.II style): `create_coloring(grid; conflicts =
+cell -> indices)`. Maximum flexibility but poor performance shape (closure per cell,
+no batch structure) and awkward ergonomics; not recommended as the primary API, and
+Option 2 subsumes its use case.
+
+Decision rationale: the assertion knob on the grid method buys little (pure-DG users
+have a dh) and invites "asserted sharp but actually mixed" bugs. Option 2's
+custom-conflict use case is instead covered by the `extra_conflicts` kwarg (section 5b),
+so the two-layer API stays shelved.
+
+### 5. Public API — grid-based and dof-based methods (current draft, Option 1)
+
+Two entry points (user decision): a minimal grid-based one, and a dof-based one that
+**mirrors the `add_sparsity_entries!`/`allocate_matrix` signature** so users can pass
+the exact same arguments they used to allocate the matrix. Headline UX: *color with the
+same `(dh, ch; kwargs...)` you allocated with, and the coloring is safe for the pattern
+you allocated*.
+
+```julia
+# Grid-based (src/Grid/coloring.jl). Unchanged default for CG. With
+# interface_coupling = true it has no field information and therefore always uses the
+# conservative product graph (safe for combined CG+DG; more colors than the dof-based
+# method gives for pure DG — document this as the reason to prefer the dof method):
+create_coloring(
+    g, cellset = 1:getncells(g);
+    alg = ColoringAlgorithm.WorkStream,
+    interface_coupling::Bool = false,
+    topology = nothing,   # optional: exact facet adjacency from it
+    extra_conflicts = nothing
+)  # see 5b
+
+# Dof-based, mirroring add_sparsity_entries!(sp, dh, ch; ...) minus `sp` (defined in
+# src/Dofs/ConstraintHandler.jl due to include order):
+create_coloring(
+    dh::DofHandler, ch::Union{ConstraintHandler, Nothing} = nothing;
+    cellset = 1:getncells(get_grid(dh)),
+    alg = ColoringAlgorithm.WorkStream,
+    keep_constrained::Bool = true,                                # no effect
+    coupling = nothing,                                           # no effect
+    interface_coupling::Union{Nothing, Bool, AbstractMatrix{Bool}} = nothing,
+    topology = nothing,
+    algebraic_couplings = (),                                     # must be ()
+    extra_conflicts = nothing
+)                                    # see 5b
+
+# Internal:
+create_incidence_matrix(
+    grid, cellset = 1:getncells(grid);
+    interface_coupling::Bool = false, topology = nothing,
+    ch = nothing
+)
+```
+
+Per-kwarg semantics of the dof-based method:
+
+- `ch`: conflict edges from affine-constraint condensation (step 4).
+- `coupling`: accepted and shape-validated (`_check_coupling_kwarg`) but **no effect**,
+  documented — any shared dof conflicts regardless of which field blocks are written
+  (even `coupling[λ, λ] = false` Lagrange setups conflict through `f` and mixed
+  blocks), so ignoring is conservative and correct.
+- `interface_coupling`: `nothing`/`false` → off; `true` or any-`true` matrix → DG
+  conflicts on. The matrix content is *not* just reduced via `any`: it determines which
+  fields cross interfaces and thereby the conflict-graph mode — sharp
+  (`A_n ∪ A_f ∪ A_f²`) when all crossing fields are discontinuous, product graph
+  otherwise (see Context). Superset of the sparsity signature, so the same arguments
+  splat through.
+- `topology`: when given, derive facet adjacency with the existing
+  `create_cell_to_neighbors(grid, topology)` (`src/Dofs/sparsity_pattern.jl:1040`) —
+  the *same helper* `add_interface_entries!` uses, so coloring conflicts are by
+  construction aligned with the pattern's interface entries. When `nothing`, use the
+  vertex-counting classification from step 2 (unlike the sparsity code, do *not*
+  auto-build an `ExclusiveTopology` — not needed).
+- `keep_constrained`: accepted, **no effect** — `_condense_local!` shows the
+  write-conflict structure is identical either way (it only changes which entries
+  exist); accepting it means the `keep_constrained = false` + `apply_assemble!`
+  workflow (exactly where `ch`-aware coloring matters) can splat its kwargs.
+- `algebraic_couplings`: accepted with default `()`, **error if nonempty** — an
+  `AlgebraicCoupling` to a global variable assembled inside the cell loop makes every
+  cell pair conflict (coloring degenerates to serial); refuse with a pointer to
+  atomic/pipeline assembly rather than silently under- or over-color. (A lone
+  `FacetCoupling` is in principle just the interface-conflict case — later refinement.)
+
+Shared notes:
+
+- The `dh` method forwards to the grid machinery on `get_grid(dh)`; mesh conflicts stay
+  node/vertex-based even in the dof-based method. `create_coloring(dh)` with no `ch` and
+  no interface coupling equals the grid method's coloring.
+- Fast path: no DG, no extras → the existing gather loop runs verbatim (default
+  benchmarks must not move).
+- No new exports (`create_coloring` already exported). Docstrings document the kwargs,
+  the closed-`ch`/`isclosed(dh)`/matching-grid requirements, that only *affine*
+  constraints add conflicts (plain Dirichlet is free), and that long-range edges may
+  reduce workstream zone quality (more colors), not correctness.
+- Extend the comment at `coloring.jl` L184: incidence matrix must be built with the same
+  cellset *and the same conflict options*.
+
+### 5b. Custom conflict entries — `extra_conflicts` kwarg (both methods)
+
+User-provided conflicts for couplings the built-ins don't model (element routines with
+cross-cell dependencies, algebraic couplings the user understands better than we can
+infer, etc.) — the escape hatch that motivated the (shelved) two-layer API, as a kwarg:
+
+```julia
+create_coloring(grid; extra_conflicts = Dict(1 => [17, 203]))         # adjacency form
+create_coloring(dh, ch; extra_conflicts = [[1, 17, 203], [4, 99]])    # cliques form
+```
+
+- Accepted forms: `AbstractDict{Int, <:AbstractVector{Int}}` (cell → conflicting
+  cells) or an iterable of cell groups, each treated as a clique (all pairs conflict —
+  the natural way to express "all cells coupled through this global variable").
+- Normalization in `create_incidence_matrix`: expand cliques to pairs, **symmetrize**
+  (an asymmetric `Dict` entry `a => [b]` still yields both directions — the incidence
+  matrix must stay symmetric), drop self-edges, **filter edges touching cells outside
+  the cellset** (consistent with how node conflicts are restricted; also lets one
+  conflict spec be reused across sub-colorings), validate ids ∈ `1:getncells` (error).
+- Merged into the same `extras::Dict{Int, Vector{Int}}` as the constraint edges before
+  the gather — dedup happens there, and the workstream partitioning automatically
+  respects the edges (they are in the matrix before BFS zoning, per the invariant).
+- Composes with everything: DG modes, `ch`, cellsets.
+
+### 6. Tests — `test/test_grid_dofhandler_vtk.jl` (extend `@testset "grid coloring"` ~L719)
+
+Independent references using *different* code paths: DG conflicts via
+`ExclusiveTopology`/`get_facet_facet_neighborhood` write-closures; constraint conflicts
+via dof-level sets `S ∪ M(S)` from `ch`. For both algorithms:
+
+1. DG safety on Line/Triangle/Quadrilateral/QuadraticTriangle/Tetrahedron/Hexahedron
+   grids + subset and unconnected-subset variants.
+2. Exactness (sharp mode, via a pure-DG dh): small QuadraticTetrahedron grid — the
+   incidence matrix equals brute-force `A_n ∪ A_f ∪ A_f²` (catches the node-run-length
+   trap); Hexahedron — 3D vertex-only-diagonal cells not added beyond `A_n`.
+2b. Combined-case necessity (product mode): mixed dh (`DiscontinuousLagrange` +
+   `Lagrange` fields, CG field crossing interfaces) on a quad strip — cells (0,0) and
+   (3,0) (three apart in a row) must get different colors; same via the grid API with
+   `interface_coupling = true`. Safety vs a dof-level write-closure reference
+   (`S(c) = dofs({c} ∪ Nf(c))`, conflict iff intersect). Also: pure-DG dh gives the
+   sharp graph while the grid API gives the product graph (sharp ⊆ product, and they
+   differ exactly on e.g. 3D vertex diagonals).
+3. Periodic (2D quad + small 3D hex): `create_coloring(dh, ch)` — necessity (cells of
+   constrained dof vs cells of master differ in color) and safety vs the dof-level
+   reference. Also `create_coloring(dh)` == grid-method coloring.
+4. Long-range `AffineConstraint` corner-to-corner: colors differ (stresses workstream
+   zoning across a component-merging edge).
+5. Combined DG + periodic: facet neighbor of a constrained cell vs master cells differ;
+   safety vs closure-expanded reference.
+6. Degenerate: Dirichlet-only `ch` == default coloring; wrong-grid `ch` throws; unclosed
+   `ch` throws; `Set` vs sorted-vector cellset equal; empty/single-cell sets with kwargs.
+7. Kwarg-mirror contract: `create_coloring(dh, ch; kwargs...)` with the *exact* kwargs
+   passed to `allocate_matrix` (incl. `coupling`, `keep_constrained`, matrix-valued
+   `interface_coupling`, `topology`) runs and is safe; `topology`-given vs
+   vertex-counting paths produce the same incidence matrix; nonempty
+   `algebraic_couplings` throws.
+8. `extra_conflicts`: two mesh-distant cells given as a conflict get different colors
+   (both algorithms — stresses workstream zoning like the long-range constraint case);
+   asymmetric `Dict` input (`a => [b]` only) still separates both directions; cliques
+   form ≡ equivalent pairwise `Dict`; edges to cells outside the cellset are ignored;
+   out-of-range cell ids throw; composes with `interface_coupling` and `ch`.
+
+### 7. Benchmarks — `benchmark/benchmarks-mesh.jl` (~L66-81)
+
+Add to the coloring let-block: workstream DG (Hexahedron 15³), greedy DG (Tetrahedron
+8³), workstream periodic (Quadrilateral 50×50 with a `PeriodicDirichlet` ch). Existing
+default-path cases must not regress (fast path).
+
+### 8. Docs + CHANGELOG
+
+- `docs/src/literate-howto/threaded_assembly.jl` (~L58-60): note the default conflict
+  definition is only valid for continuous fields assembled cell-locally; point to
+  `interface_coupling` and the `(dh, ch)` method.
+- CHANGELOG.md `### Added` entry; default behavior and determinism guarantee unchanged.
+- `reference/grid.md` needs nothing (docstring flows through existing `@docs`).
+
+## Verification
+
+1. Full test suite, or at minimum the coloring testsets:
+   `test/test_grid_dofhandler_vtk.jl`, `test/test_abstractgrid.jl`.
+2. New tests above (safety against independent references is the load-bearing check).
+3. Benchmark sanity: run the coloring cases before/after — default path unchanged,
+   DG/periodic cases with sane cost.
+4. End-to-end smoke test (ad-hoc script, not committed): thread the DG heat equation
+   tutorial's cell+interface loops over `create_coloring(grid; interface_coupling =
+   true)` colors (interfaces owned by the lower cell id, processed within the owner's
+   item) and check the assembled `K` matches the serial result exactly; same for a CG
+   problem with `PeriodicDirichlet` + `apply_assemble!` and `create_coloring(dh, ch)`.
+
+## Open points for iteration
+
+- ~~Naming/shape of `interface_coupling`~~ → settled: dof-based method mirrors the
+  `add_sparsity_entries!` kwargs verbatim (accepting `Bool` as a convenience superset);
+  irrelevant kwargs are accepted-and-documented as no-ops since ignoring them is
+  provably conservative.
+- `algebraic_couplings`: currently refused when nonempty. Possible refinement: accept
+  descriptors we can reason about (`FacetCoupling` ⇒ interface conflicts;
+  `CellCoupling` ⇒ nothing beyond the node graph?) and only error on
+  `AlgebraicCoupling`. Needs reading the descriptor types first.
+- Whether the `dh` method should restrict conflicts to cells covered by the
+  `SubDofHandler`s (cells outside any sdh have no dofs — currently they'd still get
+  node-based edges from the grid machinery, which is conservative but never wrong).
+- Whether `_build_facet_adjacency` should be skipped in favor of classifying during the
+  union gather itself (one pass fewer, but `A_f²` needs completed neighbor lists —
+  probably keep two passes).
+- Combined DG + constraints write-closure expansion (step 4.5): included for
+  correctness; confirm it's not over-engineering for the intended use cases.

--- a/benchmark/benchmarks-mesh.jl
+++ b/benchmark/benchmarks-mesh.jl
@@ -78,4 +78,23 @@ let g = SUITE["mesh"]["coloring"]
     tetgrid = generate_grid(Tetrahedron, (8, 8, 8))
     g["workstream (Tetrahedron 8×8×8)"] = @benchmarkable create_coloring($tetgrid; alg = ColoringAlgorithm.WorkStream) evals = 1
     g["greedy (Tetrahedron 8×8×8)"] = @benchmarkable create_coloring($tetgrid; alg = ColoringAlgorithm.Greedy) evals = 1
+    # Interface (DG) conflicts: purely discontinuous discretization (facet mode) via the
+    # DofHandler, and the conservative graph via the grid-only method
+    hexdh = DofHandler(hexgrid)
+    add!(hexdh, :u, DiscontinuousLagrange{RefHexahedron, 1}())
+    close!(hexdh)
+    g["workstream DG (Hexahedron 15×15×15)"] = @benchmarkable create_coloring($hexdh; interface_coupling = true, alg = ColoringAlgorithm.WorkStream) evals = 1
+    g["workstream DG conservative (Hexahedron 15×15×15)"] = @benchmarkable create_coloring($hexgrid; interface_coupling = true, alg = ColoringAlgorithm.WorkStream) evals = 1
+    tetdh = DofHandler(tetgrid)
+    add!(tetdh, :u, DiscontinuousLagrange{RefTetrahedron, 1}())
+    close!(tetdh)
+    g["greedy DG (Tetrahedron 8×8×8)"] = @benchmarkable create_coloring($tetdh; interface_coupling = true, alg = ColoringAlgorithm.Greedy) evals = 1
+    # Constraint (periodic) conflicts
+    quaddh = DofHandler(quadgrid)
+    add!(quaddh, :u, Lagrange{RefQuadrilateral, 1}())
+    close!(quaddh)
+    quadch = ConstraintHandler(quaddh)
+    add!(quadch, PeriodicDirichlet(:u, collect_periodic_facets(quadgrid, "left", "right")))
+    close!(quadch)
+    g["workstream periodic (Quadrilateral 50×50)"] = @benchmarkable create_coloring($quaddh, $quadch; alg = ColoringAlgorithm.WorkStream) evals = 1
 end

--- a/docs/src/literate-howto/threaded_assembly.jl
+++ b/docs/src/literate-howto/threaded_assembly.jl
@@ -65,6 +65,29 @@
 # roughly the same number of elements. The workstream algorithm is the default one since it
 # in general results in more balanced colors. For unstructured grids the greedy algorithm
 # can result in colors with very few elements, for example.
+#
+# !!! note "Interface (DG) assembly and constraints"
+#     The default coloring ensures that cells with the same color share no *nodes*, which
+#     makes concurrent assembly safe only for cell-local assembly of continuous fields.
+#     If the assembly loop also writes to other dofs the conflicts must be declared when
+#     creating the coloring:
+#      - for interface terms (e.g. DG assembly with `InterfaceValues`, which writes to
+#        dofs of the neighboring cell) pass `interface_coupling` to [`create_coloring`](@ref),
+#        preferably via the `DofHandler` method (`create_coloring(dh; interface_coupling)`)
+#        which uses the interpolations to compute the smallest safe set of colors;
+#      - when constraints are condensed during assembly ([`apply_assemble!`](@ref)/
+#        [`apply_local!`](@ref)) with affine constraints such as [`PeriodicDirichlet`](@ref),
+#        cells on opposite sides of the domain write to the same master dofs and conflict
+#        even though they share no nodes: pass the constraint handler via
+#        `create_coloring(dh, ch)`;
+#      - conflicts that Ferrite cannot infer can be declared with the `extra_conflicts`
+#        keyword argument.
+#     See the [`create_coloring`](@ref) documentation for details. Note that the
+#     [atomic assembly](@ref howto-threaded-assembly-atomic) approach below does not need
+#     any of this analysis for the *assembly* writes, since atomic additions are safe
+#     regardless of which cells are processed concurrently (constraint condensation with
+#     `apply_assemble!` is however not atomic, so for that the coloring approach is
+#     required).
 
 using Ferrite, SparseArrays
 

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -2096,3 +2096,188 @@ function integrate_projected_dbc!(::Union{H1Conformity, L2Conformity}, _, _, _, 
     ip_str = sprint(show, function_interpolation(fv))
     throw(ArgumentError("ProjectedDirichlet is not implemented for H¹ and L2 conformities ($ip_str)"))
 end
+
+###########################################
+# Constraint aware grid coloring support  #
+###########################################
+
+# All basis functions of the interpolation are interior to the cell, i.e. no dofs are
+# shared with neighboring cells. Note that this is what matters for assembly conflicts,
+# not the conformity: e.g. `CrouzeixRaviart` is L2-conforming but places (shared) dofs
+# on the facets.
+_all_dofs_volume_interior(ip::VectorizedInterpolation) = _all_dofs_volume_interior(ip.ip)
+function _all_dofs_volume_interior(ip::Interpolation)
+    return length(volumedof_interior_indices(ip)) == getnbasefunctions(ip)
+end
+
+# Determine the interface conflict mode for `create_incidence_matrix` from the
+# discretization (see the gather functions in src/Grid/coloring.jl):
+#  - a continuous field couples across interfaces: interface terms write to shared dofs
+#    of the facet neighbors, requiring the conservative product graph (:product);
+#  - only discontinuous fields cross, but continuous fields exist: their cell assembly
+#    still conflicts all node neighbors (:sharp = node graph ∪ A_f²);
+#  - purely discontinuous discretization: no dofs are shared between cells at all and
+#    only the interface writes conflict (:facet = A_f ∪ A_f², fewest colors).
+function _interface_conflict_mode(dh::DofHandler, interface_coupling::Union{Nothing, Bool, AbstractMatrix{Bool}})
+    if interface_coupling === nothing || interface_coupling === false
+        return :none
+    elseif interface_coupling isa AbstractMatrix{Bool} && !any(interface_coupling)
+        return :none
+    end
+    fieldnames = getfieldnames(dh)
+    nfields = length(fieldnames)
+    # Which fields couple across interfaces? For a Bool (or a coupling matrix that
+    # cannot be interpreted per-field) all fields are assumed to cross.
+    crossing = if interface_coupling isa AbstractMatrix{Bool} && size(interface_coupling) == (nfields, nfields)
+        Bool[any(view(interface_coupling, i, :)) || any(view(interface_coupling, :, i)) for i in 1:nfields]
+    else
+        fill(true, nfields)
+    end
+    all_discontinuous = true
+    for sdh in dh.subdofhandlers
+        for (name, ip) in zip(sdh.field_names, sdh.field_interpolations)
+            if !_all_dofs_volume_interior(ip)
+                all_discontinuous = false
+                fi = findfirst(==(name), fieldnames)
+                @assert fi !== nothing
+                if crossing[fi]
+                    return :product
+                end
+            end
+        end
+    end
+    return all_discontinuous ? :facet : :sharp
+end
+
+# Conflict edges from constraint condensation during assembly (`apply_assemble!` /
+# `apply_local!`): condensing the local matrix of an assembly item with (global) dofs S
+# writes global entries only within S ∪ M(S), where M(S) are the master dofs of the
+# affinely constrained dofs in S (see `_condense_local!`; plain Dirichlet constraints
+# cause no global writes). The node based conflict graph already covers S_A ∩ S_B, so
+# the new conflicts are exactly the cell pairs whose writes meet in a master dof: for
+# each master m, all pairs among the cells containing m or a dof constrained to m --
+# expanded with facet neighbors when interface (DG) assembly is active, since interface
+# items also condense the dofs of the facet neighbor.
+function _incidence_constraint_extras(ch::ConstraintHandler, grid::AbstractGrid, cellvec, facetptr, facetadj)
+    isclosed(ch) || error("the ConstraintHandler must be closed")
+    dh = ch.dh
+    if get_grid(dh) !== grid
+        error("the ConstraintHandler belongs to a DofHandler on a different grid")
+    end
+    # Index the master dofs and map affinely constrained dofs to their masters. Note
+    # that `close!(ch)` has already resolved recursive constraints, so the coefficient
+    # lists are final.
+    n = ndofs(dh)
+    master_of = zeros(Int, n) # dof -> master index, or 0
+    affine_of = zeros(Int, n) # dof -> index into affine_masters, or 0
+    nmasters = 0
+    affine_masters = Vector{Int}[]
+    for (i, d) in pairs(ch.prescribed_dofs)
+        coefficients = ch.dofcoefficients[i]
+        (coefficients === nothing || isempty(coefficients)) && continue
+        master_ids = Int[]
+        for (m, _) in coefficients
+            if master_of[m] == 0
+                nmasters += 1
+                master_of[m] = nmasters
+            end
+            push!(master_ids, master_of[m])
+        end
+        push!(affine_masters, master_ids)
+        affine_of[d] = length(affine_masters)
+    end
+    nmasters == 0 && return nothing
+    # For each master, collect the cells (in the cellset) whose condensation writes to
+    # it: cells containing the master dof itself, and cells containing a dof constrained
+    # to it.
+    master_cells = [Int[] for _ in 1:nmasters]
+    dofbuf = Int[]
+    for sdh in dh.subdofhandlers
+        resize!(dofbuf, ndofs_per_cell(sdh))
+        for cellid in sdh.cellset
+            insorted(cellid, cellvec) || continue
+            celldofs!(dofbuf, dh, cellid)
+            for dof in dofbuf
+                mi = master_of[dof]
+                if mi != 0
+                    push!(master_cells[mi], cellid)
+                end
+                ai = affine_of[dof]
+                if ai != 0
+                    for m in affine_masters[ai]
+                        push!(master_cells[m], cellid)
+                    end
+                end
+            end
+        end
+    end
+    # With interface (DG) conflicts active the write set of an item is the facet closure
+    # of the cell (the item also condenses the facet neighbors' constrained dofs), so
+    # expand the lists with the facet neighbors of their members.
+    if facetptr !== nothing
+        for cells in master_cells
+            norig = length(cells)
+            for k in 1:norig
+                c = cells[k]
+                for r in facetptr[c]:(facetptr[c + 1] - 1)
+                    push!(cells, facetadj[r])
+                end
+            end
+        end
+    end
+    # All pairs within each list conflict. Duplicate edges (e.g. from multiple masters)
+    # are deduplicated in the incidence matrix gather.
+    extras = Dict{Int, Vector{Int}}()
+    for cells in master_cells
+        sort!(cells)
+        unique!(cells)
+        length(cells) < 2 && continue
+        for a in cells, b in cells
+            a == b && continue
+            push!(get!(() -> Int[], extras, a), b)
+        end
+    end
+    return isempty(extras) ? nothing : extras
+end
+
+# DofHandler/ConstraintHandler based method of `create_coloring`, mirroring the
+# signature of `add_sparsity_entries!` so that the same arguments used for matrix
+# allocation can be forwarded as-is. See the docstring in src/Grid/coloring.jl.
+function create_coloring(
+        dh::DofHandler, ch::Union{ConstraintHandler, Nothing} = nothing;
+        cellset = 1:getncells(get_grid(dh)),
+        alg::ColoringAlgorithm.T = ColoringAlgorithm.WorkStream,
+        keep_constrained::Bool = true, # accepted for symmetry; no effect on conflicts
+        coupling = nothing,            # accepted for symmetry; no effect on conflicts
+        interface_coupling::Union{Nothing, Bool, AbstractMatrix{Bool}} = nothing,
+        topology = nothing,
+        algebraic_couplings = (),
+        extra_conflicts = nothing,
+    )
+    isclosed(dh) || error("the DofHandler must be closed")
+    if ch !== nothing
+        isclosed(ch) || error("the ConstraintHandler must be closed")
+        ch.dh === dh || error("the ConstraintHandler belongs to a different DofHandler")
+    end
+    # `coupling` cannot reduce the conflict graph (two cells sharing any dof conflict
+    # regardless of which field blocks are written) so it is validated but otherwise
+    # ignored, like `keep_constrained` (which only changes which entries exist in the
+    # sparsity pattern, not which entries assembly writes to).
+    _check_coupling_kwarg(coupling)
+    if !isempty(algebraic_couplings)
+        throw(
+            ArgumentError(
+                "conflict analysis for `algebraic_couplings` is not implemented: a coupling " *
+                    "to e.g. a global variable makes all coupled cells conflict with each other. " *
+                    "Assemble these entries outside of the colored loop (or use atomic assembly), " *
+                    "or provide the conflicts explicitly with the `extra_conflicts` keyword argument."
+            )
+        )
+    end
+    incidence_matrix = create_incidence_matrix(
+        get_grid(dh), cellset;
+        interface_mode = _interface_conflict_mode(dh, interface_coupling),
+        topology, ch, extra_conflicts,
+    )
+    return _color_incidence_matrix(incidence_matrix, cellset, alg)
+end

--- a/src/Grid/coloring.jl
+++ b/src/Grid/coloring.jl
@@ -8,7 +8,38 @@ end
 _sorted_cellvec(cellset::AbstractUnitRange{Int}) = cellset
 _sorted_cellvec(cellset) = unique!(sort!(collect(Int, cellset)))
 
-function _gather_neighbor_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodecells)
+# Append the extra conflict cells (constraint condensation and/or user provided) for
+# `cellid` to the candidate list. The lists are constructed such that they never contain
+# `cellid` itself and only cells in the cellset.
+_append_extra_conflicts!(candidates, ::Nothing, cellid) = candidates
+function _append_extra_conflicts!(candidates, extras::Dict{Int, Vector{Int}}, cellid)
+    l = get(extras, cellid, nothing)
+    l === nothing || append!(candidates, l)
+    return candidates
+end
+
+# Sort the gathered candidates and append them, deduplicated, to `buf`, counting into
+# `colcount[cellid]`. The candidate list must not contain `cellid` itself.
+function _append_candidates_sorted_unique!(buf, colcount, candidates, cellid)
+    # QuickSort sorts in-place without allocations. The default algorithm dispatches
+    # to counting/radix sort which allocates a workspace on each call so we use QuickSort
+    # which performs better here.
+    sort!(candidates; alg = QuickSort)
+    # A candidate may occur multiple times (e.g. a neighbor sharing k nodes with the cell
+    # occurs k times). After sorting, duplicates are adjacent and can be skipped by
+    # comparing with the previous entry (a unique! fused with the counting).
+    prev = 0
+    for cell_neighbour in candidates
+        if cell_neighbour != prev
+            push!(buf, cell_neighbour)
+            colcount[cellid] += 1
+            prev = cell_neighbour
+        end
+    end
+    return buf
+end
+
+function _gather_neighbor_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodecells, extras = nothing)
     buf = Int[]
     candidates = Int[]
     # Loop over cells in the chunk
@@ -23,35 +54,14 @@ function _gather_neighbor_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodece
                 cell_neighbour == cellid || push!(candidates, cell_neighbour)
             end
         end
-        # QuickSort sorts in-place without allocations. The default algorithm dispatches
-        # to counting/radix sort which allocates a workspace on each call so we use QuickSort
-        # which performs better here.
-        sort!(candidates; alg = QuickSort)
-        # Each per-node cell list in nodecells is duplicate-free, but candidates
-        # concatenates the lists of all nodes of this cell, so a neighbor sharing k nodes
-        # with the cell occurs k times. After sorting, duplicates are adjacent and can be
-        # skipped by comparing with the previous entry (a unique! fused with the counting).
-        prev = 0
-        for cell_neighbour in candidates
-            if cell_neighbour != prev
-                push!(buf, cell_neighbour)
-                colcount[cellid] += 1
-                prev = cell_neighbour
-            end
-        end
+        _append_extra_conflicts!(candidates, extras, cellid)
+        _append_candidates_sorted_unique!(buf, colcount, candidates, cellid)
     end
     return buf
 end
 
-# Incidence matrix for element connections in the grid
-function create_incidence_matrix(grid::AbstractGrid, cellset = 1:getncells(grid))
-    ncells = getncells(grid)
-    cellvec = _sorted_cellvec(cellset)
-    if isempty(cellvec)
-        return SparseArrays.spzeros(Bool, Int, ncells, ncells)
-    end
-
-    # Map from node id to the cells in the cellset containing it, in CSR-like form.
+# Map from node id to the cells in `cellvec` containing it, in CSR-like form.
+function _build_node_to_cell_map(grid::AbstractGrid, cellvec)
     nnodes = getnnodes(grid)
     nodeptr = zeros(Int, nnodes + 1)
     nodeptr[1] = 1
@@ -71,32 +81,326 @@ function create_incidence_matrix(grid::AbstractGrid, cellset = 1:getncells(grid)
             cursor[v] += 1
         end
     end
+    return nodeptr, nodecells
+end
 
-    # For each cell, gather the unique cells sharing at least one node with it.
-    # Since `cellvec` is sorted, each chunk corresponds to a contiguous range of
-    # columns in the CSC structure, so the chunk buffers can be computed in
-    # parallel and afterwards concatenated to form rowval.
+# Run `gather!(counts, chunk) -> buf` over contiguous chunks of `cellvec` in parallel and
+# assemble the per-chunk buffers into a CSR-like (ptr, adj) structure over all cells.
+# Since `cellvec` is sorted and the chunks are contiguous, each chunk's buffer is a
+# contiguous range of the output, which makes the result independent of the number of
+# threads.
+function _chunked_gather!(gather!::F, ncells::Int, cellvec) where {F}
     chunks = collect(_color_chunks(length(cellvec), Threads.nthreads()))
-    colcount = zeros(Int, ncells)
+    counts = zeros(Int, ncells)
     buffers = Vector{Vector{Int}}(undef, length(chunks))
     @sync for (ci, chunk) in enumerate(chunks)
         Threads.@spawn begin
-            buffers[$ci] = _gather_neighbor_chunk!(colcount, grid, cellvec, $chunk, nodeptr, nodecells)
+            buffers[$ci] = gather!(counts, $chunk)
         end
     end
-
-    colptr = Vector{Int}(undef, ncells + 1)
-    colptr[1] = 1
+    ptr = Vector{Int}(undef, ncells + 1)
+    ptr[1] = 1
     for c in 1:ncells
-        colptr[c + 1] = colptr[c] + colcount[c]
+        ptr[c + 1] = ptr[c] + counts[c]
     end
-    rowval = Vector{Int}(undef, colptr[end] - 1)
-    @assert length(rowval) == sum(length, buffers; init = 0)
+    adj = Vector{Int}(undef, ptr[end] - 1)
+    @assert length(adj) == sum(length, buffers; init = 0)
     # This loop is trivially parallelizable but it is just a memcpy so there is no
     # measurable speedup from doing so.
     for (ci, chunk) in enumerate(chunks)
         buf = buffers[ci]
-        copyto!(rowval, colptr[cellvec[first(chunk)]], buf, 1, length(buf))
+        copyto!(adj, ptr[cellvec[first(chunk)]], buf, 1, length(buf))
+    end
+    return ptr, adj
+end
+
+# Two cells sharing at least this many vertices share a facet: 1 vertex in 1D, an edge
+# (2 vertices) in 2D, a triangular or quadrilateral face (>= 3 vertices) in 3D. On
+# conforming grids this matches the facet classification in `ExclusiveTopology`. The
+# `min` makes the relation symmetric and conservative (over-inclusive, which only adds
+# conflict edges and is thus safe) for grids with mixed reference dimensions.
+_facet_conflict_threshold(a::AbstractCell, b::AbstractCell) = min(getrefdim(a), getrefdim(b))
+
+# Like `_gather_neighbor_chunk!` but only keeping the facet neighbors: node-sharing
+# candidates that share at least `_facet_conflict_threshold` *vertices* with the cell.
+# Counting corner vertices (`_num_shared_vertices`) rather than nodes matters for
+# higher-order cells: e.g. a `QuadraticTetrahedron` edge neighbor shares 3 nodes (2
+# vertices + midside node) but only 2 vertices, and must not classify as a facet
+# neighbor.
+function _gather_facet_neighbor_chunk!(facetcount, grid, cellvec, chunk, nodeptr, nodecells)
+    buf = Int[]
+    candidates = Int[]
+    for i in chunk
+        cellid = cellvec[i]
+        cell = getcells(grid, cellid)
+        empty!(candidates)
+        for v in get_node_ids(cell)
+            for r in nodeptr[v]:(nodeptr[v + 1] - 1)
+                cell_neighbour = nodecells[r]
+                cell_neighbour == cellid || push!(candidates, cell_neighbour)
+            end
+        end
+        sort!(candidates; alg = QuickSort)
+        prev = 0
+        for cell_neighbour in candidates
+            cell_neighbour == prev && continue
+            prev = cell_neighbour
+            other = getcells(grid, cell_neighbour)
+            if _num_shared_vertices(cell, other) >= _facet_conflict_threshold(cell, other)
+                push!(buf, cell_neighbour)
+                facetcount[cellid] += 1
+            end
+        end
+    end
+    return buf
+end
+
+# Facet adjacency A_f restricted to the cellset, in CSR-like form (ptr indexed by cell
+# id over all cells; only cellset cells have entries).
+function _build_facet_adjacency(grid::AbstractGrid, cellvec, nodeptr, nodecells)
+    return _chunked_gather!(getncells(grid), cellvec) do counts, chunk
+        _gather_facet_neighbor_chunk!(counts, grid, cellvec, chunk, nodeptr, nodecells)
+    end
+end
+
+# Facet adjacency from an existing topology, using the same helper as the sparsity
+# pattern's interface entries (`add_interface_entries!`) so that the conflict graph is
+# consistent with the pattern by construction.
+function _facet_adjacency_from_topology(grid::AbstractGrid, cellvec, topology)
+    ncells = getncells(grid)
+    neighbor_cells = create_cell_to_neighbors(grid, topology)
+    ptr = Vector{Int}(undef, ncells + 1)
+    ptr[1] = 1
+    for cellid in 1:ncells
+        cnt = 0
+        if insorted(cellid, cellvec)
+            for n in neighbor_cells[cellid]
+                cnt += insorted(n, cellvec)
+            end
+        end
+        ptr[cellid + 1] = ptr[cellid] + cnt
+    end
+    adj = Vector{Int}(undef, ptr[end] - 1)
+    for cellid in cellvec
+        k = ptr[cellid]
+        for n in neighbor_cells[cellid]
+            insorted(n, cellvec) || continue
+            adj[k] = n
+            k += 1
+        end
+        sort!(view(adj, ptr[cellid]:(ptr[cellid + 1] - 1)))
+    end
+    return ptr, adj
+end
+
+# Conflict gather for interface (DG) assembly where only discontinuous (L2) fields cross
+# the interfaces: an assembly item writes dofs of the cell and its facet neighbors, and
+# with cell-interior dofs two items' interface writes conflict iff their facet closures
+# intersect: A_f ∪ A_f² ("cells sharing a facet neighbor" -- both items write the shared
+# neighbor's dofs). Note that e.g. 2D corner neighbors conflict through their two shared
+# facet neighbors, while 3D vertex-only diagonal neighbors share no facet neighbor and
+# their interface writes do not conflict.
+# `include_node_conflicts` unions in the node-sharing graph, which is required whenever
+# the DofHandler carries any continuous field (its *cell* assembly writes shared dofs of
+# all node neighbors, including 3D vertex diagonals). For a purely discontinuous
+# discretization no dofs are shared between cells and the node graph is dropped
+# ("facet" mode, fewest colors).
+function _gather_interface_chunk!(colcount, grid, cellvec, chunk, nodeptr, nodecells, facetptr, facetadj, extras, include_node_conflicts::Bool)
+    buf = Int[]
+    candidates = Int[]
+    for i in chunk
+        cellid = cellvec[i]
+        empty!(candidates)
+        if include_node_conflicts
+            # Node neighbors (this includes the facet neighbors A_f)
+            for v in get_node_ids(getcells(grid, cellid))
+                for r in nodeptr[v]:(nodeptr[v + 1] - 1)
+                    cell_neighbour = nodecells[r]
+                    cell_neighbour == cellid || push!(candidates, cell_neighbour)
+                end
+            end
+        else
+            # A_f: the facet neighbors themselves
+            for r in facetptr[cellid]:(facetptr[cellid + 1] - 1)
+                push!(candidates, facetadj[r])
+            end
+        end
+        # A_f²: facet neighbors of facet neighbors
+        for r in facetptr[cellid]:(facetptr[cellid + 1] - 1)
+            j = facetadj[r]
+            for r2 in facetptr[j]:(facetptr[j + 1] - 1)
+                k = facetadj[r2]
+                k == cellid || push!(candidates, k)
+            end
+        end
+        _append_extra_conflicts!(candidates, extras, cellid)
+        _append_candidates_sorted_unique!(buf, colcount, candidates, cellid)
+    end
+    return buf
+end
+
+# Conflict gather for interface (DG) assembly where a continuous field crosses the
+# interfaces ("product" mode): an item writes dofs of its facet closure {i} ∪ Nf(i),
+# and continuous dofs are shared between node neighbors, so two items conflict iff
+# their facet closures contain node-adjacent (or equal) cells. This is the closure
+# product (I ∪ A_f)·(I ∪ A_n)·(I ∪ A_f), which strictly contains node-distance-2 (e.g.
+# 3D vertex diagonals) *and* some node-distance-3 pairs (two cells three apart in a row
+# conflict through the shared dofs of the two cells between them).
+function _gather_product_chunk!(colcount, cellvec, chunk, an_ptr, an_adj, facetptr, facetadj, extras)
+    buf = Int[]
+    candidates = Int[]
+    closure = Int[]
+    for ii in chunk
+        cellid = cellvec[ii]
+        empty!(candidates)
+        # X ∈ {i} ∪ Nf(i)
+        empty!(closure)
+        push!(closure, cellid)
+        for r in facetptr[cellid]:(facetptr[cellid + 1] - 1)
+            push!(closure, facetadj[r])
+        end
+        for X in closure
+            # Y = X: append {X} ∪ Nf(X)
+            X == cellid || push!(candidates, X)
+            for r in facetptr[X]:(facetptr[X + 1] - 1)
+                k = facetadj[r]
+                k == cellid || push!(candidates, k)
+            end
+            # Y ∈ Nn(X): append {Y} ∪ Nf(Y)
+            for r in an_ptr[X]:(an_ptr[X + 1] - 1)
+                Y = an_adj[r]
+                Y == cellid || push!(candidates, Y)
+                for r2 in facetptr[Y]:(facetptr[Y + 1] - 1)
+                    k = facetadj[r2]
+                    k == cellid || push!(candidates, k)
+                end
+            end
+        end
+        _append_extra_conflicts!(candidates, extras, cellid)
+        _append_candidates_sorted_unique!(buf, colcount, candidates, cellid)
+    end
+    return buf
+end
+
+# Normalize user-provided extra conflicts into the internal Dict form: symmetrized,
+# self-edge free, restricted to the cellset (so that one conflict specification can be
+# reused for different sub-colorings). Accepts a Dict (cell => conflicting cells) or an
+# iterable of cell groups where all cells in a group mutually conflict ("cliques").
+_normalize_extra_conflicts(::Nothing, ncells::Int, cellvec) = nothing
+function _normalize_extra_conflicts(spec, ncells::Int, cellvec)
+    extras = Dict{Int, Vector{Int}}()
+    add_edge! = function (a::Int, b::Int)
+        if !(1 <= a <= ncells && 1 <= b <= ncells)
+            throw(ArgumentError("cell id out of range in extra_conflicts: got cells ($a, $b) for a grid with $ncells cells"))
+        end
+        a == b && return
+        # Conflicts with cells outside the colored set are irrelevant for the coloring
+        (insorted(a, cellvec) && insorted(b, cellvec)) || return
+        push!(get!(() -> Int[], extras, a), b)
+        push!(get!(() -> Int[], extras, b), a)
+        return
+    end
+    if spec isa AbstractDict
+        for (a, bs) in spec, b in bs
+            add_edge!(Int(a), Int(b))
+        end
+    else
+        for group in spec
+            cells = collect(Int, group)
+            for i in eachindex(cells)
+                for j in (i + 1):lastindex(cells)
+                    add_edge!(cells[i], cells[j])
+                end
+            end
+        end
+    end
+    return isempty(extras) ? nothing : extras
+end
+
+function _merge_extras(a::Union{Nothing, Dict{Int, Vector{Int}}}, b::Union{Nothing, Dict{Int, Vector{Int}}})
+    a === nothing && return b
+    b === nothing && return a
+    for (k, v) in b
+        append!(get!(() -> Int[], a, k), v)
+    end
+    return a
+end
+
+# Conflict edges from constraint condensation during assembly. The method for
+# `ch::ConstraintHandler` is defined in src/Dofs/ConstraintHandler.jl (this file is
+# included before the DofHandler/ConstraintHandler definitions).
+_incidence_constraint_extras(::Nothing, grid, cellvec, facetptr, facetadj) = nothing
+
+# Incidence matrix for element connections in the grid: cells i and j are connected if
+# assembly items for i and j may write to the same global matrix/vector entries.
+#  - `interface_mode = :none`: conflict iff sharing a node (cell-local assembly of
+#    continuous fields).
+#  - `interface_mode = :facet`: interface (DG) assembly for a purely discontinuous
+#    discretization: A_f ∪ A_f² (see `_gather_interface_chunk!`).
+#  - `interface_mode = :sharp`: interface (DG) assembly where only discontinuous fields
+#    cross interfaces but continuous fields exist: node graph ∪ A_f².
+#  - `interface_mode = :product`: interface assembly where a continuous field crosses
+#    interfaces, or field information is unavailable (see `_gather_product_chunk!`).
+#  - `topology`: optional `ExclusiveTopology` used for exact facet adjacency (otherwise
+#    facet neighbors are classified by shared-vertex counting).
+#  - `ch`: optional `ConstraintHandler`; affine constraints (e.g. `PeriodicDirichlet`)
+#    add conflicts between cells writing to the same master dofs during condensation.
+#  - `extra_conflicts`: optional user-provided conflicts (see `create_coloring`).
+# Note: the conflict graph is restricted to the cellset -- interfaces to cells outside
+# the cellset are not considered part of the assembly loop.
+function create_incidence_matrix(
+        grid::AbstractGrid, cellset = 1:getncells(grid);
+        interface_mode::Symbol = :none,
+        topology = nothing,
+        ch = nothing,
+        extra_conflicts = nothing,
+    )
+    if interface_mode !== :none && interface_mode !== :facet && interface_mode !== :sharp && interface_mode !== :product
+        throw(ArgumentError("invalid interface_mode: $(repr(interface_mode))"))
+    end
+    ncells = getncells(grid)
+    cellvec = _sorted_cellvec(cellset)
+    if isempty(cellvec)
+        return SparseArrays.spzeros(Bool, Int, ncells, ncells)
+    end
+
+    nodeptr, nodecells = _build_node_to_cell_map(grid, cellvec)
+
+    # Facet adjacency (within the cellset) for interface (DG) conflicts
+    if interface_mode === :none
+        facetptr = facetadj = nothing
+    elseif topology === nothing
+        facetptr, facetadj = _build_facet_adjacency(grid, cellvec, nodeptr, nodecells)
+    else
+        facetptr, facetadj = _facet_adjacency_from_topology(grid, cellvec, topology)
+    end
+
+    # Extra conflict edges from constraint condensation and/or user input
+    extras = _merge_extras(
+        _incidence_constraint_extras(ch, grid, cellvec, facetptr, facetadj),
+        _normalize_extra_conflicts(extra_conflicts, ncells, cellvec),
+    )
+
+    # For each cell, gather the unique conflicting cells. The chunked gather makes the
+    # result independent of the number of threads (see `_chunked_gather!`).
+    local colptr, rowval
+    if interface_mode === :none
+        colptr, rowval = _chunked_gather!(ncells, cellvec) do counts, chunk
+            _gather_neighbor_chunk!(counts, grid, cellvec, chunk, nodeptr, nodecells, extras)
+        end
+    elseif interface_mode === :facet || interface_mode === :sharp
+        include_node_conflicts = interface_mode === :sharp
+        colptr, rowval = _chunked_gather!(ncells, cellvec) do counts, chunk
+            _gather_interface_chunk!(counts, grid, cellvec, chunk, nodeptr, nodecells, facetptr, facetadj, extras, include_node_conflicts)
+        end
+    else # :product
+        # The closure product composition needs the node adjacency in queryable form
+        an_ptr, an_adj = _chunked_gather!(ncells, cellvec) do counts, chunk
+            _gather_neighbor_chunk!(counts, grid, cellvec, chunk, nodeptr, nodecells)
+        end
+        colptr, rowval = _chunked_gather!(ncells, cellvec) do counts, chunk
+            _gather_product_chunk!(counts, cellvec, chunk, an_ptr, an_adj, facetptr, facetadj, extras)
+        end
     end
     nzval = fill(true, length(rowval))
     return SparseMatrixCSC(ncells, ncells, colptr, rowval, nzval)
@@ -181,8 +485,13 @@ function workstream_coloring(incidence_matrix, cellset)
     ###################
     # 1. Partitioning #
     ###################
-    # Note: the incidence matrix is assumed to be created with the same cellset, so all
-    # neighbors found through it are members of the cellset.
+    # Note: the incidence matrix is assumed to be created with the same cellset and the
+    # same conflict options, so all neighbors found through it are members of the
+    # cellset. In particular, all conflict edges (including long-range ones from e.g.
+    # periodic constraints or user input) must already be present in the matrix here:
+    # the odd/even zone merge in step 3 is only correct because a breadth-first-search
+    # edge never spans more than one zone, which holds for any edge of the graph being
+    # traversed but not for edges added afterwards.
     zone_of = zeros(Int, ncells) # Zero represents no zone assigned yet
     zones = Vector{Int}[]
     n_visited = 0
@@ -268,10 +577,13 @@ const GREEDY = ColoringAlgorithm.Greedy
 const WORKSTREAM = ColoringAlgorithm.WorkStream
 
 """
-    create_coloring(g::Grid, cellset = 1:getncells(g); alg::ColoringAlgorithm)
+    create_coloring(g::Grid, cellset = 1:getncells(g); alg::ColoringAlgorithm, kwargs...)
+    create_coloring(dh::DofHandler, [ch::ConstraintHandler]; alg::ColoringAlgorithm, kwargs...)
 
-Create a coloring of the cells in grid `g` such that no neighboring cells
-have the same color. If only a subset of cells should be colored, the cells to color can be specified by `cellset`.
+Create a coloring of the cells in grid `g` such that no two conflicting cells -- cells
+whose (concurrent) assembly may write to the same entries of the global matrix and
+vector -- have the same color. If only a subset of cells should be colored, the cells to
+color can be specified by `cellset`.
 
 Returns a vector of vectors with cell indexes, e.g.:
 
@@ -289,6 +601,42 @@ Two different algorithms are available, specified with the `alg` keyword argumen
  - `alg = ColoringAlgorithm.Greedy`: greedy algorithm that works well for structured quadrilateral grids such as
    e.g. quadrilateral grids from `generate_grid`.
 
+By default two cells conflict when they share a node, which is correct for cell-local
+assembly of continuous fields. Additional conflict sources can be enabled with keyword
+arguments:
+
+ - `interface_coupling`: also account for interface (DG) assembly, where an assembly
+   item writes to dofs of the cell *and its facet neighbors* (e.g. via
+   [`InterfaceValues`](@ref)). For the grid based method this is a `Bool`, and the
+   conflict graph is conservative: it must be safe also when continuous fields are
+   written from the interface terms, since the grid carries no information about the
+   discretization. The `DofHandler` based method additionally accepts the same coupling
+   matrix as [`allocate_matrix`](@ref)/[`init_sparsity_pattern`](@ref) and uses the
+   interpolations to build a sharper conflict graph (fewer colors) when all fields that
+   couple across interfaces are discontinuous.
+ - `topology`: optional [`ExclusiveTopology`](@ref), used to determine facet neighbors
+   for `interface_coupling`. If not given, facet neighbors are classified directly from
+   the grid.
+ - `ch::ConstraintHandler` (second positional argument of the `DofHandler` method):
+   account for constraint condensation during assembly (i.e.
+   [`apply_assemble!`](@ref)/[`apply_local!`](@ref)): cells whose condensation writes to
+   the same master dofs conflict, even if they are far apart in the grid (e.g. cells on
+   opposite sides with [`PeriodicDirichlet`](@ref), or arbitrary
+   [`AffineConstraint`](@ref)s). Only affine constraints add conflicts -- plain
+   `Dirichlet` conditions do not write to other dofs during condensation.
+ - `extra_conflicts`: user-provided conflicts for couplings that Ferrite cannot infer.
+   Accepts a `Dict{Int, Vector{Int}}` (cell id => conflicting cell ids; symmetrized
+   automatically) or an iterable of cell id collections where all cells in a collection
+   mutually conflict, e.g. `[[1, 17, 203], [4, 99]]`.
+
+The `DofHandler` method accepts (and validates) the full set of keyword arguments of
+[`add_sparsity_entries!`](@ref) so that the arguments used for matrix allocation can be
+forwarded as-is; `coupling` and `keep_constrained` do not influence the conflict graph
+and are ignored.
+
+Note that conflicts are only considered between cells in `cellset`: interface terms
+between a cell in the set and a cell outside of it are not accounted for.
+
 The resulting colors can be visualized using [`Ferrite.write_cell_colors`](@ref).
 
 !!! note "Cell to color mapping"
@@ -305,8 +653,26 @@ The resulting colors can be visualized using [`Ferrite.write_cell_colors`](@ref)
 # References
  - [Turcksin2016](@cite) Turcksin et al. ACM Trans. Math. Softw. 43 (2016).
 """
-function create_coloring(g::AbstractGrid, cellset = 1:getncells(g); alg::ColoringAlgorithm.T = ColoringAlgorithm.WorkStream)
-    incidence_matrix = create_incidence_matrix(g, cellset)
+function create_coloring(
+        g::AbstractGrid, cellset = 1:getncells(g);
+        alg::ColoringAlgorithm.T = ColoringAlgorithm.WorkStream,
+        interface_coupling::Bool = false,
+        topology = nothing,
+        extra_conflicts = nothing,
+    )
+    # Without a DofHandler there is no information about the discretization, so for
+    # interface coupling the conservative conflict graph must be used (see
+    # `_gather_product_chunk!`). Pass a DofHandler to get a sharper coloring for purely
+    # discontinuous interpolations.
+    incidence_matrix = create_incidence_matrix(
+        g, cellset;
+        interface_mode = interface_coupling ? :product : :none,
+        topology, extra_conflicts,
+    )
+    return _color_incidence_matrix(incidence_matrix, cellset, alg)
+end
+
+function _color_incidence_matrix(incidence_matrix, cellset, alg::ColoringAlgorithm.T)
     if alg === ColoringAlgorithm.WorkStream
         return workstream_coloring(incidence_matrix, cellset)
     elseif alg === ColoringAlgorithm.Greedy

--- a/test/test_grid_dofhandler_vtk.jl
+++ b/test/test_grid_dofhandler_vtk.jl
@@ -759,6 +759,364 @@ end
     end
 end
 
+@testset "grid coloring with extended conflicts" begin
+    cell_color(colors, c) = findfirst(cv -> c in cv, colors)
+    both_algs = (ColoringAlgorithm.Greedy, ColoringAlgorithm.WorkStream)
+
+    # Facet neighbors within the cellset, computed independently via ExclusiveTopology
+    function facet_neighbors_ref(grid, cellset)
+        topology = ExclusiveTopology(grid)
+        nbh = Ferrite.get_facet_facet_neighborhood(topology, grid)
+        Nf = Dict{Int, Vector{Int}}()
+        for cellid in cellset
+            nbs = Int[]
+            for f in 1:Ferrite.nfacets(getcells(grid, cellid))
+                for fidx in nbh[cellid, f]
+                    other = fidx[1]
+                    other in cellset && push!(nbs, other)
+                end
+            end
+            Nf[cellid] = nbs
+        end
+        return Nf
+    end
+
+    # Reference conflict predicates from dof-level write-set reasoning:
+    #  - facet: pure DG, items write dofs of their facet closure, cell dofs disjoint
+    #  - sharp: only discontinuous fields cross interfaces, but continuous fields exist
+    #  - product: a continuous field crosses interfaces
+    function conflict_predicates(grid, cellset)
+        An = Ferrite.create_incidence_matrix(grid, cellset)
+        Nf = facet_neighbors_ref(grid, cellset)
+        closure(c) = vcat([c], Nf[c])
+        facet_conflict(c1, c2) = !isempty(intersect(closure(c1), closure(c2)))
+        sharp_conflict(c1, c2) = An[c1, c2] || facet_conflict(c1, c2)
+        product_conflict(c1, c2) = any(x == y || An[x, y] for x in closure(c1), y in closure(c2))
+        return facet_conflict, sharp_conflict, product_conflict
+    end
+
+    function check_partition(colors, cellset)
+        @test sum(length, colors, init = 0) == length(cellset)
+        @test union!(Set{Int}(), colors...) == Set(cellset)
+        return
+    end
+
+    function check_safe(colors, conflict)
+        for color in colors, c1 in color, c2 in color
+            c1 == c2 && continue
+            @test !conflict(c1, c2)
+        end
+        return
+    end
+
+    function test_conflict_coloring(grid, cellset = 1:getncells(grid))
+        cellvec = sort!(unique!(collect(Int, cellset)))
+        facet_conflict, sharp_conflict, product_conflict = conflict_predicates(grid, cellvec)
+        refshape = Ferrite.getrefshape(getcelltype(grid))
+        dh_dg = DofHandler(grid)
+        add!(dh_dg, :u, DiscontinuousLagrange{refshape, 1}())
+        close!(dh_dg)
+        dh_mix = DofHandler(grid)
+        add!(dh_mix, :u, DiscontinuousLagrange{refshape, 1}())
+        add!(dh_mix, :p, Lagrange{refshape, 1}())
+        close!(dh_mix)
+        ic_dg_only = [true false; false false] # only :u couples across interfaces
+        for alg in both_algs
+            # Grid method: no field information -> conservative product graph
+            colors = create_coloring(grid, cellvec; alg, interface_coupling = true)
+            check_partition(colors, cellvec)
+            check_safe(colors, product_conflict)
+            # Pure DG discretization -> facet graph
+            colors = create_coloring(dh_dg; cellset = cellvec, alg, interface_coupling = true)
+            check_partition(colors, cellvec)
+            check_safe(colors, facet_conflict)
+            # Mixed discretization, only the DG field crosses -> sharp graph
+            colors = create_coloring(dh_mix; cellset = cellvec, alg, interface_coupling = ic_dg_only)
+            check_partition(colors, cellvec)
+            check_safe(colors, sharp_conflict)
+            # Mixed discretization, all fields cross -> product graph
+            colors = create_coloring(dh_mix; cellset = cellvec, alg, interface_coupling = true)
+            check_partition(colors, cellvec)
+            check_safe(colors, product_conflict)
+        end
+        return
+    end
+    test_conflict_coloring(generate_grid(Line, (6,)))
+    test_conflict_coloring(generate_grid(Triangle, (4, 4)))
+    test_conflict_coloring(generate_grid(Quadrilateral, (4, 4)))
+    test_conflict_coloring(generate_grid(Tetrahedron, (3, 3, 3)))
+    test_conflict_coloring(generate_grid(Hexahedron, (3, 3, 3)))
+    test_conflict_coloring(generate_grid(Quadrilateral, (5, 5)), 1:12) # subset
+    test_conflict_coloring(generate_grid(Quadrilateral, (6, 6)), union(Set(1:8), Set(25:36))) # unconnected subset
+
+    # Exactness of the conflict graphs against brute force references. The quadratic
+    # cells catch node-count-vs-vertex-count misclassification of facet neighbors (e.g.
+    # a QuadraticTetrahedron edge neighbor shares 3 nodes but only 2 vertices).
+    function brute_force_matrix(grid, cellset, conflict)
+        n = getncells(grid)
+        A = zeros(Bool, n, n)
+        for c1 in cellset, c2 in cellset
+            c1 == c2 && continue
+            A[c1, c2] = conflict(c1, c2)
+        end
+        return A
+    end
+    # There is no generate_grid for QuadraticTetrahedron: upgrade a linear tetrahedral
+    # grid by inserting edge midside nodes (only the connectivity matters here)
+    function quadratic_tet_grid(dims)
+        lin = generate_grid(Tetrahedron, dims)
+        nodes = copy(Ferrite.getnodes(lin))
+        midnode = Dict{NTuple{2, Int}, Int}()
+        cells = QuadraticTetrahedron[]
+        for cell in getcells(lin)
+            mids = Int[]
+            for (a, b) in Ferrite.edges(cell)
+                id = get!(midnode, minmax(a, b)) do
+                    xm = (Ferrite.get_node_coordinate(lin, a) + Ferrite.get_node_coordinate(lin, b)) / 2
+                    push!(nodes, Node(xm))
+                    length(nodes)
+                end
+                push!(mids, id)
+            end
+            push!(cells, QuadraticTetrahedron((cell.nodes..., mids...)))
+        end
+        return Grid(cells, nodes)
+    end
+    for (grid, cellset) in (
+            (quadratic_tet_grid((2, 2, 2)), 1:48),
+            (generate_grid(QuadraticQuadrilateral, (3, 3)), 1:9),
+            (generate_grid(Hexahedron, (3, 3, 3)), 1:27),
+            (generate_grid(Quadrilateral, (4, 4)), 1:12),
+        )
+        predicates = conflict_predicates(grid, cellset)
+        topology = ExclusiveTopology(grid)
+        for (mode, conflict) in zip((:facet, :sharp, :product), predicates)
+            im = Ferrite.create_incidence_matrix(grid, cellset; interface_mode = mode)
+            @test Matrix(im) == brute_force_matrix(grid, cellset, conflict)
+            # Facet adjacency from a topology gives the same graph
+            im2 = Ferrite.create_incidence_matrix(grid, cellset; interface_mode = mode, topology)
+            @test im2 == im
+        end
+    end
+
+    # Hand-verified cases on a 3x3x3 Hexahedron grid (cell (i, j, k) has id
+    # i + 3(j-1) + 9(k-1)): cell 14 = (2, 2, 2) is vertex-diagonal to cell 1 and their
+    # interface writes do not conflict in pure DG, while cell 5 = (2, 2, 1) is
+    # edge-diagonal and conflicts through the shared facet neighbors 2 and 4.
+    let grid = generate_grid(Hexahedron, (3, 3, 3))
+        im_facet = Ferrite.create_incidence_matrix(grid; interface_mode = :facet)
+        im_sharp = Ferrite.create_incidence_matrix(grid; interface_mode = :sharp)
+        @test !im_facet[1, 14]
+        @test im_sharp[1, 14] # continuous fields share dofs at the vertex
+        @test im_facet[1, 5]
+        @test im_facet[1, 3] # two apart in a row: shared facet neighbor 2
+        @test !im_facet[1, 15] # (3, 2, 2): no shared facet neighbor, no shared vertex
+    end
+    # 2D corner neighbors conflict also in pure DG (via the two shared facet neighbors)
+    let grid = generate_grid(Quadrilateral, (3, 3))
+        im_facet = Ferrite.create_incidence_matrix(grid; interface_mode = :facet)
+        @test im_facet[1, 5] # corner diagonal
+        @test im_facet[1, 3] # two apart in a row
+        @test !im_facet[1, 6] # closures {1,2,4} and {6,5,3,9} are disjoint
+    end
+
+    # Product-mode necessity: with a continuous field crossing interfaces, cells three
+    # apart in a row conflict through the shared dofs of the two cells between them.
+    let grid = generate_grid(Quadrilateral, (6, 1))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+        close!(dh)
+        im = Ferrite.create_incidence_matrix(grid; interface_mode = :product)
+        @test im[1, 4]
+        @test !im[1, 5]
+        for alg in both_algs
+            colors = create_coloring(dh; alg, interface_coupling = true)
+            @test cell_color(colors, 1) != cell_color(colors, 4)
+            colors = create_coloring(grid; alg, interface_coupling = true)
+            @test cell_color(colors, 1) != cell_color(colors, 4)
+        end
+    end
+
+    # Constraint conflicts: periodic constraints make cells on opposite sides conflict
+    # through the master dofs written during condensation.
+    function nontrivial_constraints(ch)
+        masters = Dict{Int, Vector{Int}}()
+        for (i, d) in pairs(ch.prescribed_dofs)
+            coefficients = ch.dofcoefficients[i]
+            (coefficients === nothing || isempty(coefficients)) && continue
+            masters[d] = [m for (m, _) in coefficients]
+        end
+        return masters
+    end
+    function condensation_write_sets(dh, ch, Nf = nothing)
+        masters = nontrivial_constraints(ch)
+        grid = Ferrite.get_grid(dh)
+        write_sets = Dict{Int, Set{Int}}()
+        for cellid in 1:getncells(grid)
+            closure = Nf === nothing ? [cellid] : vcat([cellid], Nf[cellid])
+            s = Set{Int}()
+            for c in closure, d in celldofs(dh, c)
+                push!(s, d)
+                union!(s, get(masters, d, Int[]))
+            end
+            write_sets[cellid] = s
+        end
+        return write_sets
+    end
+    for celltype in (Quadrilateral, Hexahedron)
+        dim = celltype === Quadrilateral ? 2 : 3
+        grid = generate_grid(celltype, ntuple(_ -> 3, dim))
+        refshape = Ferrite.getrefshape(celltype)
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{refshape, 1}())
+        close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, PeriodicDirichlet(:u, collect_periodic_facets(grid, "left", "right")))
+        close!(ch)
+        write_sets = condensation_write_sets(dh, ch)
+        for alg in both_algs
+            colors = create_coloring(dh, ch; alg)
+            check_partition(colors, 1:getncells(grid))
+            # Safety: same-color cells must have disjoint write sets (covers both the
+            # node graph and the constraint conflicts)
+            check_safe(colors, (c1, c2) -> !isempty(intersect(write_sets[c1], write_sets[c2])))
+            # Necessity: cells containing a constrained dof conflict with cells
+            # containing one of its masters
+            masters = nontrivial_constraints(ch)
+            @test !isempty(masters)
+            for (d, ms) in masters, m in ms
+                for c1 in 1:getncells(grid), c2 in 1:getncells(grid)
+                    c1 == c2 && continue
+                    if d in celldofs(dh, c1) && m in celldofs(dh, c2)
+                        @test cell_color(colors, c1) != cell_color(colors, c2)
+                    end
+                end
+            end
+        end
+        # Dirichlet-only constraints add no conflicts
+        ch_dbc = ConstraintHandler(dh)
+        add!(ch_dbc, Dirichlet(:u, getfacetset(grid, "left"), (x, t) -> 0))
+        close!(ch_dbc)
+        @test create_coloring(dh, ch_dbc) == create_coloring(dh)
+    end
+
+    # Long-range AffineConstraint: couples the first and last cells of the grid
+    let grid = generate_grid(Quadrilateral, (5, 5))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+        close!(dh)
+        d1 = first(celldofs(dh, 1))
+        d2 = last(celldofs(dh, 25))
+        ch = ConstraintHandler(dh)
+        add!(ch, AffineConstraint(d1, [d2 => 1.0], 0.0))
+        close!(ch)
+        for alg in both_algs
+            colors = create_coloring(dh, ch; alg)
+            @test cell_color(colors, 1) != cell_color(colors, 25)
+        end
+    end
+
+    # Combined DG + periodic constraints: the mixed dh has a periodic CG field and a DG
+    # field crossing interfaces, so master conflicts extend over the facet closure.
+    # The (nonzero) write set of an item is: all own dofs, the DG field dofs of the
+    # facet neighbors, and the masters of constrained dofs anywhere in the facet closure
+    # (interface items condense the neighbor's dofs too).
+    let grid = generate_grid(Quadrilateral, (4, 4))
+        dh = DofHandler(grid)
+        add!(dh, :u, DiscontinuousLagrange{RefQuadrilateral, 1}())
+        add!(dh, :p, Lagrange{RefQuadrilateral, 1}())
+        close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, PeriodicDirichlet(:p, collect_periodic_facets(grid, "left", "right")))
+        close!(ch)
+        Nf = facet_neighbors_ref(grid, 1:getncells(grid))
+        masters = nontrivial_constraints(ch)
+        @test !isempty(masters)
+        sdh = first(dh.subdofhandlers)
+        urange = dof_range(sdh, :u)
+        write_sets = Dict{Int, Set{Int}}()
+        for cellid in 1:getncells(grid)
+            s = Set{Int}(celldofs(dh, cellid))
+            for n in Nf[cellid]
+                union!(s, celldofs(dh, n)[urange])
+            end
+            for c in vcat([cellid], Nf[cellid]), d in celldofs(dh, c)
+                union!(s, get(masters, d, Int[]))
+            end
+            write_sets[cellid] = s
+        end
+        ic_dg_only = [true false; false false]
+        for alg in both_algs
+            colors = create_coloring(dh, ch; alg, interface_coupling = ic_dg_only)
+            check_partition(colors, 1:getncells(grid))
+            check_safe(colors, (c1, c2) -> !isempty(intersect(write_sets[c1], write_sets[c2])))
+        end
+    end
+
+    # Kwarg mirror contract: the same kwargs as for allocate_matrix/add_sparsity_entries!
+    let grid = generate_grid(Quadrilateral, (3, 3))
+        dh = DofHandler(grid)
+        add!(dh, :u, Lagrange{RefQuadrilateral, 1}())
+        close!(dh)
+        ch = ConstraintHandler(dh)
+        add!(ch, Dirichlet(:u, getfacetset(grid, "left"), (x, t) -> 0))
+        close!(ch)
+        topology = ExclusiveTopology(grid)
+        colors = create_coloring(
+            dh, ch;
+            keep_constrained = false, coupling = trues(1, 1),
+            interface_coupling = trues(1, 1), topology,
+        )
+        check_partition(colors, 1:getncells(grid))
+        # coupling and keep_constrained have no effect
+        @test colors == create_coloring(dh, ch; interface_coupling = trues(1, 1), topology)
+        # interface_coupling matrix with no coupling is equivalent to no interface coupling
+        @test create_coloring(dh; interface_coupling = falses(1, 1)) == create_coloring(dh)
+        # algebraic couplings are refused
+        @test_throws ArgumentError create_coloring(dh; algebraic_couplings = (1,))
+        # validation
+        @test_throws ErrorException create_coloring(DofHandler(grid)) # unclosed dh
+        ch_other = ConstraintHandler(close!(add!(DofHandler(grid), :u, Lagrange{RefQuadrilateral, 1}())))
+        @test_throws ErrorException create_coloring(dh, ch_other) # ch from another dh
+    end
+
+    # User-provided extra conflicts
+    let grid = generate_grid(Quadrilateral, (4, 4))
+        for alg in both_algs
+            # Dict form, asymmetric input is symmetrized
+            colors = create_coloring(grid; alg, extra_conflicts = Dict(1 => [16]))
+            @test cell_color(colors, 1) != cell_color(colors, 16)
+            # Clique form
+            colors = create_coloring(grid; alg, extra_conflicts = [[1, 13, 16]])
+            @test cell_color(colors, 1) != cell_color(colors, 13) !=
+                cell_color(colors, 16) != cell_color(colors, 1)
+        end
+        # Clique form is equivalent to the pairwise Dict form
+        @test Ferrite.create_incidence_matrix(grid; extra_conflicts = [[1, 13, 16]]) ==
+            Ferrite.create_incidence_matrix(
+            grid; extra_conflicts = Dict(1 => [13, 16], 13 => [16])
+        )
+        # Edges to cells outside the cellset are ignored
+        @test Ferrite.create_incidence_matrix(grid, 1:8; extra_conflicts = Dict(1 => [16])) ==
+            Ferrite.create_incidence_matrix(grid, 1:8)
+        # Out of range cell ids throw
+        @test_throws ArgumentError create_coloring(grid; extra_conflicts = Dict(1 => [17]))
+        @test_throws ArgumentError create_coloring(grid; extra_conflicts = [[0, 1]])
+        # Composes with other conflict sources
+        colors = create_coloring(grid; interface_coupling = true, extra_conflicts = Dict(1 => [16]))
+        @test cell_color(colors, 1) != cell_color(colors, 16)
+    end
+
+    # Set cellset and sorted vector cellset give the same result with the new kwargs
+    let grid = generate_grid(Quadrilateral, (4, 4))
+        @test create_coloring(grid, Set(1:9); interface_coupling = true) ==
+            create_coloring(grid, collect(1:9); interface_coupling = true)
+        # Empty and single-cell sets
+        @test create_coloring(grid, Int[]; interface_coupling = true) == Vector{Int}[]
+        @test create_coloring(grid, [5]; interface_coupling = true) == [[5]]
+    end
+end
+
 @testset "High order dof distribution" begin
     # 3-----4
     # | \   |


### PR DESCRIPTION
I haven't reviewed this yet so this is just the robots output.

---

Extend create_coloring beyond node-sharing conflicts so that colored
multithreaded assembly is safe for more problem types:

- Interface (DG) assembly via the interface_coupling keyword argument.
  Three conflict graphs, each exact for its field configuration and
  selected automatically from the interpolations by the new
  create_coloring(dh, [ch]; ...) method: A_f ∪ A_f² for purely
  discontinuous discretizations, node graph ∪ A_f² when continuous
  fields exist but only discontinuous ones cross interfaces, and the
  closure product (I ∪ A_f)(I ∪ A_n)(I ∪ A_f) when a continuous field
  crosses (this contains node-distance-3 pairs; node-distance-2 is
  insufficient). The grid-only method always uses the conservative
  product graph since it has no field information. Facet neighbors are
  classified by shared-vertex counting, or taken from an optionally
  passed topology via the same helper as the sparsity pattern.
- Constraint condensation during assembly (apply_assemble!/apply_local!)
  via create_coloring(dh, ch): cells whose condensation writes to the
  same master dofs conflict, even when mesh-distant (e.g. opposite sides
  with PeriodicDirichlet). Only affine constraints add conflicts; plain
  Dirichlet performs no global writes during condensation.
- User-provided conflicts via the extra_conflicts keyword argument
  (Dict or cliques form; symmetrized and restricted to the cellset).

The DofHandler method mirrors the add_sparsity_entries! keyword
arguments so the arguments used for matrix allocation can be forwarded
as-is (coupling and keep_constrained are validated no-ops; nonempty
algebraic_couplings is refused with a pointer to extra_conflicts).

The coloring algorithms are untouched: all conflict edges are unioned
into the incidence matrix before the workstream BFS partitioning, whose
odd/even zone merge remains correct for any edge present during the
BFS. The default code path is unchanged (byte-identical gather loop,
no measurable timing difference) and colorings remain deterministic
and independent of the thread count.
