### PR TITLE
docs: Upgrade Documenter to 1.18 and use inline at-id anchors for figures

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.7"
 manifest_format = "2.0"
-project_hash = "8bc9f5c0108d82776caf192618c5ffa1b7222253"
+project_hash = "3b50a0c0c38617d51d70cb7b4bec554c05b22c41"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -516,9 +516,9 @@ version = "0.9.5"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "56e9c37b5e7c3b4f080ab1da18d72d5c290e184a"
+git-tree-sha1 = "17d7a103a75db0d3f8c5764d51e478341a905c36"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.17.0"
+version = "1.18.0"
 
 [[deps.DocumenterCitations]]
 deps = ["AbstractTrees", "Bibliography", "Bijections", "Dates", "Documenter", "Logging", "Markdown", "MarkdownAST", "OrderedCollections", "SHA", "Unicode"]
@@ -528,9 +528,9 @@ version = "1.5.0"
 
 [[deps.DocumenterCodeBlocks]]
 deps = ["CRC32c", "Documenter", "JuliaSyntax"]
-git-tree-sha1 = "f22e6b591995ee0b354280169dc47c9660611867"
+git-tree-sha1 = "326d0dc2dc9e08fb4076372aa49f86056a0d7dd2"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.4.0"
+version = "1.5.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -37,4 +37,5 @@ VTKHDF = "45d8cf6f-ab5f-45bc-ab92-77e36ab192e6"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
+Documenter = "1.18"
 OrdinaryDiffEqRosenbrock = "2"

--- a/docs/src/devdocs/documentation.md
+++ b/docs/src/devdocs/documentation.md
@@ -59,7 +59,12 @@ The pipeline consists of the following pieces:
    machines) fetch them when building the docs.
 6. Show the figure at the top of the example by adding an `# ![](<name>-light.png)` /
    `# ![](<name>-dark.png)` pair after the title in the literate source file (see e.g.
-   `docs/src/literate-tutorials/heat_equation.jl`).
+   `docs/src/literate-tutorials/heat_equation.jl`). Give the caption a named anchor,
+   `# [[*Figure 1*](@ref <page-id>-figure-1)](@id <page-id>-figure-1):` on its own line
+   followed by the caption text, where `<page-id>` is the `@id` of the page title. The
+   inner `@ref` makes the label a link to itself (so its URL can be copied), and the
+   figure can be referenced from the text (on any page) with
+   `[Figure 1](@ref <page-id>-figure-1)`.
 7. For a tutorial or gallery example, add it to the overview page: an entry in the
    corresponding `cards` list in `docs/generate.jl` *and* a `---`-separated description
    section in

--- a/docs/src/literate-gallery/elasticity_adaptivity.jl
+++ b/docs/src/literate-gallery/elasticity_adaptivity.jl
@@ -3,7 +3,8 @@
 # ![](elasticity_adaptivity-light.webp)
 # ![](elasticity_adaptivity-dark.webp)
 #
-# *Figure 1*: The adaptive refinement loop, colored by the von Mises stress:
+# [[*Figure 1*](@ref gallery-elasticity-adaptivity-figure-1)](@id gallery-elasticity-adaptivity-figure-1):
+# The adaptive refinement loop, colored by the von Mises stress:
 # the refinement concentrates at the stress singularity of the re-entrant
 # corner (displacements exaggerated).
 #

--- a/docs/src/literate-gallery/helmholtz.jl
+++ b/docs/src/literate-gallery/helmholtz.jl
@@ -22,6 +22,11 @@
 # ![](helmholtz-light.png)
 # ![](helmholtz-dark.png)
 #
+# [[*Figure 1*](@ref tutorial-helmholtz-figure-1)](@id tutorial-helmholtz-figure-1):
+# Finite element solution ``u`` of the Helmholtz
+# equation on the square domain, with Dirichlet conditions on ``\Gamma_1`` (top and right
+# boundary) and Neumann conditions on ``\Gamma_2`` (bottom and left boundary).
+#
 # We will use the following weak formulation:
 # ```math
 # \int_\Omega \nabla δu \cdot \nabla u \, d\Omega

--- a/docs/src/literate-gallery/landau.jl
+++ b/docs/src/literate-gallery/landau.jl
@@ -2,13 +2,18 @@
 
 # ![landau_orig.png](landau_orig-light.png)
 # ![landau_orig.png](landau_orig-dark.png)
-
-# Original
+#
+# [[*Figure 1*](@ref tutorial-ginzburg-landau-minimizer-figure-1)](@id tutorial-ginzburg-landau-minimizer-figure-1):
+# Magnitude of the
+# polarization ``|\boldsymbol{P}|`` for the prescribed initial guess.
 
 # ![landau_opt.png](landau_opt-light.png)
 # ![landau_opt.png](landau_opt-dark.png)
-
-# Optimized
+#
+# [[*Figure 2*](@ref tutorial-ginzburg-landau-minimizer-figure-2)](@id tutorial-ginzburg-landau-minimizer-figure-2):
+# Magnitude of the
+# polarization ``|\boldsymbol{P}|`` after minimizing the Ginzburg-Landau free energy with
+# Newton's method.
 
 # In this example a basic Ginzburg-Landau model is solved.
 # This example gives an idea of how the API together with automatic differentiation can be

--- a/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
+++ b/docs/src/literate-gallery/quasi_incompressible_hyperelasticity.jl
@@ -2,6 +2,12 @@
 #
 # ![](quasi_incompressible_hyperelasticity-light.webp)
 # ![](quasi_incompressible_hyperelasticity-dark.webp)
+#
+# [[*Figure 1*](@ref tutorial-nearly-incompressible-hyperelasticity-figure-1)](@id tutorial-nearly-incompressible-hyperelasticity-figure-1):
+# Deformation of the
+# unit cube, colored by the displacement magnitude ``|\mathbf{u}|``, as the right face is
+# displaced in the ``x``-direction while the left, bottom and back faces are supported by
+# rollers.
 #-
 #md # !!! tip
 #md #     This example is also available as a Jupyter notebook:

--- a/docs/src/literate-gallery/topology_optimization.jl
+++ b/docs/src/literate-gallery/topology_optimization.jl
@@ -5,7 +5,8 @@
 # ![](topology_optimization-light.webp)
 # ![](topology_optimization-dark.webp)
 #
-# *Figure 1*: Evolution of the material density during topology optimization of the
+# [[*Figure 1*](@ref tutorial-topology-optimization-figure-1)](@id tutorial-topology-optimization-figure-1):
+# Evolution of the material density during topology optimization of the
 # bending beam for a fixed total mass.
 #
 #-
@@ -542,12 +543,13 @@ end
 topopt(0.03, 0.5, 60, "topopt_frames"; output = true); #src iteration series for the docs animation (docs/screenshots.py)
 
 # We observe, that the stiffness for the lower value of $ra$ is higher,
-# but also requires more iterations until convergence and finer structures to be manufactured, as can be seen in Figure 2:
+# but also requires more iterations until convergence and finer structures to be manufactured, as can be seen in [Figure 2](@ref tutorial-topology-optimization-figure-2):
 #
 # ![](topology_optimization_result-light.png)
 # ![](topology_optimization_result-dark.png)
 #
-# *Figure 2*: Optimization results of the bending beam for smaller (left) and larger (right) value of the regularization parameter $\beta$.
+# [[*Figure 2*](@ref tutorial-topology-optimization-figure-2)](@id tutorial-topology-optimization-figure-2):
+# Optimization results of the bending beam for smaller (left) and larger (right) value of the regularization parameter $\beta$.
 #
 # To prove mesh independence, the user could vary the mesh resolution and compare the results.
 

--- a/docs/src/literate-howto/postprocessing.jl
+++ b/docs/src/literate-howto/postprocessing.jl
@@ -3,7 +3,8 @@
 # ![](postprocessing-light.png)
 # ![](postprocessing-dark.png)
 #
-# *Figure 1*: Heat flux computed from the solution to the heat equation on the unit square,
+# [[*Figure 1*](@ref howto-postprocessing-figure-1)](@id howto-postprocessing-figure-1):
+# Heat flux computed from the solution to the heat equation on the unit square,
 # coloured by magnitude with arrows for the direction. See the previous example:
 # [Heat equation](@ref tutorial-heat-equation).
 #
@@ -103,7 +104,7 @@ q_projected = project(projector, q_gp, qr);
 # ## Exporting to VTK
 # To visualize the heat flux, we export the projected field `q_projected`
 # to a VTK-file, which can be viewed in e.g. [ParaView](https://www.paraview.org/).
-# The result is also visualized in *Figure 1*.
+# The result is also visualized in [*Figure 1*](@ref howto-postprocessing-figure-1).
 VTKGridFile("heat_equation_flux", grid) do vtk
     write_projection(vtk, projector, q_projected, "q")
 end;
@@ -112,10 +113,12 @@ end;
 # ![](postprocessing_cutline-light.png)
 # ![](postprocessing_cutline-dark.png)
 #
-# *Figure 2*: The temperature field, with the cut line along which we want to compute
+# [[*Figure 2*](@ref howto-postprocessing-figure-2)](@id howto-postprocessing-figure-2):
+# The temperature field, with the cut line along which we want to compute
 # the temperature and heat flux drawn on top.
 
-# Consider a cut-line through the domain like the one in *Figure 2* above.
+# Consider a cut-line through the domain like the one in
+# [*Figure 2*](@ref howto-postprocessing-figure-2) above.
 # We will evaluate the temperature and the heat flux distribution along a horizontal line.
 points = [Vec((x, 0.75)) for x in range(-1.0, 1.0, length = 101)];
 
@@ -140,11 +143,15 @@ import Plots
 
 # Firstly, we are going to plot the temperature values along the given line.
 Plots.plot(getindex.(points, 1), u_points, xlabel = "x (coordinate)", ylabel = "u (temperature)", label = nothing)
-# *Figure 3*: Temperature along the cut line from *Figure 2*.
+# [[*Figure 3*](@ref howto-postprocessing-figure-3)](@id howto-postprocessing-figure-3):
+# Temperature along the cut line from
+# [*Figure 2*](@ref howto-postprocessing-figure-2).
 
 # Secondly, the horizontal heat flux (i.e. the first component of the heat flux vector) is plotted.
 Plots.plot(getindex.(points, 1), getindex.(q_points, 1), xlabel = "x (coordinate)", ylabel = "q_x (flux in x-direction)", label = nothing)
-# *Figure 4*: ``x``-component of the flux along the cut line from *Figure 2*.
+# [[*Figure 4*](@ref howto-postprocessing-figure-4)](@id howto-postprocessing-figure-4):
+# ``x``-component of the flux along the cut
+# line from [*Figure 2*](@ref howto-postprocessing-figure-2).
 
 #md # ## [Plain program](@id postprocessing-plain-program)
 #md #

--- a/docs/src/literate-howto/threaded_assembly.jl
+++ b/docs/src/literate-howto/threaded_assembly.jl
@@ -55,7 +55,8 @@
 #
 # Ferrite include functionality to color the grid with the [`create_coloring`](@ref)
 # function. Here we create a simple 2D grid, color it, and export the colors to a VTK file
-# to visualize the result (see *Figure 1*.). Note that no cells with the same color has any
+# to visualize the result (see [*Figure 1*](@ref howto-threaded-assembly-figure-1)). Note that
+# no cells with the same color has any
 # shared nodes (dofs). This means that it is safe to assemble in parallel as long as we only
 # assemble one color at a time.
 #
@@ -84,7 +85,8 @@ create_example_2d_grid()
 # ![](coloring-light.png)
 # ![](coloring-dark.png)
 #
-# *Figure 1*: Element coloring using the "workstream"-algorithm (left) and the "greedy"-
+# [[*Figure 1*](@ref howto-threaded-assembly-figure-1)](@id howto-threaded-assembly-figure-1):
+# Element coloring using the "workstream"-algorithm (left) and the "greedy"-
 # algorithm (right). The swatches below each grid are the colors the algorithm used.
 
 # ## Multithreaded assembly of a cantilever beam in 3D

--- a/docs/src/literate-tutorials/computational_homogenization.jl
+++ b/docs/src/literate-tutorials/computational_homogenization.jl
@@ -3,7 +3,8 @@
 # ![](computational_homogenization-light.png)
 # ![](computational_homogenization-dark.png)
 #
-# *Figure 1*: von Mises stress in an RVE with 5 stiff inclusions embedded in a softer matrix
+# [[*Figure 1*](@ref tutorial-computational-homogenization-figure-1)](@id tutorial-computational-homogenization-figure-1):
+# von Mises stress in an RVE with 5 stiff inclusions embedded in a softer matrix
 # material that is loaded in shear. The problem is solved by using homogeneous Dirichlet
 # boundary conditions (left) and (strong) periodic boundary conditions (right).
 #
@@ -18,7 +19,7 @@
 # In this example we will solve the Representative Volume Element (RVE) problem for
 # computational homogenization of linear elasticity and compute the effective/homogenized
 # stiffness of an RVE with 5 stiff circular inclusions embedded in a softer matrix material
-# (see Figure 1).
+# (see [Figure 1](@ref tutorial-computational-homogenization-figure-1)).
 #
 # It is possible to obtain upper and lower bounds on the stiffness analytically, see for
 # example [Rule of mixtures](https://en.wikipedia.org/wiki/Rule_of_mixtures). An upper

--- a/docs/src/literate-tutorials/darcy_flow.jl
+++ b/docs/src/literate-tutorials/darcy_flow.jl
@@ -3,7 +3,8 @@
 # ![](darcy_flow-light.png)
 # ![](darcy_flow-dark.png)
 #
-# *Figure 1*: Pressure (left) and flux magnitude (right) for Darcy flow through a domain
+# [[*Figure 1*](@ref tutorial-darcy-flow-figure-1)](@id tutorial-darcy-flow-figure-1):
+# Pressure (left) and flux magnitude (right) for Darcy flow through a domain
 # with an almost impermeable barrier: the flow is forced through the gap in the middle.
 #
 #-
@@ -63,7 +64,8 @@
 # ![](darcy_flow-geometry-light.png)
 # ![](darcy_flow-geometry-dark.png)
 #
-# *Figure 2*: Geometry and boundary conditions: the pressure is prescribed on the left
+# [[*Figure 2*](@ref tutorial-darcy-flow-figure-2)](@id tutorial-darcy-flow-figure-2):
+# Geometry and boundary conditions: the pressure is prescribed on the left
 # and right edges (``\Gamma_\mathrm{p}``), the top and bottom edges are impermeable
 # (``\Gamma_\mathrm{q}``), and the flow must pass through the gap in the almost
 # impermeable barrier.
@@ -317,7 +319,8 @@ VTKGridFile("darcy_flow", dh) do vtk
     Ferrite.write_cellset(vtk, grid, "barrier")
 end;
 
-# Visualizing the flux magnitude (Figure 1) shows the flow channeling through the gap in
+# Visualizing the flux magnitude ([Figure 1](@ref tutorial-darcy-flow-figure-1)) shows the
+# flow channeling through the gap in
 # the barrier, with the flux vanishing inside the barrier itself.
 #
 # ### Local and global conservation

--- a/docs/src/literate-tutorials/dg_heat_equation.jl
+++ b/docs/src/literate-tutorials/dg_heat_equation.jl
@@ -3,7 +3,8 @@
 # ![](dg_heat_equation-light.png)
 # ![](dg_heat_equation-dark.png)
 #
-# *Figure 1*: Temperature field on the unit square with an internal uniform heat source
+# [[*Figure 1*](@ref tutorial-dg-heat-equation-figure-1)](@id tutorial-dg-heat-equation-figure-1):
+# Temperature field on the unit square with an internal uniform heat source
 # solved with inhomogeneous Dirichlet boundary conditions on the left and right boundaries
 # and flux on the top and bottom boundaries.
 #

--- a/docs/src/literate-tutorials/elastodynamics.jl
+++ b/docs/src/literate-tutorials/elastodynamics.jl
@@ -3,7 +3,8 @@
 # ![](elastodynamics-light.webp)
 # ![](elastodynamics-dark.webp)
 #
-# *Figure 1*: Free vibration of the cantilever beam after the static tip load is released
+# [[*Figure 1*](@ref tutorial-elastodynamics-figure-1)](@id tutorial-elastodynamics-figure-1):
+# Free vibration of the cantilever beam after the static tip load is released
 # at $t = 0$, colored by the deflection magnitude (displacements exaggerated by a factor
 # of 75). The animation covers three periods of the first bending mode.
 #
@@ -324,7 +325,8 @@ end
 # ![](elastodynamics_modes-light.png)
 # ![](elastodynamics_modes-dark.png)
 #
-# *Figure 2*: The four lowest vibration modes, from top to bottom. Modes 1, 3 and 4 are
+# [[*Figure 2*](@ref tutorial-elastodynamics-figure-2)](@id tutorial-elastodynamics-figure-2):
+# The four lowest vibration modes, from top to bottom. Modes 1, 3 and 4 are
 # the first three bending modes about the weak axis, deflecting in the thickness direction
 # $z$; mode 2 (second from the top, recognizable by its wide face) is the first bending
 # mode about the strong axis, deflecting sideways in $y$. For easy comparison all modes
@@ -518,7 +520,8 @@ plt = plot_tip_deflection(:black)
 # ![](elastodynamics_tip-light.svg)
 # ![](elastodynamics_tip-dark.svg)
 #
-# *Figure 3*: Tip deflection history from the finite element simulation compared with the
+# [[*Figure 3*](@ref tutorial-elastodynamics-figure-3)](@id tutorial-elastodynamics-figure-3):
+# Tip deflection history from the finite element simulation compared with the
 # analytical single mode solution.
 #
 # The finite element solution follows the envelope and frequency of the single mode

--- a/docs/src/literate-tutorials/heat_adaptivity.jl
+++ b/docs/src/literate-tutorials/heat_adaptivity.jl
@@ -3,7 +3,8 @@
 # ![](heat_adaptivity-light.webp)
 # ![](heat_adaptivity-dark.webp)
 #
-# *Figure 1*: The adaptive refinement loop, shown on a cross section of the cube.
+# [[*Figure 1*](@ref tutorial-heat-adaptivity-figure-1)](@id tutorial-heat-adaptivity-figure-1):
+# The adaptive refinement loop, shown on a cross section of the cube.
 # On the coarse initial meshes the solution is badly polluted; as the mesh refines
 # around the sharp spherical feature the solution converges.
 #

--- a/docs/src/literate-tutorials/heat_equation.jl
+++ b/docs/src/literate-tutorials/heat_equation.jl
@@ -3,7 +3,8 @@
 # ![](heat_equation-light.png)
 # ![](heat_equation-dark.png)
 #
-# *Figure 1*: Temperature field on the unit square with an internal uniform heat source
+# [[*Figure 1*](@ref tutorial-heat-equation-figure-1)](@id tutorial-heat-equation-figure-1):
+# Temperature field on the unit square with an internal uniform heat source
 # solved with homogeneous Dirichlet boundary conditions on the boundary.
 #
 #-

--- a/docs/src/literate-tutorials/hyperelasticity.jl
+++ b/docs/src/literate-tutorials/hyperelasticity.jl
@@ -6,7 +6,8 @@
 # ![](hyperelasticity-light.png)
 # ![](hyperelasticity-dark.png)
 #
-# *Figure 1*: Cube loaded in torsion modeled with a hyperelastic material model and
+# [[*Figure 1*](@ref tutorial-hyperelasticity-figure-1)](@id tutorial-hyperelasticity-figure-1):
+# Cube loaded in torsion modeled with a hyperelastic material model and
 # finite strain.
 #
 #-
@@ -41,7 +42,8 @@
 # are defined on the deformed (sometimes also called *current* or *spatial*) domain, depending
 # on the specific formulation.
 #
-# The specific problem we will solve in this example is the cube from Figure 1: On one side
+# The specific problem we will solve in this example is the cube from
+# [Figure 1](@ref tutorial-hyperelasticity-figure-1): On one side
 # we apply a rotation using Dirichlet boundary conditions, on the opposite side we fix the
 # displacement with a homogeneous Dirichlet boundary condition, and on the remaining four
 # sides we apply a traction in the normal direction of the surface. In addition, a body

--- a/docs/src/literate-tutorials/incompressible_elasticity.jl
+++ b/docs/src/literate-tutorials/incompressible_elasticity.jl
@@ -3,7 +3,8 @@
 # ![](incompressible_elasticity-light.png)
 # ![](incompressible_elasticity-dark.png)
 #
-# *Figure 1*: von Mises stress on the deformed Cook's membrane.
+# [[*Figure 1*](@ref tutorial-incompressible-elasticity-figure-1)](@id tutorial-incompressible-elasticity-figure-1):
+# von Mises stress on the deformed Cook's membrane.
 #
 #-
 #md # !!! tip
@@ -447,13 +448,15 @@ u2 = solve(0.5, quadratic_u, linear_p);
 
 # ## Results
 #
-# The two solutions are compared in Figure 2, where the computed pressure field is
+# The two solutions are compared in
+# [Figure 2](@ref tutorial-incompressible-elasticity-figure-2), where the computed pressure field is
 # plotted on the deformed geometry.
 #
 # ![](incompressible_elasticity_pressure-light.png)
 # ![](incompressible_elasticity_pressure-dark.png)
 #
-# *Figure 2*: Pressure field for the linear/linear element (left) and the
+# [[*Figure 2*](@ref tutorial-incompressible-elasticity-figure-2)](@id tutorial-incompressible-elasticity-figure-2):
+# Pressure field for the linear/linear element (left) and the
 # quadratic/linear element (right). The color scale is fitted to the range of the
 # quadratic/linear solution.
 #
@@ -468,8 +471,9 @@ u2 = solve(0.5, quadratic_u, linear_p);
 # the displacement field, and therefore the deformed shape, looks reasonable also for the
 # linear/linear element, but since the stress depends on the pressure (recall
 # ``\boldsymbol{\sigma} = 2G\, \boldsymbol{\varepsilon}^\mathrm{dev} - p\,
-# \boldsymbol{I}``) the stress output from the unstable element is useless. Figure 1 at
-# the top of this page shows the von Mises stress from the stable quadratic/linear
+# \boldsymbol{I}``) the stress output from the unstable element is useless.
+# [Figure 1](@ref tutorial-incompressible-elasticity-figure-1) at the top of this page
+# shows the von Mises stress from the stable quadratic/linear
 # solution.
 
 ## test the result                 #src

--- a/docs/src/literate-tutorials/linear_elasticity.jl
+++ b/docs/src/literate-tutorials/linear_elasticity.jl
@@ -3,7 +3,8 @@
 # ![](linear_elasticity-light.png)
 # ![](linear_elasticity-dark.png)
 #
-# *Figure 1*: Vertical normal stress $\sigma_{22}$ (MPa) on the deformed geometry. The
+# [[*Figure 1*](@ref tutorial-linear-elasticity-figure-1)](@id tutorial-linear-elasticity-figure-1):
+# Vertical normal stress $\sigma_{22}$ (MPa) on the deformed geometry. The
 # computational mesh is generated from the 1mm $\times$ 1mm Ferrite logo.
 #
 #md # !!! tip
@@ -392,14 +393,16 @@ VTKGridFile("linear_elasticity", dh) do vtk
     write_cell_data(vtk, color_data, "colors") #hide
 end
 
-# We used the displacement field to visualize the deformed logo in *Figure 1*,
-# and in *Figure 2*, we demonstrate the difference between the interpolated stress
+# We used the displacement field to visualize the deformed logo in
+# [*Figure 1*](@ref tutorial-linear-elasticity-figure-1), and in
+# [*Figure 2*](@ref tutorial-linear-elasticity-figure-2), we demonstrate the difference between the interpolated stress
 # field and the constant stress in each cell.
 
 # ![](linear_elasticity_stress-light.png)
 # ![](linear_elasticity_stress-dark.png)
 #
-# *Figure 2*: Vertical normal stresses (MPa) exported using the `L2Projector` (left)
+# [[*Figure 2*](@ref tutorial-linear-elasticity-figure-2)](@id tutorial-linear-elasticity-figure-2):
+# Vertical normal stresses (MPa) exported using the `L2Projector` (left)
 # and constant stress in each cell (right).
 
 # The mesh produced by gmsh is not stable between different OS        #src

--- a/docs/src/literate-tutorials/linear_shell.jl
+++ b/docs/src/literate-tutorials/linear_shell.jl
@@ -4,7 +4,8 @@
 # ![](linear_shell-light.png)
 # ![](linear_shell-dark.png)
 #
-# *Figure 1*: Magnitude of the deflection of the shell (deformation magnified).
+# [[*Figure 1*](@ref tutorial-linear-shell-figure-1)](@id tutorial-linear-shell-figure-1):
+# Magnitude of the deflection of the shell (deformation magnified).
 #-
 # ## Introduction
 #

--- a/docs/src/literate-tutorials/ns_vs_diffeq.jl
+++ b/docs/src/literate-tutorials/ns_vs_diffeq.jl
@@ -10,6 +10,10 @@ nothing                    #hide
 # ![nsdiffeq](ns_vs_diffeq-light.webp)
 # ![nsdiffeq](ns_vs_diffeq-dark.webp)
 #
+# [[*Figure 1*](@ref tutorial-ins-ordinarydiffeq-figure-1)](@id tutorial-ins-ordinarydiffeq-figure-1):
+# Velocity magnitude of the flow around a
+# circular obstacle in a channel, showing the von Kármán vortex street that develops
+# behind the obstacle.
 #
 # In this example we focus on a simple but visually appealing problem from
 # fluid dynamics, namely vortex shedding. This problem is also known as

--- a/docs/src/literate-tutorials/plasticity.jl
+++ b/docs/src/literate-tutorials/plasticity.jl
@@ -3,7 +3,8 @@
 # ![Shows the von Mises stress distribution in a cantilever beam.](plasticity-light.png)
 # ![Shows the von Mises stress distribution in a cantilever beam.](plasticity-dark.png)
 #
-# *Figure 1.* A coarse mesh solution of a cantilever beam subjected to a load
+# [[*Figure 1*](@ref tutorial-plasticity-figure-1)](@id tutorial-plasticity-figure-1):
+# A coarse mesh solution of a cantilever beam subjected to a load
 # causing plastic deformations. The initial yield limit is 200 MPa but due to
 # hardening it increases up to approximately 240 MPa.
 #
@@ -375,7 +376,8 @@ plot(
 ylabel!("Traction [Pa]")
 xlabel!("Maximum deflection [m]")
 
-# *Figure 2.* Load-displacement-curve for the beam, showing a clear decrease
+# [[*Figure 2*](@ref tutorial-plasticity-figure-2)](@id tutorial-plasticity-figure-2):
+# Load-displacement-curve for the beam, showing a clear decrease
 # in stiffness as more material starts to yield.
 
 ## test the result                       #src

--- a/docs/src/literate-tutorials/porous_media.jl
+++ b/docs/src/literate-tutorials/porous_media.jl
@@ -1,4 +1,4 @@
-# # Porous media
+# # [Porous media](@id tutorial-porous-media)
 
 # Porous media is a two-phase material, consisting of solid parts and a liquid occupying
 # the pores in between.
@@ -10,10 +10,16 @@
 # In the porous media, denoted the matrix, we have both the displacement field,
 # `:u`, as well as the liquid pressure, `:p`, as unknown. The simulation results,
 # the vertical strain (defined on the whole domain) and the liquid pressure (only
-# defined in the porous matrix), are shown below
+# defined in the porous matrix), are shown in [Figure 1](@ref tutorial-porous-media-figure-1).
 #
 # ![Vertical strain (left) and pressure (right) evolution.](porous_media-light.webp)
 # ![Vertical strain (left) and pressure (right) evolution.](porous_media-dark.webp)
+#
+# [[*Figure 1*](@ref tutorial-porous-media-figure-1)](@id tutorial-porous-media-figure-1):
+# Vertical strain ``\epsilon_{22}`` (left) and
+# liquid pressure ``p`` (right) over time as the top surface is compressed. The strain is
+# defined on the whole domain, whereas the pressure only exists in the porous matrix; the
+# impermeable solid aggregates are shown in gray.
 #
 # ## Theory of porous media
 # The strong forms are given as

--- a/docs/src/literate-tutorials/reactive_surface.jl
+++ b/docs/src/literate-tutorials/reactive_surface.jl
@@ -11,7 +11,8 @@ nothing                    #hide
 # ![](reactive_surface-light.webp)
 # ![](reactive_surface-dark.webp)
 #
-# *Figure 1*: Reactant concentration field of the Gray-Scott model on the unit sphere.
+# [[*Figure 1*](@ref tutorial-reactive-surface-figure-1)](@id tutorial-reactive-surface-figure-1):
+# Reactant concentration field of the Gray-Scott model on the unit sphere.
 #
 #-
 #md # !!! tip

--- a/docs/src/literate-tutorials/stokes-flow.jl
+++ b/docs/src/literate-tutorials/stokes-flow.jl
@@ -10,8 +10,9 @@
 #
 # ![](stokes-flow-light.png)
 # ![](stokes-flow-dark.png)
-# *Figure 1*: Magnitude of the resulting velocity field on the quarter disk
-# domain ``\Omega`` (see *Figure 2*).
+# [[*Figure 1*](@ref tutorial-stokes-flow-figure-1)](@id tutorial-stokes-flow-figure-1):
+# Magnitude of the resulting velocity field on the quarter disk
+# domain ``\Omega`` (see [*Figure 2*](@ref tutorial-stokes-flow-figure-2)).
 
 # ## Introduction and problem formulation
 #
@@ -34,7 +35,8 @@
 # \end{align*}
 # ```
 # where the domain is defined as ``\Omega = \{\boldsymbol{x} \in (0, 1)^2:
-# \ ||\boldsymbol{x}|| \in (0.5, 1)\}``, see *Figure 2*. For the velocity we use periodic
+# \ ||\boldsymbol{x}|| \in (0.5, 1)\}``, see [*Figure 2*](@ref tutorial-stokes-flow-figure-2).
+# For the velocity we use periodic
 # boundary conditions on the inlet ``\Gamma_1`` and outlet ``\Gamma_3``:
 # ```math
 # \begin{align*}
@@ -51,7 +53,8 @@
 # ![](stokes-flow-geometry-light.png)
 # ![](stokes-flow-geometry-dark.png)
 #
-# *Figure 2*: Computational domain ``\Omega`` with boundaries ``\Gamma_1``,
+# [[*Figure 2*](@ref tutorial-stokes-flow-figure-2)](@id tutorial-stokes-flow-figure-2):
+# Computational domain ``\Omega`` with boundaries ``\Gamma_1``,
 # ``\Gamma_3`` (periodic boundary conditions) and ``\Gamma_2``, ``\Gamma_4``
 # (homogeneous Dirichlet boundary conditions).
 #
@@ -125,7 +128,7 @@
 # ```
 #
 # !!! note
-#     The constraint matrix ``\underline{\underline{C}}_p`` is the same matrix we would have
+#     [The constraint matrix](@id stokes-multiplier-note) ``\underline{\underline{C}}_p`` is the same matrix we would have
 #     obtained when assembling the system with the Lagrange multiplier. In that case the
 #     full system would be
 #     ```math
@@ -540,13 +543,15 @@ end
 
 main()
 
-# The resulting magnitude of the velocity field is visualized in *Figure 1*.
+# The resulting magnitude of the velocity field is visualized in
+# [*Figure 1*](@ref tutorial-stokes-flow-figure-1).
 
 # ## [Alternative: retaining the Lagrange multiplier](@id stokes-multiplier)
 #
 # As discussed in the introduction, the mean value constraint can also be enforced by
-# keeping the Lagrange multiplier ``\lambda`` as an unknown -- the note above shows the
-# resulting block system. We implement this variant too, since it is a good illustration
+# keeping the Lagrange multiplier ``\lambda`` as an unknown -- the
+# [note above](@ref stokes-multiplier-note) shows the resulting block system. We implement
+# this variant too, since it is a good illustration
 # of [algebraic variables](@ref topic-algebraic-variables): ``\lambda`` is a single
 # scalar unknown without spatial variation, which is exactly what an
 # [`AlgebraicVariable`](@ref) declares. In contrast to the `AffineConstraint`, this

--- a/docs/src/literate-tutorials/stress_driven_homogenization.jl
+++ b/docs/src/literate-tutorials/stress_driven_homogenization.jl
@@ -3,10 +3,12 @@
 # ![](stress_driven_homogenization-light.png)
 # ![](stress_driven_homogenization-dark.png)
 #
-# *Figure 1*: von Mises stress in the RVE from the strain-driven homogenization
+# [[*Figure 1*](@ref tutorial-stress-driven-homogenization-figure-1)](@id tutorial-stress-driven-homogenization-figure-1):
+# von Mises stress in the RVE from the strain-driven homogenization
 # tutorial, deformed by the total displacement (macroscopic plus fluctuation part) that
 # results from the prescribed macroscopic shear stress ``\bar{\sigma}_{12}`` -- compare
-# with the strain-driven (periodic) shear load case in that tutorial's Figure 1. The
+# with the strain-driven (periodic) shear load case in that tutorial's
+# [Figure 1](@ref tutorial-computational-homogenization-figure-1). The
 # gray outline is the undeformed RVE (displacements exaggerated by a factor of 4; the
 # wiggles of the boundary are the periodic fluctuation field, matching on opposite
 # edges).
@@ -489,7 +491,7 @@ end
 # Since the exported `:u` is only the *fluctuation* (which does not show the
 # macroscopic deformation), we also export the total displacement ``\boldsymbol{u} =
 # \bar{\boldsymbol{\varepsilon}} \cdot \boldsymbol{x} + \boldsymbol{u}^\mu``, which is
-# what deforms the RVE (see Figure 1).
+# what deforms the RVE (see [Figure 1](@ref tutorial-stress-driven-homogenization-figure-1)).
 uμ_nodes = evaluate_at_grid_nodes(dh, a, :u)
 u_total = [ε̄ ⋅ get_node_coordinate(grid, n) + uμ_nodes[n] for n in 1:getnnodes(grid)]
 

--- a/docs/src/literate-tutorials/transient_heat_equation.jl
+++ b/docs/src/literate-tutorials/transient_heat_equation.jl
@@ -3,7 +3,8 @@
 # ![](transient_heat-light.webp)
 # ![](transient_heat-dark.webp)
 #
-# *Figure 1*: Visualization of the temperature time evolution on a unit
+# [[*Figure 1*](@ref tutorial-transient-heat-equation-figure-1)](@id tutorial-transient-heat-equation-figure-1):
+# Visualization of the temperature time evolution on a unit
 # square where the prescribed temperature on the upper and lower parts
 # of the boundary increase with time.
 #

--- a/src/Quadrature/quadrature.jl
+++ b/src/Quadrature/quadrature.jl
@@ -181,7 +181,7 @@ end
 
 Create a `FacetQuadratureRule` used for integration of the facets of the refshape `shape` (of
 type [`AbstractRefShape`](@ref)). `order` is the order of the quadrature rule.
-If no symbol is provided, the default `quad_rule_type` for each facet's reference shape is used (see [QuadratureRule](@ref)).
+If no symbol is provided, the default `quad_rule_type` for each facet's reference shape is used (see [`QuadratureRule`](@ref)).
 For non-default `quad_rule_type`s on cells with mixed facet types (e.g. `RefPrism` and `RefPyramid`), the
 `facet_rules` must be provided explicitly.
 


### PR DESCRIPTION
Documenter 1.18 supports named anchors on arbitrary inline content. Use
this to give every numbered figure caption in the tutorials, gallery and
how-to examples a named, self-linking anchor,

```
[[*Figure N*](at-ref <id>)](at-id <id>): Caption text.
```

and turn all prose mentions of figures into `[Figure N](at-ref ...)`
links (including the cross-page reference from the stress-driven
homogenization tutorial to Figure 1 of the computational homogenization
tutorial).

The five examples that lacked figure captions (porous media,
Navier-Stokes, Helmholtz, Ginzburg-Landau, nearly incompressible
hyperelasticity) get captions, and the porous media tutorial a page
at-id. The Stokes flow tutorial's reference to an earlier note is also
turned into a link using an inline anchor. The convention is documented
in the developer documentation.
