### PR TITLE
add DefElement verification badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![codecov.io](https://codecov.io/github/Ferrite-FEM/Ferrite.jl/coverage.svg?branch=master)](https://codecov.io/github/Ferrite-FEM/Ferrite.jl?branch=master)
 [![code style: runic](https://img.shields.io/badge/code_style-%E1%9A%B1%E1%9A%A2%E1%9A%BE%E1%9B%81%E1%9A%B2-black)](https://github.com/fredrikekre/Runic.jl)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13862652.svg)](https://doi.org/10.5281/zenodo.13862652)
+[![DefElement verification](https://defelement.org/badges/ferrite.svg)](https://defelement.org/verification/ferrite.html)
 
 A finite element toolbox written in Julia.
 


### PR DESCRIPTION
Now that [DefElement verification](https://defelement.org/verification/ferrite.html) is working for Ferrite, the DefElement verification badge can be added to the README.

(Feel free to close this PR if this is something you don't want to add to your README.)