### PR TITLE
🤖 Fix assembly, constraints, and projection; improve interface and L2 performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixes
+
+ - Symmetric CSC assembly now rejects incompatible row/column dof lists and
+   lower-triangle storage before modifying the system. Constraint application also
+   rejects unsupported lower-triangle CSC storage.
+ - Constraint matrices correctly account for affine constraints with prescribed masters.
+ - CSC and CSR assembly correctly accumulate repeated interface dofs.
+ - Fixed the single-argument `InterfaceValues(facetvalues)` constructor.
+ - L2 projection supports complex scalar and tensor data.
+ - `ArrayOfVectorViews` validates offsets before constructing unchecked views.
+
+### Performance
+
+ - `InterfaceIterator` caches topology lookups, avoiding quadratic traversal for grids
+   with abstract cell storage. Recreate the iterator after changing the grid or topology.
+ - L2 right-hand-side assembly avoids temporary row-slice allocations.
+
 ## [v1.7.0] - 2026-08-31
 
 ### Added

--- a/benchmark/benchmarks-mesh.jl
+++ b/benchmark/benchmarks-mesh.jl
@@ -3,6 +3,17 @@
 #----------------------------------------------------------------------#
 SUITE["mesh"] = BenchmarkGroup()
 
+# Repeated traversal must not recompute grid-wide reference dimensions when the
+# cell vector has an abstract element type. Construction is outside the timing.
+SUITE["mesh"]["InterfaceIterator"] = BenchmarkGroup()
+let g = SUITE["mesh"]["InterfaceIterator"]
+    grid = generate_grid(Quadrilateral, (40, 40))
+    for (name, cells) in (("concrete", grid.cells), ("abstract", Ferrite.AbstractCell[grid.cells...]))
+        iterator = InterfaceIterator(Grid(cells, grid.nodes))
+        g[name] = @benchmarkable FerriteBenchmarkHelpers.interface_sweep($iterator) evals = 1
+    end
+end
+
 # Grid generation for one geometry per structurally different generator: 2D quadrilateral
 # (tensor product), 3D hexahedron (tensor product with face sets in 3D) and 3D tetrahedron
 # (subdivision of hexahedra). Sizes are picked to land well above the noise floor.

--- a/benchmark/benchmarks-postprocessing.jl
+++ b/benchmark/benchmarks-postprocessing.jl
@@ -20,6 +20,18 @@ let g = SUITE["postprocessing"]["L2Projector"]
     proj = build_projector(grid, ip, qr)
     qp_data = [[rand(SymmetricTensor{2, 2}) for _ in 1:getnquadpoints(qr)] for _ in 1:getncells(grid)]
     g["project tensor data (Triangle 30×30)"] = @benchmarkable project($proj, $qp_data) evals = 1
+
+    # Isolate RHS assembly from the solve to track allocations in the cell scatter.
+    sdh = only(proj.dh.subdofhandlers)
+    cv = CellValues(qr, ip; update_gradients = false)
+    scalar_data = [rand(getnquadpoints(qr)) for _ in 1:getncells(grid)]
+    for (name, data, ncomponents) in (("scalar", scalar_data, 1), ("tensor", qp_data, 3))
+        rhs = zeros(ndofs(proj.dh), ncomponents)
+        g["assemble $name RHS (Triangle 30×30)"] = @benchmarkable(
+            Ferrite.assemble_proj_rhs!($rhs, $cv, $sdh, $data),
+            setup = (fill!($rhs, 0)), evals = 1,
+        )
+    end
 end
 
 # Evaluating a finite element field at arbitrary points in the domain: locating the points

--- a/benchmark/helper.jl
+++ b/benchmark/helper.jl
@@ -10,6 +10,14 @@ module FerriteBenchmarkHelpers
 using Ferrite
 using LinearAlgebra: norm
 
+function interface_sweep(iterator)
+    checksum = 0
+    for ic in iterator
+        checksum += cellid(ic.a) + cellid(ic.b)
+    end
+    return checksum
+end
+
 # Coordinates for `n` cells, cycling through the grid if it has fewer.
 function cell_coordinate_batch(grid, n)
     return [getcoordinates(grid, mod1(i, getncells(grid))) for i in 1:n]

--- a/ext/FerriteSparseMatrixCSR.jl
+++ b/ext/FerriteSparseMatrixCSR.jl
@@ -18,6 +18,10 @@ end
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
         sym::Bool, atomic::Val = Val(false), rowoffset::Int = 0, coloffset::Int = 0
     )
+    if Ferrite._has_repeated_dofs(sortedcoldofs)
+        return Ferrite._assemble_repeated!(K, Ke, sortedrowdofs, rowpermutation, sortedcoldofs, colpermutation, sym, atomic, rowoffset, coloffset)
+    end
+
     current_row = 1
     ld = length(coldofs)
     ncols = size(K, 2)

--- a/src/CollectionsOfViews.jl
+++ b/src/CollectionsOfViews.jl
@@ -193,14 +193,14 @@ Creates the `ArrayOfVectorViews` directly where the user is responsible for havi
 Checking of the argument dimensions can be elided by setting `checkargs = false`, but incorrect dimensions
 may lead to illegal out of bounds access later.
 
-`data` is indexed by `indices[i]:indices[i+1]`, where `i = lin_idx[idx...]` and `idx...` are the user-provided
+`data` is indexed by `indices[i]:(indices[i+1]-1)`, where `i = lin_idx[idx...]` and `idx...` are the user-provided
 indices to the `ArrayOfVectorViews`.
 """
 function ArrayOfVectorViews(indices::Vector{Int}, data::Vector{T}, lin_idx::LinearIndices{N}; checkargs = true) where {T, N}
     if checkargs
-        checkbounds(data, 1:(last(indices) - 1))
-        checkbounds(indices, last(lin_idx) + 1)
+        length(indices) == length(lin_idx) + 1 || throw(DimensionMismatch("indices must contain one offset per view and a terminal offset"))
         issorted(indices) || throw(ArgumentError("indices must be weakly increasing"))
+        1 <= first(indices) <= last(indices) <= length(data) + 1 || throw(ArgumentError("indices must lie between 1 and length(data) + 1"))
     end
     return ArrayOfVectorViews{T, N}(indices, data, lin_idx)
 end

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -1092,6 +1092,9 @@ function create_constraint_matrix(ch::ConstraintHandler{dh, T}) where {dh, T}
         dofcoef = ch.dofcoefficients[i]
         if dofcoef !== nothing #if affine constraint
             for (d, v) in dofcoef
+                # Prescribed masters are already included in the effective
+                # inhomogeneity computed by update!, not in the free-dof map.
+                ch.isconstrained[d] && continue
                 push!(I, pdof)
                 j = searchsortedfirst(ch.free_dofs, d)
                 push!(J, j)

--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -616,6 +616,7 @@ conditions specified in `ch` such that `K \\ rhs` gives the expected solution.
 SparseMatricesCSR loaded) or a `BlockMatrix` of any of these (with BlockArrays loaded). Other
 matrix types are supported as soon as they implement the internal constraint interface, see
 [the devdocs on assembly](@ref devdocs-assembly).
+Symmetric matrices backed by `SparseMatrixCSC` must use upper-triangle storage (`Symmetric(K, :U)`).
 
 !!! note
     `apply!(K, rhs, ch)` essentially calculates
@@ -721,6 +722,7 @@ end
 function apply!(KK::AbstractMatrix, f::AbstractVector, ch::ConstraintHandler, applyzero::Bool = false)
     @assert isclosed(ch)
     sym = isa(KK, Symmetric)
+    KK isa Symmetric{<:Any, <:SparseMatrixCSC} && _check_upper_triangle(KK)
     K = sym ? KK.data : KK
     @assert length(f) == 0 || length(f) == size(K, 1)
     @boundscheck checkbounds(K, ch.prescribed_dofs, ch.prescribed_dofs)
@@ -826,6 +828,7 @@ function _add_inhomogeneities_minors!(f::AbstractVector, K::AbstractSparseMatrix
 end
 
 function add_inhomogeneities!(f::AbstractVector, KK::Symmetric{<:Any, <:SparseMatrixCSC}, ch::ConstraintHandler)
+    _check_upper_triangle(KK)
     (; inhomogeneities, prescribed_dofs, dofmapping) = ch
     K = KK.data
 

--- a/src/FEValues/InterfaceValues.jl
+++ b/src/FEValues/InterfaceValues.jl
@@ -83,7 +83,7 @@ function InterfaceValues(
     )
 end
 # From FacetValue(s)
-InterfaceValues(facetvalues_here::FVA, facetvalues_there::FVB = deepcopy(FacetValues_here)) where {FVA <: FacetValues, FVB <: FacetValues} =
+InterfaceValues(facetvalues_here::FVA, facetvalues_there::FVB = deepcopy(facetvalues_here)) where {FVA <: FacetValues, FVB <: FacetValues} =
     InterfaceValues{FVA, FVB}(facetvalues_here, facetvalues_there)
 
 function Base.copy(iv::InterfaceValues)

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -296,7 +296,7 @@ function _project(proj::L2Projector, vars::Union{AbstractVector{TC}, AbstractDic
 end
 
 function _project(proj::L2Projector, qrs_rhs::Vector{<:QuadratureRule}, vars::Union{AbstractVector, AbstractDict}, M::Integer, ::Type{T}) where {T}
-    f = zeros(ndofs(proj.dh), M)
+    f = zeros(promote_type(eltype(proj.M_cholesky), eltype(T)), ndofs(proj.dh), M)
     for (sdh, qr_rhs) in zip(proj.dh.subdofhandlers, qrs_rhs)
         ip_fun = only(sdh.field_interpolations)
         ip_geo = geometric_interpolation(getcelltype(sdh))
@@ -331,7 +331,7 @@ function assemble_proj_rhs!(f::Matrix, cellvalues::CellValues, sdh::SubDofHandle
     # The number of columns corresponds to the length of the data-tuple in the tensor x̂.
     M = size(f, 2)
     n = getnbasefunctions(cellvalues)
-    fe = zeros(n, M)
+    fe = zeros(eltype(f), n, M)
     nqp = getnquadpoints(cellvalues)
 
     get_data(x::AbstractTensor, i) = x.data[i]

--- a/src/L2_projection.jl
+++ b/src/L2_projection.jl
@@ -357,7 +357,9 @@ function assemble_proj_rhs!(f::Matrix, cellvalues::CellValues, sdh::SubDofHandle
 
         # Assemble cell contribution
         for (num, dof) in enumerate(celldofs(cell))
-            f[dof, :] += fe[num, :]
+            for j in axes(f, 2)
+                f[dof, j] += fe[num, j]
+            end
         end
     end
     return

--- a/src/arrayutils.jl
+++ b/src/arrayutils.jl
@@ -169,3 +169,8 @@ function fillzero!(A::Symmetric{T, <:AbstractSparseMatrix}) where {T}
     fillzero!(A.data)
     return A
 end
+
+function _check_upper_triangle(K::Symmetric)
+    K.uplo == 'U' || throw(ArgumentError("Only upper-triangle Symmetric storage is supported. Use Symmetric(K, :U)."))
+    return
+end

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -255,6 +255,7 @@ Create a `CSCAssembler{Tv}` from the matrix `K` and optional vector `f` with val
     start_assemble(K::Symmetric{AbstractSparseMatrixCSC{Tv}}, f::Vector = Tv[]; fillzero = true, atomic = false) -> SymmetricCSCAssembler{Tv}
 
 Create a `SymmetricCSCAssembler{Tv}` from the matrix `K` and optional vector `f` with value type `Tv`.
+Only upper-triangle storage (`Symmetric(K, :U)`) is supported.
 
 `CSCAssembler` and `SymmetricCSCAssembler` allocate workspace
 necessary for efficient matrix assembly. To assemble the contribution from an element, use
@@ -290,6 +291,7 @@ Base.@constprop :aggressive function start_assemble(K::AbstractSparseMatrixCSC{T
     return CSCAssembler{T, Ti, typeof(K), atomic}(K, f, zeros(Int, maxcelldofs_hint), zeros(Int, maxcelldofs_hint), zeros(Int, maxcelldofs_hint), zeros(Int, maxcelldofs_hint))
 end
 Base.@constprop :aggressive function start_assemble(K::Symmetric{T, <:SparseMatrixCSC{T, Ti}}, f::Vector = T[]; fillzero::Bool = true, maxcelldofs_hint::Int = 0, atomic::Bool = false) where {T, Ti}
+    _check_upper_triangle(K)
     _check_atomic_eltype(atomic, T)
     fillzero && (fillzero!(K); fillzero!(f))
     permutation = zeros(Int, maxcelldofs_hint)

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -383,6 +383,33 @@ end
 # search instead of the linear merge walk in `_assemble_inner!`.
 const SPARSE_COLUMN_SEARCH_RATIO = 8
 
+@inline function _has_repeated_dofs(sorteddofs)
+    repeated = false
+    @inbounds @simd for i in 2:length(sorteddofs)
+        repeated |= sorteddofs[i] == sorteddofs[i - 1]
+    end
+    return repeated
+end
+
+# Repeated interface dofs need multiple additions into the same stored entry.
+# Use independent lookups for this uncommon case, leaving the merge walk for
+# ordinary elements unchanged. Test the global triangle, including every local
+# contribution to a repeated global diagonal dof.
+@noinline function _assemble_repeated!(K, Ke, sortedrowdofs, rowpermutation, sortedcoldofs, colpermutation, sym, atomic, rowoffset, coloffset)
+    for (j, col) in pairs(sortedcoldofs), (i, row) in pairs(sortedrowdofs)
+        sym && row > col && continue
+        val = Ke[rowpermutation[i], colpermutation[j]]
+        iszero(val) && continue
+        try
+            addindex!(K, convert(eltype(K), val), row, col, atomic)
+        catch err
+            err isa SparsityError || rethrow()
+            _missing_sparsity_pattern_error(row + rowoffset, col + coloffset)
+        end
+    end
+    return
+end
+
 """
     Ferrite._assemble_inner!(K, Ke, rowdofs, sortedrowdofs, rowpermutation, coldofs, sortedcoldofs, colpermutation, sym, atomic, rowoffset, coloffset)
 
@@ -391,7 +418,7 @@ Scatter the element matrix `Ke` into the (already allocated) entries of `K`, i.e
 and sorted ascending (`sortedrowdofs`, `sortedcoldofs`), the latter together with the
 permutations mapping a sorted position back to its index in `Ke`, so that a format storing
 its entries in sorted order can walk them and the element matrix in a single pass. If `sym`
-is `true` only the upper triangle of `Ke` is read. `atomic` is a `Val{Bool}` selecting
+is `true` only contributions to the global upper triangle are read. `atomic` is a `Val{Bool}` selecting
 whether the accumulation is concurrency safe.
 
 `rowoffset` and `coloffset` place the matrix within a larger system; they are only used to
@@ -425,6 +452,10 @@ end
         coldofs::AbstractVector, sortedcoldofs::AbstractVector, colpermutation::AbstractVector,
         sym::Bool, atomic::Val = Val(false), rowoffset::Int = 0, coloffset::Int = 0
     )
+    if _has_repeated_dofs(sortedrowdofs)
+        return _assemble_repeated!(K, Ke, sortedrowdofs, rowpermutation, sortedcoldofs, colpermutation, sym, atomic, rowoffset, coloffset)
+    end
+
     current_col = 1
     Krows = rowvals(K)
     Kvals = nonzeros(K)

--- a/src/assembler.jl
+++ b/src/assembler.jl
@@ -316,6 +316,9 @@ This is equivalent to `K[dofs, dofs] += Ke` and `f[dofs] += fe`, where `K` is th
 Assemble the element stiffness matrix `Ke` (and optional force vector `fe`) into the global
 stiffness (and force) in `A`, given the element row degrees of freedom, `rowdofs`, and element column degrees of freedom, `coldofs`.
 This is equivalent to `K[rowdofs, coldofs] += Ke` and `f[rowdofs] += fe`, but more efficient.
+
+For a symmetric assembler, `rowdofs` and `coldofs` must be equal. To assemble
+rectangular blocks with different row and column dofs, use a nonsymmetric assembler.
 """
 assemble!(::AbstractAssembler, ::AbstractVector{<:Integer}, ::AbstractMatrix, ::AbstractVector)
 
@@ -327,7 +330,12 @@ end
     return _assemble!(A, rowdofs, coldofs, Ke, fe, false)
 end
 @propagate_inbounds function assemble!(A::SymmetricCSCAssembler, dofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
+    size(Ke, 1) == size(Ke, 2) || throw(ArgumentError("Ke must be square for symmetric assembly."))
     return _assemble!(A, dofs, dofs, Ke, fe, true)
+end
+@propagate_inbounds function assemble!(A::SymmetricCSCAssembler, rowdofs::AbstractVector{<:Integer}, coldofs::AbstractVector{<:Integer}, Ke::AbstractMatrix, fe::Union{AbstractVector, Nothing} = nothing)
+    rowdofs == coldofs || throw(ArgumentError("Symmetric assembly requires equal row and column dofs. Use a nonsymmetric assembler for rectangular blocks."))
+    return assemble!(A, rowdofs, Ke, fe)
 end
 
 """

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -351,11 +351,20 @@ end
 !!! warning
     `InterfaceIterator` is stateful and should not be used for things other than `for`-looping
     (e.g. broadcasting over, or collecting the iterator may yield unexpected results).
+    Construct a new iterator after changing the grid or its topology.
 """
-struct InterfaceIterator{IC <: InterfaceCache, G <: AbstractGrid, TopologyType <: AbstractTopology}
+struct InterfaceIterator{IC <: InterfaceCache, G <: AbstractGrid, TopologyType <: AbstractTopology, N, S}
     cache::IC
     grid::G
     topology::TopologyType
+    neighborhood::N
+    skeleton::S
+end
+
+function InterfaceIterator(cache::InterfaceCache, grid::AbstractGrid, topology::AbstractTopology)
+    neighborhood = get_facet_facet_neighborhood(topology, grid)
+    skeleton = facetskeleton(topology, grid)
+    return InterfaceIterator(cache, grid, topology, neighborhood, skeleton)
 end
 
 function InterfaceIterator(
@@ -368,8 +377,8 @@ end
 
 # Iterator interface
 @inline function Base.iterate(ii::InterfaceIterator, i::Integer)
-    neighborhood = get_facet_facet_neighborhood(ii.topology, ii.grid) # TODO: This could be moved to InterfaceIterator constructor (potentially type-instable for non-union or mixed grids)
-    skeleton = facetskeleton(ii.topology, ii.grid)
+    neighborhood = ii.neighborhood
+    skeleton = ii.skeleton
     while i <= length(skeleton)
         facet_a = skeleton[i]; i += 1
         neighbors = neighborhood[facet_a[1], facet_a[2]]

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -1,6 +1,16 @@
 using Ferrite, SparseArrays
 import LinearAlgebra: Symmetric
 
+@testset "symmetric assembly storage validation" begin
+    for atomic in (false, true), fillzero in (false, true)
+        K = Symmetric(sparse([1.0 2.0; 2.0 3.0]), :L)
+        f = [4.0, 5.0]
+        @test_throws ArgumentError start_assemble(K, f; atomic, fillzero)
+        @test parent(K) == [1.0 2.0; 2.0 3.0]
+        @test f == [4.0, 5.0]
+    end
+end
+
 @testset "symmetric assembly dof validation" begin
     K = Symmetric(sparse(ones(4, 4)))
     f = ones(4)

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -1,6 +1,30 @@
 using Ferrite, SparseArrays
 import LinearAlgebra: Symmetric
 
+@testset "symmetric assembly dof validation" begin
+    K = Symmetric(sparse(ones(4, 4)))
+    f = ones(4)
+    a = start_assemble(K, f; fillzero = false)
+    for (rdofs, cdofs) in (([1, 2], [3, 4]), ([1], [2, 3]), ([1, 2, 3], [4]))
+        @test_throws ArgumentError assemble!(a, rdofs, cdofs, ones(length(rdofs), length(cdofs)), ones(length(rdofs)))
+        @test all(isone, K)
+        @test all(isone, f)
+    end
+    @test_throws ArgumentError assemble!(a, [1, 2], ones(2, 3), ones(2))
+    @test all(isone, K)
+    @test all(isone, f)
+
+    # Equal but distinct vectors must use the same local ordering and triangle.
+    a = start_assemble(K, f)
+    dofs = [3, 1]
+    Ke = [2.0 4.0; 4.0 6.0]
+    assemble!(a, dofs, copy(dofs), Ke, [7.0, 8.0])
+    expected = zeros(4, 4)
+    expected[dofs, dofs] = Ke
+    @test K == expected
+    @test f == [8.0, 0.0, 7.0, 0.0]
+end
+
 @testset "assemble" begin
     dofs = [1, 3, 5, 7]
     maxd = maximum(dofs)

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -1,6 +1,47 @@
 using Ferrite, SparseArrays
 import LinearAlgebra: Symmetric
 
+@testset "assembly with repeated dofs" begin
+    # Exercise dense columns, the merge walk, and binary search separately.
+    for mode in (:dense, :merge, :binary), sym in (false, true), atomic in (false, true)
+        dofs = [3, 1, 3]
+        pattern = mode === :dense ? ones(40, 40) : zeros(40, 40)
+        if mode === :binary
+            pattern[1:39, :] .= 1
+        else
+            pattern[dofs, dofs] .= 1
+        end
+        K = sym ? Symmetric(sparse(pattern)) : sparse(pattern)
+        f = zeros(40)
+        Ke = [1.0 2.0 3.0; 2.0 5.0 6.0; 3.0 6.0 9.0]
+        fe = [2.0, 3.0, 5.0]
+        expected = zeros(40, 40)
+        expected_f = zeros(40)
+        for (j, J) in pairs(dofs), (i, I) in pairs(dofs)
+            expected[I, J] += Ke[i, j]
+        end
+        for (i, I) in pairs(dofs)
+            expected_f[I] += fe[i]
+        end
+        assemble!(start_assemble(K, f; atomic), dofs, Ke, fe)
+        @test K == expected
+        @test f == expected_f
+    end
+
+    # Repetitions can occur independently in rectangular row and column lists.
+    for atomic in (false, true)
+        rdofs, cdofs = [3, 1, 3], [2, 4, 2, 1]
+        expected = zeros(5, 5)
+        Ke = reshape(1.0:12.0, 3, 4)
+        for (j, J) in pairs(cdofs), (i, I) in pairs(rdofs)
+            expected[I, J] += Ke[i, j]
+        end
+        K = sparse(expected)
+        assemble!(start_assemble(K; atomic), rdofs, cdofs, Ke)
+        @test K == expected
+    end
+end
+
 @testset "symmetric assembly storage validation" begin
     for atomic in (false, true), fillzero in (false, true)
         K = Symmetric(sparse([1.0 2.0; 2.0 3.0]), :L)

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -2,6 +2,26 @@ using Ferrite
 import SparseMatricesCSR: SparseMatrixCSR, sparsecsr
 using SparseArrays, LinearAlgebra
 
+@testset "CSR assembly with repeated dofs" begin
+    for mode in (:dense, :merge, :binary), atomic in (false, true)
+        rdofs, cdofs = [3, 1, 3], [2, 4, 2, 1]
+        pattern = mode === :dense ? ones(40, 40) : zeros(40, 40)
+        if mode === :binary
+            pattern[:, 1:39] .= 1
+        else
+            pattern[rdofs, cdofs] .= 1
+        end
+        K = SparseMatrixCSR(sparse(pattern))
+        Ke = reshape(1.0:12.0, 3, 4)
+        expected = zeros(40, 40)
+        for (j, J) in pairs(cdofs), (i, I) in pairs(rdofs)
+            expected[I, J] += Ke[i, j]
+        end
+        assemble!(start_assemble(K; atomic), rdofs, cdofs, Ke)
+        @test K == expected
+    end
+end
+
 @testset "SparseMatricesCSR extension" begin
 
     @testset "apply!(::SparseMatrixCSR,...)" begin

--- a/test/test_assembler_extensions.jl
+++ b/test/test_assembler_extensions.jl
@@ -24,6 +24,10 @@ using SparseArrays, LinearAlgebra
         f0 = K0 * sol
         f1 = K1 * sol
         f2 = K2 * sol
+        # CSR uses the generic symmetric RHS operation, which supports either triangle.
+        Klower = Symmetric(copy(K1), :L)
+        flower = copy(f0)
+        apply!(Klower, flower, ch)
         apply!(K0, f0, ch)
         apply!(K1, f1, ch)
         apply!(K2, f2, ch)
@@ -31,6 +35,8 @@ using SparseArrays, LinearAlgebra
         @test K1 == K2
         @test f0 ≈ f1
         @test f1 ≈ f2
+        @test Klower == K0
+        @test flower ≈ f0
         # Affine constraints are condensed just like for the CSC matrix. The sparsity pattern
         # has to hold the fill-in, so allocate it through the constraint handler.
         ch = ConstraintHandler(dh)

--- a/test/test_collectionsofviews.jl
+++ b/test/test_collectionsofviews.jl
@@ -1,4 +1,25 @@
 @testset "ArrayOfVectorViews" begin
+    @testset "checked offsets" begin
+        for indices in ([0, 2], [-1, 2], [1, 3], [2, 1], [typemin(Int), 1], [1, typemax(Int)])
+            @test_throws ArgumentError Ferrite.ArrayOfVectorViews(indices, [1.0], LinearIndices((1,)))
+        end
+        for indices in (Int[], [1], [1, 2, 2])
+            @test_throws DimensionMismatch Ferrite.ArrayOfVectorViews(indices, [1.0], LinearIndices((1,)))
+        end
+        for dims in ((0,), (0, 2))
+            a = Ferrite.ArrayOfVectorViews([1], Float64[], LinearIndices(dims))
+            @test size(a) == dims
+            @test isempty(a)
+        end
+        a = Ferrite.ArrayOfVectorViews([1, 1, 2, 2], [10.0], LinearIndices((3,)))
+        @test isempty(a[1])
+        @test a[2] == [10.0]
+        @test isempty(a[3])
+        # Views may use only part of the backing data.
+        a = Ferrite.ArrayOfVectorViews([2, 3], [10.0, 20.0, 30.0], LinearIndices((1,)))
+        @test a[1] == [20.0]
+    end
+
     # Create a vector sorting integers into bins and check
     test_ints = rand(0:99, 100)
     # Create for 3 different sizehints

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1,6 +1,39 @@
 # Imports for parallel (isolated) test execution:
 using LinearAlgebra, SparseArrays, Logging
 
+@testset "constraint matrix with prescribed masters" begin
+    grid = generate_grid(Line, (2,))
+    dh = DofHandler(grid)
+    add!(dh, :u, Lagrange{RefLine, 1}())
+    close!(dh)
+    for master in (1, 3), weight in (0.0, -2.0)
+        free = 4 - master
+        ch = ConstraintHandler(dh)
+        add!(ch, AffineConstraint(master, Pair{Int, Float64}[], 2.0))
+        entries = [master => 3.0]
+        iszero(weight) || push!(entries, free => weight)
+        add!(ch, AffineConstraint(2, entries, 1.0))
+        close!(ch)
+        C, g = Ferrite.create_constraint_matrix(ch)
+        @test size(C) == (3, 1)
+        for value in (0.0, 5.0)
+            u = zeros(3)
+            u[free] = value
+            apply!(u, ch)
+            @test C * [value] + g == u
+        end
+    end
+
+    ch = ConstraintHandler(dh)
+    add!(ch, AffineConstraint(1, Pair{Int, Float64}[], 2.0))
+    add!(ch, AffineConstraint(2, [1 => 3.0], 1.0))
+    add!(ch, AffineConstraint(3, Pair{Int, Float64}[], 5.0))
+    close!(ch)
+    C, g = Ferrite.create_constraint_matrix(ch)
+    @test size(C) == (3, 0)
+    @test C * Float64[] + g == apply!(zeros(3), ch)
+end
+
 # Minimal atomic assembler used to verify that `apply_assemble!` propagates its atomic
 # mode into the non-local constraint condensation before regular assembly.
 struct AtomicApplyAssembler{M, V} <: Ferrite.AbstractAssembler{Float64}

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -1,6 +1,24 @@
 # Imports for parallel (isolated) test execution:
 using LinearAlgebra, SparseArrays, Logging
 
+@testset "symmetric constraint storage validation" begin
+    grid = generate_grid(Line, (1,))
+    dh = DofHandler(grid)
+    add!(dh, :u, Lagrange{RefLine, 1}())
+    close!(dh)
+    ch = ConstraintHandler(dh)
+    add!(ch, AffineConstraint(1, Pair{Int, Float64}[], 2.0))
+    close!(ch)
+    K = Symmetric(sparse([1.0 2.0; 2.0 3.0]), :L)
+    f = [4.0, 5.0]
+    @test_throws ArgumentError apply!(K, f, ch)
+    @test_throws ArgumentError apply_zero!(K, f, ch)
+    @test_throws ArgumentError apply!(K, ch)
+    @test_throws ArgumentError Ferrite.add_inhomogeneities!(f, K, ch)
+    @test parent(K) == [1.0 2.0; 2.0 3.0]
+    @test f == [4.0, 5.0]
+end
+
 @testset "constraint matrix with prescribed masters" begin
     grid = generate_grid(Line, (2,))
     dh = DofHandler(grid)

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -2,6 +2,25 @@
 include(joinpath(@__DIR__, "test_utils.jl"))
 
 @testset "InterfaceValues" begin
+    @testset "construction from one FacetValues" begin
+        grid = generate_grid(Quadrilateral, (2, 1))
+        fv = FacetValues(FacetQuadratureRule{RefQuadrilateral}(2), Lagrange{RefQuadrilateral, 1}())
+        iv = InterfaceValues(fv)
+        @test iv.here === fv
+        @test iv.there !== fv
+        ic = first(InterfaceIterator(grid))
+        reinit!(iv, ic)
+        coords_here, coords_there = getcoordinates(ic)
+        for qp in 1:getnquadpoints(iv)
+            @test spatial_coordinate(iv.here, qp, coords_here) ≈ spatial_coordinate(iv.there, qp, coords_there)
+            @test getnormal(iv.here, qp) ≈ -getnormal(iv.there, qp)
+        end
+        # Reinitializing one side must leave the other side's cached data intact.
+        normals_there = copy(iv.there.normals)
+        reinit!(fv, coords_here, 1)
+        @test iv.there.normals == normals_there
+    end
+
     function test_interfacevalues(grid::Ferrite.AbstractGrid, iv::InterfaceValues; tol = 0)
         ip_here = Ferrite.function_interpolation(iv.here)
         ip_there = Ferrite.function_interpolation(iv.there)

--- a/test/test_interfacevalues.jl
+++ b/test/test_interfacevalues.jl
@@ -1,6 +1,28 @@
 # Imports for parallel (isolated) test execution:
 include(joinpath(@__DIR__, "test_utils.jl"))
 
+@testset "interface iteration with abstract cell storage" begin
+    function interface_facets(iterator)
+        result = Tuple{FacetIndex, FacetIndex}[]
+        for ic in iterator
+            push!(result, (FacetIndex(cellid(ic.a), ic.a.current_facet_id), FacetIndex(cellid(ic.b), ic.b.current_facet_id)))
+        end
+        return result
+    end
+    grid = generate_grid(Quadrilateral, (4, 3))
+    abstract_grid = Grid(Ferrite.AbstractCell[grid.cells...], grid.nodes)
+    expected = interface_facets(InterfaceIterator(grid))
+    @test length(expected) == 17
+    iterator = InterfaceIterator(abstract_grid)
+    @test interface_facets(iterator) == expected
+    @test interface_facets(iterator) == expected # Iteration can be restarted.
+    @test isempty(interface_facets(InterfaceIterator(generate_grid(Quadrilateral, (1, 1)))))
+
+    # Caching must retain the error for mixed reference dimensions.
+    mixed = Grid(Ferrite.AbstractCell[grid.cells[1], Line((1, 2))], grid.nodes)
+    @test_throws ArgumentError InterfaceIterator(mixed)
+end
+
 @testset "InterfaceValues" begin
     @testset "construction from one FacetValues" begin
         grid = generate_grid(Quadrilateral, (2, 1))

--- a/test/test_l2_projection.jl
+++ b/test/test_l2_projection.jl
@@ -3,6 +3,37 @@ using LinearAlgebra
 import SHA
 import Ferrite: getrefdim
 
+@testset "complex L2 projection" begin
+    for nonconforming in (false, true)
+        grid = generate_grid(Quadrilateral, (2, 2))
+        if nonconforming
+            forest = ForestBWG(grid, 3)
+            Ferrite.refine!(forest, [1])
+            Ferrite.balanceforest!(forest)
+            grid = Ferrite.creategrid(forest)
+        end
+        ip = Lagrange{RefQuadrilateral, 1}()
+        qr = QuadratureRule{RefQuadrilateral}(2)
+        cv = CellValues(qr, ip)
+        proj = L2Projector(ip, grid)
+        for T in (ComplexF32, ComplexF64), value_shape in (identity, z -> Vec((z, 2z)), z -> SymmetricTensor{2, 2}((z, 2z, 3z)))
+            f(x) = value_shape(T(1 + x[1] + (2 - x[2]) * im))
+            data = map(1:getncells(grid)) do cellid
+                coords = getcoordinates(grid, cellid)
+                reinit!(cv, coords)
+                [f(spatial_coordinate(cv, qp, coords)) for qp in 1:getnquadpoints(cv)]
+            end
+            projected = project(proj, data, qr)
+            @test eltype(projected) == typeof(f(zero(Vec{2})))
+            for cell in CellIterator(proj.dh)
+                for (dof, x) in zip(celldofs(cell), getcoordinates(cell))
+                    @test all(a ≈ b for (a, b) in zip(projected[dof], f(x)))
+                end
+            end
+        end
+    end
+end
+
 # Tests a L2-projection of integration point values (to nodal values),
 # determined from the function y = 1 + x[1]^2 + (2x[2])^2
 function test_projection(order, refshape)


### PR DESCRIPTION
New model is out = new bugfixes

Fixes incorrect assembly and constraint results, broken constructors and complex projection, and two performance bottlenecks.

Each fix is a separate commit:

- cc97d3af — Reject incompatible row/column dof lists in symmetric assembly before mutation; accept equal lists.
- 6b0f93e0 — Exclude prescribed masters from the free-dof constraint matrix; retain their contribution in the inhomogeneity.
- c675aa02 — Reject unsupported lower-triangle CSC storage in symmetric assembly and constraint application; preserve CSR support.
- aa94d697 — Accumulate repeated interface dofs correctly in CSC/CSR assembly, including shared diagonal entries.
- ae95a833 — Fix `InterfaceValues(fv)` and verify that its two sides have independent mutable state.
- 52319b9c — Preserve complex coefficients in L2 projection, including tensor data and hanging-node constraints.
- 95acb1b3 — Validate collection view offsets and handle empty collections safely.
- cf557492 — Cache interface topology lookups, avoiding quadratic traversal with abstract cell storage; add benchmarks.
- d978caee — Replace L2 RHS row-slice copies with scalar accumulation; add benchmarks.
- 7ab697be — Add the required changelog entries.

Validation: targeted assembly, constraint, collection, interface, projection, sparsity, and grid/VTK tests passed on Julia 1.12.7. Benchmark fixtures, Runic, and pre-commit checks also passed. The full test suite was not run.
