### PR TITLE
Implement macro element P1isoP2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.x.x] 
+
+### Added
+- Added the P1isoP2 element for lines, triangles and quadrilaterals. ([#1506])
+
 ## [v1.7.0] - 2026-08-31
 
 ### Added

--- a/docs/src/devdocs/interpolations.md
+++ b/docs/src/devdocs/interpolations.md
@@ -47,6 +47,13 @@ Ferrite.mapping_type
 Ferrite.get_direction
 ```
 
+#### Macro elements
+For macro elements, you must also define
+```@docs
+Ferrite.is_macro_element
+Ferrite.get_sub_elements
+```
+
 #### Interpolations that cannot be constructed from their type
 For interpolations, `ip`, for which `ip == typeof(ip)()` is false (or doesn't work), the following must be implemented manually
 ```@docs

--- a/src/Quadrature/quadrature.jl
+++ b/src/Quadrature/quadrature.jl
@@ -322,3 +322,54 @@ getrefshape(::QuadratureRule{RefShape}) where {RefShape} = RefShape
 
 # TODO: This is used in copy(::(Cell|Facet)Values), but it it useful to get an actual copy?
 Base.copy(qr::Union{QuadratureRule, FacetQuadratureRule}) = qr
+
+"""
+    adapt_quadrature_rule_to_macro_element(qr::QuadratureRule, ip::Interpolation)
+
+Adapt a standard quadrature rule `qr` for a macro-element `ip` by duplicating
+and mapping it to all sub-elements that comprise the macro-element.
+
+Both the integration points and weights are adjusted: points are mapped into the
+respective sub-element's local reference space, and weights are scaled by the
+determinant of the Jacobian of the sub-element mapping. The resulting quadrature rule 
+conforms to the macro-element's coordinate system and size.
+"""
+function adapt_quadrature_rule_to_macro_element(qr::QuadratureRule{shape}, ip::P1isoP2{shape}) where {shape}
+    @assert is_macro_element(ip)
+    sub_elements = get_sub_elements(ip)
+    geo_ip = Lagrange{shape, 1}()
+
+    T = eltype(qr.points)
+    dim = length(first(qr.points))
+
+    new_weights = Float64[]
+    new_points = T[]
+
+    for sub_coords in sub_elements
+        for (w, p) in zip(qr.weights, qr.points)
+
+            # 1. Map standard integration point `p` into the sub-element's space
+            mapped_p = zero(T)
+            for i in 1:length(sub_coords)
+                N_i = reference_shape_value(geo_ip, p, i)
+                mapped_p += N_i * sub_coords[i]
+            end
+
+            # 2. Compute Jacobian of the affine mapping to scale the weight correctly
+            # J = dx/dξ = sum( V_i ⊗ ∇N_i )
+            J_mat = zero(Tensor{2, dim, Float64})
+            for i in 1:length(sub_coords)
+                dN_i = reference_shape_gradient(geo_ip, p, i)
+                J_mat += sub_coords[i] ⊗ dN_i
+            end
+
+            # 3. Apply the determinant mapping factor to the quadrature weight
+            detJ = det(J_mat)
+
+            push!(new_points, mapped_p)
+            push!(new_weights, w * detJ)
+        end
+    end
+
+    return QuadratureRule{shape}(new_weights, new_points)
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -20,6 +20,7 @@ export
     Nedelec,
     RaviartThomas,
     BrezziDouglasMarini,
+    P1isoP2,
     getnbasefunctions,
     getrefshape,
 
@@ -27,6 +28,7 @@ export
     QuadratureRule,
     FacetQuadratureRule,
     getnquadpoints,
+    adapt_quadrature_rule_to_macro_element,
 
     # FEValues
     AbstractCellValues,

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -502,6 +502,31 @@ dirichlet_boundarydof_indices(::Type{FacetIndex}) = dirichlet_facetdof_indices
 get_edge_direction(cell, edgenr) = get_edge_direction(edges(cell)[edgenr])
 get_face_direction(cell, facenr) = get_face_direction(faces(cell)[facenr])
 
+"""
+    is_macro_element(::Interpolation)
+
+Return `true` if the interpolation is a macro-element (i.e., composed of multiple
+sub-elements or split domains), and `false` otherwise.
+"""
+is_macro_element(ip::Interpolation) = false
+
+"""
+    get_sub_elements(::Interpolation)
+
+Return a tuple of tuples containing the local reference coordinates of the vertices
+for each sub-element that comprises the macro-element. Each sub-element shares the
+same reference shape type as the parent macro-element.
+"""
+get_sub_elements(ip::Interpolation)
+
+"""
+    find_sub_element(::Interpolation, xi::Vec)
+
+Determine and return the integer index of the sub-element within a macro-element
+in which the given local reference coordinate `ξ` lies.
+"""
+find_sub_element(ip::Interpolation, ξ::Vec)
+
 #########################
 # DiscontinuousLagrange #
 #########################
@@ -1773,6 +1798,7 @@ struct VectorizedInterpolation{vdim, refshape, order, SI <: ScalarInterpolation{
     end
 end
 conformity(ip::VectorizedInterpolation) = conformity(ip.ip)
+is_macro_element(ip::VectorizedInterpolation) = is_macro_element(ip.ip)
 
 adjust_dofs_during_distribution(ip::VectorizedInterpolation) = adjust_dofs_during_distribution(ip.ip)
 interior_facedofs_on_lattice(ip::VectorizedInterpolation) = interior_facedofs_on_lattice(ip.ip)
@@ -2163,4 +2189,240 @@ adjust_dofs_during_distribution(::Nedelec{RefHexahedron, 1}) = false
 
 function get_direction(::Nedelec{RefHexahedron, 1}, shape_nr, cell)
     return get_edge_direction(cell, shape_nr) # shape_nr = edge_nr
+end
+
+#####################################
+# P1isoP2                           #
+#####################################
+struct P1isoP2{shape, order} <: ScalarInterpolation{shape, order} end
+
+adjust_dofs_during_distribution(::P1isoP2) = false
+conformity(::P1isoP2) = H1Conformity()
+is_macro_element(::P1isoP2) = true
+
+############################
+# P1isoP2 RefLine          #
+############################
+getnbasefunctions(::P1isoP2{RefLine, 1}) = 3
+vertexdof_indices(::P1isoP2{RefLine, 1}) = ((1,), (2,))
+edgedof_interior_indices(::P1isoP2{RefLine, 1}) = ((3,),)
+facedof_interior_indices(::P1isoP2{RefLine, 1}) = ()
+volumedof_interior_indices(::P1isoP2{RefLine, 1}) = ()
+
+function reference_coordinates(::P1isoP2{RefLine, 1})
+    return [
+        Vec{1, Float64}((-1.0,)), # Node 1: Left
+        Vec{1, Float64}((1.0,)),  # Node 2: Right
+        Vec{1, Float64}((0.0,)),  # Node 3: Center
+    ]
+end
+
+function find_sub_element(::P1isoP2{RefLine, 1}, ξ::Vec{1})
+    return ξ[1] < 0.0 ? 1 : 2
+end
+
+function reference_shape_value(ip::P1isoP2{RefLine, 1}, ξ::Vec{1, T}, i::Int) where {T}
+    e = find_sub_element(ip, ξ)
+    ξ_x = ξ[1]
+    if i == 1
+        e == 1 && return -ξ_x
+        return T(0.0)
+    elseif i == 2
+        e == 2 && return ξ_x
+        return T(0.0)
+    elseif i == 3
+        e == 1 && return 1 + ξ_x
+        e == 2 && return 1 - ξ_x
+        return T(0.0)
+    end
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+function get_sub_elements(::P1isoP2{RefLine})
+    v1 = Vec{1, Float64}((-1.0,)) # Left
+    v2 = Vec{1, Float64}((1.0,)) # Right
+    v3 = Vec{1, Float64}((0.0,)) # Center
+
+    return (
+        (v1, v3), # Sub-element 1: [-1, 0]
+        (v3, v2), # Sub-element 2: [0, 1]
+    )
+end
+
+############################
+# P1isoP2 RefTriangle      #
+############################
+getnbasefunctions(::P1isoP2{RefTriangle, 1}) = 6
+vertexdof_indices(::P1isoP2{RefTriangle, 1}) = ((1,), (2,), (3,))
+edgedof_interior_indices(::P1isoP2{RefTriangle, 1}) = ((4,), (5,), (6,))
+
+function reference_coordinates(::P1isoP2{RefTriangle, 1})
+    return [
+        Vec{2, Float64}((1.0, 0.0)), # Node 1: v1
+        Vec{2, Float64}((0.0, 1.0)), # Node 2: v2
+        Vec{2, Float64}((0.0, 0.0)), # Node 3: v3
+        Vec{2, Float64}((0.5, 0.5)), # Node 4: e1 mid
+        Vec{2, Float64}((0.0, 0.5)), # Node 5: e2 mid
+        Vec{2, Float64}((0.5, 0.0)), # Node 6: e3 mid
+    ]
+end
+
+function find_sub_element(::P1isoP2{RefTriangle, 1}, ξ::Vec{2})
+    ξ1, ξ2 = ξ[1], ξ[2]
+    if ξ1 >= 0.5
+        return 1
+    elseif ξ2 >= 0.5
+        return 2
+    elseif ξ1 + ξ2 <= 0.5
+        return 3
+    else
+        return 4
+    end
+end
+
+function reference_shape_value(ip::P1isoP2{RefTriangle, 1}, ξ::Vec{2, T}, i::Int) where {T}
+    e = find_sub_element(ip, ξ)
+    ξ1, ξ2 = ξ[1], ξ[2]
+
+    if i == 1
+        e == 1 && return 2 * ξ1 - 1
+        return T(0.0)
+    elseif i == 2
+        e == 2 && return 2 * ξ2 - 1
+        return T(0.0)
+    elseif i == 3
+        e == 3 && return 1 - 2 * ξ1 - 2 * ξ2
+        return T(0.0)
+    elseif i == 4
+        e == 1 && return 2 * ξ2
+        e == 2 && return 2 * ξ1
+        e == 4 && return 2 * ξ1 + 2 * ξ2 - 1
+        return T(0.0)
+    elseif i == 5
+        e == 2 && return 2 * (1 - ξ1 - ξ2)
+        e == 3 && return 2 * ξ2
+        e == 4 && return 1 - 2 * ξ1
+        return T(0.0)
+    elseif i == 6
+        e == 1 && return 2 * (1 - ξ1 - ξ2)
+        e == 3 && return 2 * ξ1
+        e == 4 && return 1 - 2 * ξ2
+        return T(0.0)
+    end
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+function get_sub_elements(::P1isoP2{RefTriangle})
+    v1 = Vec{2, Float64}((1.0, 0.0))
+    v2 = Vec{2, Float64}((0.0, 1.0))
+    v3 = Vec{2, Float64}((0.0, 0.0))
+    v4 = Vec{2, Float64}((0.5, 0.5))
+    v5 = Vec{2, Float64}((0.0, 0.5))
+    v6 = Vec{2, Float64}((0.5, 0.0))
+
+    # Ordering strictly matches the standard Ferrite RefTriangle (1,0), (0,1), (0,0)
+    return (
+        (v1, v4, v6), # Sub-element 1 (near v1)
+        (v4, v2, v5), # Sub-element 2 (near v2)
+        (v6, v5, v3), # Sub-element 3 (near v3)
+        (v4, v5, v6), # Sub-element 4 (Center sub-triangle)
+    )
+end
+
+############################
+# P1isoP2 RefQuadrilateral #
+############################
+getnbasefunctions(::P1isoP2{RefQuadrilateral, 1}) = 9
+vertexdof_indices(::P1isoP2{RefQuadrilateral, 1}) = ((1,), (2,), (3,), (4,))
+edgedof_interior_indices(::P1isoP2{RefQuadrilateral, 1}) = ((5,), (6,), (7,), (8,))
+facedof_interior_indices(::P1isoP2{RefQuadrilateral, 1}) = ((9,),)
+volumedof_interior_indices(::P1isoP2{RefQuadrilateral, 1}) = ()
+
+function reference_coordinates(::P1isoP2{RefQuadrilateral, 1})
+    return [
+        Vec{2, Float64}((-1.0, -1.0)), # Node 1: v1
+        Vec{2, Float64}((1.0, -1.0)), # Node 2: v2
+        Vec{2, Float64}((1.0, 1.0)), # Node 3: v3
+        Vec{2, Float64}((-1.0, 1.0)), # Node 4: v4
+        Vec{2, Float64}((0.0, -1.0)), # Node 5: e1 mid
+        Vec{2, Float64}((1.0, 0.0)), # Node 6: e2 mid
+        Vec{2, Float64}((0.0, 1.0)), # Node 7: e3 mid
+        Vec{2, Float64}((-1.0, 0.0)), # Node 8: e4 mid
+        Vec{2, Float64}((0.0, 0.0)), # Node 9: Face center
+    ]
+end
+
+function find_sub_element(::P1isoP2{RefQuadrilateral, 1}, ξ::Vec{2})
+    ξ1, ξ2 = ξ[1], ξ[2]
+    if ξ1 <= 0.0 && ξ2 <= 0.0
+        return 1 # Bottom-left
+    elseif ξ1 >= 0.0 && ξ2 <= 0.0
+        return 2 # Bottom-right
+    elseif ξ1 >= 0.0 && ξ2 >= 0.0
+        return 3 # Top-right
+    else
+        return 4 # Top-left
+    end
+end
+
+function reference_shape_value(ip::P1isoP2{RefQuadrilateral, 1}, ξ::Vec{2, T}, i::Int) where {T}
+    e = find_sub_element(ip, ξ)
+    ξ1, ξ2 = ξ[1], ξ[2]
+    if i == 1
+        e == 1 && return ξ1 * ξ2
+        return T(0.0)
+    elseif i == 2
+        e == 2 && return -ξ1 * ξ2
+        return T(0.0)
+    elseif i == 3
+        e == 3 && return ξ1 * ξ2
+        return T(0.0)
+    elseif i == 4
+        e == 4 && return -ξ1 * ξ2
+        return T(0.0)
+    elseif i == 5
+        e == 1 && return -ξ2 - ξ1 * ξ2
+        e == 2 && return -ξ2 + ξ1 * ξ2
+        return T(0.0)
+    elseif i == 6
+        e == 2 && return ξ1 + ξ1 * ξ2
+        e == 3 && return ξ1 - ξ1 * ξ2
+        return T(0.0)
+    elseif i == 7
+        e == 3 && return ξ2 - ξ1 * ξ2
+        e == 4 && return ξ2 + ξ1 * ξ2
+        return T(0.0)
+    elseif i == 8
+        e == 4 && return -ξ1 + ξ1 * ξ2
+        e == 1 && return -ξ1 - ξ1 * ξ2
+        return T(0.0)
+    elseif i == 9
+        e == 1 && return 1 + ξ1 + ξ2 + ξ1 * ξ2
+        e == 2 && return 1 - ξ1 + ξ2 - ξ1 * ξ2
+        e == 3 && return 1 - ξ1 - ξ2 + ξ1 * ξ2
+        e == 4 && return 1 + ξ1 - ξ2 - ξ1 * ξ2
+        return T(0.0)
+    end
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+# 2D Quadrilateral (RefCube, 2)
+function get_sub_elements(::P1isoP2{RefQuadrilateral, 1})
+    v1 = Vec{2, Float64}((-1.0, -1.0))
+    v2 = Vec{2, Float64}((1.0, -1.0))
+    v3 = Vec{2, Float64}((1.0, 1.0))
+    v4 = Vec{2, Float64}((-1.0, 1.0))
+    v5 = Vec{2, Float64}((0.0, -1.0))
+    v6 = Vec{2, Float64}((1.0, 0.0))
+    v7 = Vec{2, Float64}((0.0, 1.0))
+    v8 = Vec{2, Float64}((-1.0, 0.0))
+    v9 = Vec{2, Float64}((0.0, 0.0))
+
+    # Ordering strictly matches standard Ferrite RefCube (-1,-1), (1,-1), (1,1), (-1,1)
+    return (
+        (v1, v5, v9, v8), # Sub-element 1 (Bottom-left)
+        (v5, v2, v6, v9), # Sub-element 2 (Bottom-right)
+        (v9, v6, v3, v7), # Sub-element 3 (Top-right)
+        (v8, v9, v7, v4), # Sub-element 4 (Top-left)
+    )
 end

--- a/test/integration/convergence_test_utils.jl
+++ b/test/integration/convergence_test_utils.jl
@@ -23,6 +23,7 @@ get_quadrature_order(::Serendipity{shape, order}) where {shape, order} = max(2 *
 get_quadrature_order(::CrouzeixRaviart{shape, order}) where {shape, order} = max(2 * order - 1, 2)
 get_quadrature_order(::RannacherTurek{shape, order}) where {shape, order} = max(2 * order - 1, 2)
 get_quadrature_order(::BubbleEnrichedLagrange{shape, order}) where {shape, order} = max(2 * order - 1, 2)
+get_quadrature_order(::P1isoP2{shape, order}) where {shape, order} = 2
 
 get_num_elements(::Ferrite.Interpolation{shape, 1}) where {shape} = 21
 get_num_elements(::Ferrite.Interpolation{shape, 2}) where {shape} = 7
@@ -167,6 +168,9 @@ function run_convergence_analysis(interpolation)
         qr_order = get_quadrature_order(interpolation)
         qr_name = get_quadrature_rule_name(getrefshape(interpolation), qr_order)
         qr = QuadratureRule{getrefshape(interpolation)}(qr_name, qr_order)
+        if Ferrite.is_macro_element(interpolation)
+            qr = adapt_quadrature_rule_to_macro_element(qr, interpolation)
+        end
         # ... and then pray to the gods of convergence.
         dh, ch, cellvalues = setup_poisson_problem(grid, interpolation, interpolation_geo, qr)
         u = solve(dh, ch, cellvalues)

--- a/test/integration/test_convergence_analysis.jl
+++ b/test/integration/test_convergence_analysis.jl
@@ -23,6 +23,10 @@ include(joinpath(@__DIR__, "convergence_test_utils.jl"))
             CrouzeixRaviart{RefTetrahedron, 1}(),
             RannacherTurek{RefQuadrilateral, 1}(),
             RannacherTurek{RefHexahedron, 1}(),
+            #
+            P1isoP2{RefLine, 1}(),
+            P1isoP2{RefTriangle, 1}(),
+            P1isoP2{RefQuadrilateral, 1}(),
         )
         ConvergenceTestHelper.run_convergence_analysis(interpolation)
     end

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -51,6 +51,10 @@ using Ferrite: reference_shape_value, reference_shape_gradient
             CrouzeixRaviart{RefTetrahedron, 1}(),
             RannacherTurek{RefQuadrilateral, 1}(),
             RannacherTurek{RefHexahedron, 1}(),
+            #
+            P1isoP2{RefLine, 1}(),
+            P1isoP2{RefTriangle, 1}(),
+            P1isoP2{RefQuadrilateral, 1}(),
         )
         # Standard test all base interpolations must fulfill
         test_interpolation_properties(interpolation)

--- a/test/test_quadrules.jl
+++ b/test/test_quadrules.jl
@@ -256,3 +256,37 @@ using Ferrite: reference_shape_value
         end
     end
 end
+
+
+@testset "Adapt Quadrature Rule to Macro Element" begin
+    # Integrate f(x) = x[1] + x[2] over the element, with both the macro element and the sub element and compare results.
+    for ip_macro in (P1isoP2{RefLine, 1}(), P1isoP2{RefTriangle, 1}(), P1isoP2{RefQuadrilateral, 1}())
+        ip_macro = P1isoP2{RefLine, 1}()
+        shape = Ferrite.getrefshape(ip_macro)
+        ip_sub = Lagrange{shape, 1}()
+        macro_coords = [x + 0.01 * rand(x) for x in Ferrite.reference_coordinates(ip_sub)]
+
+        qr_base = QuadratureRule{shape}(2)
+        qr_macro = adapt_quadrature_rule_to_macro_element(qr_base, ip_macro)
+        cv_macro = CellValues(qr_macro, ip_macro)
+        cv_sub = CellValues(qr_base, ip_sub)
+
+        #Macro integral
+        macro_integral = 0.0
+        reinit!(cv_macro, macro_coords)
+        for iqp in 1:getnquadpoints(cv_macro)
+            macro_integral += sum(spatial_coordinate(cv_macro, iqp, macro_coords)) * getdetJdV(cv_macro, iqp)
+        end
+
+        #Sub integral
+        sub_integral = 0.0
+        for coords_sub_ref in Ferrite.get_sub_elements(ip_macro)
+            coords_sub = [spatial_coordinate(ip_sub, ξ, macro_coords) for ξ in coords_sub_ref]
+            reinit!(cv_sub, coords_sub)
+            for iqp in 1:getnquadpoints(cv_sub)
+                sub_integral += sum(spatial_coordinate(cv_sub, iqp, coords_sub)) * getdetJdV(cv_sub, iqp)
+            end
+        end
+        @test macro_integral ≈ sub_integral
+    end
+end


### PR DESCRIPTION
On the quest of implementing all elements, here is [P1isoP2](https://defelement.org/elements/p1-iso-p2.html).

It is a macro elements (i.e. piece wise polynomials within the element) that acts as a uniform mesh refinement. I don't know where it useful, but It was fun to implement 😄 

Maybe it should go in FerriteInterpolations.jl, but I think it could be good to have a base macro element in Ferrite.jl which defines and implements all the macro-element specific functions.

Also added adapt_quadrature_rule_to_macro_element.